### PR TITLE
refactor(policy-pack): split pack_dependency_validation.clj — extract trust (2/3)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/rules/pack_dependency_validation.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/rules/pack_dependency_validation.clj
@@ -30,8 +30,9 @@
    6 real layers, max 3 -- same convention as the mdc-compiler split,
    miniforge#1729-#1743, and the workflow-runner split, miniforge#1662).
    Slice 1 (#1770) moved version parsing/comparison/constraint-satisfaction
-   to `...pack-dependency-validation.versions`. This slice moves the
-   trust-check chain to `...pack-dependency-validation.trust`:
+   to `ai.miniforge.policy-pack.rules.pack-dependency-validation.versions`.
+   This slice moves the trust-check chain to
+   `ai.miniforge.policy-pack.rules.pack-dependency-validation.trust`:
    tainted-dependency?, untrusted-instruction-escalation?,
    check-dependency-trust, detect-trust-violations. This file now
    measures 4 real layers; the graph-construction group moves out in

--- a/components/policy-pack/src/ai/miniforge/policy_pack/rules/pack_dependency_validation.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/rules/pack_dependency_validation.clj
@@ -26,29 +26,28 @@
    - Dependency depth limit (default: 5 levels)
    - Complete dependency graph validation before loading
 
-   Slice 1/3 of a rule 210 split train (SL003: this namespace measured
+   Slice 2/3 of a rule 210 split train (SL003: this namespace measured
    6 real layers, max 3 -- same convention as the mdc-compiler split,
-   miniforge#1729-#1743, and the workflow-runner split, miniforge#1662):
-   version parsing/comparison/constraint-satisfaction moved to
-   `ai.miniforge.policy-pack.rules.pack-dependency-validation.versions`.
-   `detect-version-conflicts` now calls `versions/satisfies-constraint?`
-   (a qualified, cross-namespace call, so it no longer counts toward
-   this file's local layer depth) and drops to Layer 0. This file now
-   measures 5 real layers; the graph-construction and trust-check
-   groups move out in the remaining slices of this train.
+   miniforge#1729-#1743, and the workflow-runner split, miniforge#1662).
+   Slice 1 (#1770) moved version parsing/comparison/constraint-satisfaction
+   to `...pack-dependency-validation.versions`. This slice moves the
+   trust-check chain to `...pack-dependency-validation.trust`:
+   tainted-dependency?, untrusted-instruction-escalation?,
+   check-dependency-trust, detect-trust-violations. This file now
+   measures 4 real layers; the graph-construction group moves out in
+   the final slice of this train.
 
    Layer 0: get-pack-dependencies, detect-circular/missing-dependencies,
-     tainted-dependency? / untrusted-instruction-escalation? predicates,
      calculate-pack-depths, detect-version-conflicts
    Layer 1: build-dependency-graph (over get-pack-dependencies),
-     check-dependency-trust, detect-depth-violations (over
-     calculate-pack-depths)
-   Layer 2: detect-trust-violations (over check-dependency-trust)
-   Layer 3: validate-pack-dependencies (orchestrates the Layer 0-2 detectors)
-   Layer 4: validate-single-pack (public entry point, over
+     detect-depth-violations (over calculate-pack-depths)
+   Layer 2: validate-pack-dependencies (orchestrates the Layer 0-1
+     detectors plus trust/detect-trust-violations, an external call)
+   Layer 3: validate-single-pack (public entry point, over
      validate-pack-dependencies)"
   (:require
    [ai.miniforge.algorithms.interface :as alg]
+   [ai.miniforge.policy-pack.rules.pack-dependency-validation.trust :as trust]
    [ai.miniforge.policy-pack.rules.pack-dependency-validation.versions :as versions]
    [clojure.string :as str]))
 
@@ -111,21 +110,6 @@
                              :message (str "Pack '" pack-id "' requires missing dependency '" dep-id "'")})
                           missing))))
          vec)))
-
-(defn- ^{:stratum 0} tainted-dependency?
-  "True when a non-tainted pack depends on a tainted pack."
-  [pack dep-pack]
-  (and dep-pack
-       (= :tainted (get dep-pack :pack/trust-level))
-       (not= :tainted (get pack :pack/trust-level))))
-
-(defn- ^{:stratum 0} untrusted-instruction-escalation?
-  "True when an untrusted pack with instruction authority depends on a trusted pack."
-  [pack dep-pack]
-  (and dep-pack
-       (= :untrusted (get pack :pack/trust-level :untrusted))
-       (= :authority/instruction (get pack :pack/authority :authority/data))
-       (= :trusted (get dep-pack :pack/trust-level))))
 
 (defn ^{:stratum 0} calculate-pack-depths
   "Calculate maximum depth for each pack using bottom-up traversal.
@@ -240,26 +224,6 @@
      :by-id by-id
      :versions versions}))
 
-(defn- ^{:stratum 1} check-dependency-trust
-  "Check a single pack→dependency pair for trust violations.
-   Returns a violation map or nil."
-  [pack-id pack dep-id dep-pack]
-  (cond
-    (tainted-dependency? pack dep-pack)
-    {:type       :trust-violation
-     :pack-id    pack-id
-     :dependency dep-id
-     :message    (str "Tainted dependency " dep-id
-                      " cannot be used by non-tainted pack " pack-id)}
-
-    (untrusted-instruction-escalation? pack dep-pack)
-    {:type       :trust-violation
-     :pack-id    pack-id
-     :dependency dep-id
-     :message    (str "Untrusted pack " pack-id
-                      " with instruction authority cannot depend on "
-                      "trusted pack " dep-id)}))
-
 (defn ^{:stratum 1} detect-depth-violations
   "Detect dependency chains that exceed the depth limit.
    Returns vector of violation maps:
@@ -284,29 +248,8 @@
 
 ;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 2} detect-trust-violations
-  "Detect trust level constraint violations per N4 §2.4.2.
-
-   Checks:
-   1. Untrusted pack with instruction authority depending on trusted pack
-   2. Tainted pack as dependency of any non-tainted pack
-
-   Returns vector of violation maps."
-  [_graph by-id]
-  (->> (vals by-id)
-       (mapcat (fn [pack]
-                 (let [pack-id (get pack :pack/id)]
-                   (->> (get pack :pack/extends [])
-                        (keep (fn [dep]
-                                (let [dep-id (get dep :pack-id)]
-                                  (check-dependency-trust
-                                   pack-id pack dep-id (get by-id dep-id)))))))))
-       vec))
-
-;------------------------------------------------------------------------------ Layer 3
-
 ;; Public API
-(defn ^{:stratum 3} validate-pack-dependencies
+(defn ^{:stratum 2} validate-pack-dependencies
   "Validate pack dependencies according to N4 §2.4.2.
 
    Checks:
@@ -340,7 +283,7 @@
         missing (detect-missing-dependencies graph by-id)
         version-conflicts (detect-version-conflicts graph versions)
         trust-violations (when check-trust?
-                          (detect-trust-violations graph by-id))
+                          (trust/detect-trust-violations graph by-id))
         depth-violations (detect-depth-violations graph max-depth)
 
         ;; Separate hard failures from warnings
@@ -354,9 +297,9 @@
      :violations failures
      :warnings warnings}))
 
-;------------------------------------------------------------------------------ Layer 4
+;------------------------------------------------------------------------------ Layer 3
 
-(defn ^{:stratum 4} validate-single-pack
+(defn ^{:stratum 3} validate-single-pack
   "Validate a single pack's dependencies against a registry of available packs.
 
    Arguments:

--- a/components/policy-pack/src/ai/miniforge/policy_pack/rules/pack_dependency_validation/trust.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/rules/pack_dependency_validation/trust.clj
@@ -1,0 +1,89 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.rules.pack-dependency-validation.trust
+  "Trust-level constraint checks for pack dependency validation (N4
+   §2.4.2): tainted-dependency and untrusted-instruction-authority
+   escalation detection. Split out of
+   `ai.miniforge.policy-pack.rules.pack-dependency-validation` (rule
+   210, SL003 split train, slice 2/3) — the self-contained trust-check
+   chain `detect-trust-violations` sits on top of.
+
+   Layer 0: tainted-dependency?, untrusted-instruction-escalation?
+     predicates
+   Layer 1: check-dependency-trust (over both Layer 0 predicates)
+   Layer 2: detect-trust-violations (over check-dependency-trust)")
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} tainted-dependency?
+  "True when a non-tainted pack depends on a tainted pack."
+  [pack dep-pack]
+  (and dep-pack
+       (= :tainted (get dep-pack :pack/trust-level))
+       (not= :tainted (get pack :pack/trust-level))))
+
+(defn- ^{:stratum 0} untrusted-instruction-escalation?
+  "True when an untrusted pack with instruction authority depends on a trusted pack."
+  [pack dep-pack]
+  (and dep-pack
+       (= :untrusted (get pack :pack/trust-level :untrusted))
+       (= :authority/instruction (get pack :pack/authority :authority/data))
+       (= :trusted (get dep-pack :pack/trust-level))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} check-dependency-trust
+  "Check a single pack→dependency pair for trust violations.
+   Returns a violation map or nil."
+  [pack-id pack dep-id dep-pack]
+  (cond
+    (tainted-dependency? pack dep-pack)
+    {:type       :trust-violation
+     :pack-id    pack-id
+     :dependency dep-id
+     :message    (str "Tainted dependency " dep-id
+                      " cannot be used by non-tainted pack " pack-id)}
+
+    (untrusted-instruction-escalation? pack dep-pack)
+    {:type       :trust-violation
+     :pack-id    pack-id
+     :dependency dep-id
+     :message    (str "Untrusted pack " pack-id
+                      " with instruction authority cannot depend on "
+                      "trusted pack " dep-id)}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} detect-trust-violations
+  "Detect trust level constraint violations per N4 §2.4.2.
+
+   Checks:
+   1. Untrusted pack with instruction authority depending on trusted pack
+   2. Tainted pack as dependency of any non-tainted pack
+
+   Returns vector of violation maps."
+  [_graph by-id]
+  (->> (vals by-id)
+       (mapcat (fn [pack]
+                 (let [pack-id (get pack :pack/id)]
+                   (->> (get pack :pack/extends [])
+                        (keep (fn [dep]
+                                (let [dep-id (get dep :pack-id)]
+                                  (check-dependency-trust
+                                   pack-id pack dep-id (get by-id dep-id)))))))))
+       vec))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/rules/pack_dependency_validation/trust.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/rules/pack_dependency_validation/trust.clj
@@ -20,8 +20,8 @@
    §2.4.2): tainted-dependency and untrusted-instruction-authority
    escalation detection. Split out of
    `ai.miniforge.policy-pack.rules.pack-dependency-validation` (rule
-   210, SL003 split train, slice 2/3) — the self-contained trust-check
-   chain `detect-trust-violations` sits on top of.
+   210, SL003 split train, slice 2/3) — a self-contained trust-check
+   chain that `detect-trust-violations` sits atop.
 
    Layer 0: tainted-dependency?, untrusted-instruction-escalation?
      predicates

--- a/components/policy-pack/test/ai/miniforge/policy_pack/governance_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/governance_test.clj
@@ -6,7 +6,7 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.policy-pack.core :as core]
-   [ai.miniforge.policy-pack.rules.pack-dependency-validation :as dep-val]))
+   [ai.miniforge.policy-pack.rules.pack-dependency-validation.trust :as trust]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -63,7 +63,7 @@
                  :pack/authority :authority/data
                  :pack/extends [{:pack-id "tainted"}]}
           by-id {"consumer" pack "tainted" tainted-pack}
-          viols (dep-val/detect-trust-violations {} by-id)]
+          viols (trust/detect-trust-violations {} by-id)]
       (is (= 1 (count viols)))
       (is (= :trust-violation (:type (first viols))))))
 
@@ -72,7 +72,7 @@
                  :pack/authority :authority/data
                  :pack/extends [{:pack-id "tainted"}]}
           by-id {"also-tainted" pack "tainted" tainted-pack}
-          viols (dep-val/detect-trust-violations {} by-id)]
+          viols (trust/detect-trust-violations {} by-id)]
       (is (empty? viols)))))
 
 (deftest ^{:stratum 1} untrusted-instruction-escalation-test
@@ -81,7 +81,7 @@
                  :pack/authority :authority/instruction
                  :pack/extends [{:pack-id "base"}]}
           by-id {"untrusted" pack "base" base-pack}
-          viols (dep-val/detect-trust-violations {} by-id)]
+          viols (trust/detect-trust-violations {} by-id)]
       (is (= 1 (count viols)))
       (is (= :trust-violation (:type (first viols))))))
 
@@ -90,11 +90,11 @@
                  :pack/authority :authority/data
                  :pack/extends [{:pack-id "base"}]}
           by-id {"untrusted" pack "base" base-pack}
-          viols (dep-val/detect-trust-violations {} by-id)]
+          viols (trust/detect-trust-violations {} by-id)]
       (is (empty? viols)))))
 
 (deftest ^{:stratum 1} clean-dependencies-test
   (testing "packs with no trust violations return empty"
     (let [by-id {"base" base-pack}
-          viols (dep-val/detect-trust-violations {} by-id)]
+          viols (trust/detect-trust-violations {} by-id)]
       (is (empty? viols)))))

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-pack-dependency-validation-2.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-pack-dependency-validation-2.md
@@ -1,0 +1,132 @@
+<!--
+  Title: Split policy-pack pack_dependency_validation.clj — extract trust (2/3)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split pack_dependency_validation.clj — extract trust (2/3)
+
+## Overview
+
+Slice 2 of the 3-PR split train for
+`components/policy-pack/src/ai/miniforge/policy_pack/rules/pack_dependency_validation.clj`
+(rule 210, SL003 — originally 6 real layers, max 3; slice 1 was
+[#1770](https://github.com/miniforge-ai/miniforge/pull/1770)). This
+slice extracts
+`ai.miniforge.policy-pack.rules.pack-dependency-validation.trust`: the
+trust-level constraint chain — `tainted-dependency?`,
+`untrusted-instruction-escalation?`, `check-dependency-trust`,
+`detect-trust-violations`.
+
+## Motivation
+
+Repo-wide fan-in check for the fully-qualified namespace (not a
+symbol-prefix guess):
+
+```bash
+grep -rlE "ai\.miniforge\.policy-pack\.rules\.pack-dependency-validation\b" \
+  --include='*.clj' components bases projects
+```
+
+Same 7 external callers as slice 1 (re-confirmed after rebasing onto
+the post-#1770 `main`):
+
+- `pack_dependency_graph_test.clj`, `pack_depth_limit_test.clj`,
+  `pack_validation_test.clj`, `pack_version_constraint_test.clj`,
+  `loader.clj`, `knowledge_safety/detectors.clj` — all call only
+  `validate-pack-dependencies` / `validate-single-pack` (unchanged
+  entry points). Untouched by this slice.
+- `governance_test.clj` — calls `dep-val/detect-trust-violations`
+  directly (5 call sites, white-box, bypassing the
+  `validate-pack-dependencies` orchestration path). **Updated by this
+  slice**: `detect-trust-violations` is no longer resolvable under the
+  `pack-dependency-validation` namespace.
+- `projects/miniforge/test/` re-checked directly — no match.
+
+## Changes in Detail
+
+- New file
+  `rules/pack_dependency_validation/trust.clj`
+  (`ai.miniforge.policy-pack.rules.pack-dependency-validation.trust`):
+  `tainted-dependency?`, `untrusted-instruction-escalation?` (Layer 0,
+  private), `check-dependency-trust` (Layer 1, private, over both
+  Layer 0 predicates), `detect-trust-violations` (Layer 2, public —
+  the only symbol crossing the namespace boundary). 3 real layers,
+  stratum-lint clean. Visibility unchanged for every function — the
+  two predicates and `check-dependency-trust` were already `defn-` in
+  the parent; `detect-trust-violations` was already public.
+- `pack_dependency_validation.clj`: the four functions removed;
+  `validate-pack-dependencies` now calls
+  `trust/detect-trust-violations` instead of the same-file
+  `detect-trust-violations`. Ran `stratum-lint --fix` to renumber the
+  remaining defs' heading/`:stratum` metadata (6 → 4 real layers after
+  slices 1+2) and rewrote the namespace docstring's layer summary.
+- `governance_test.clj`: replaced its `dep-val` alias (which, after
+  this slice, would resolve to nothing but the moved-out symbol) with
+  a direct require of the new `trust` namespace; all 5
+  `dep-val/detect-trust-violations` call sites become
+  `trust/detect-trust-violations`. No other symbol from the old
+  `dep-val` alias was in use, so the require swap is total (not an
+  addition alongside the old one).
+
+Pure code motion — no detection logic changed, no return shapes
+changed.
+
+The parent namespace stays over budget (4 real layers) until the
+final slice lands; the commit doing the removal used
+`MINIFORGE_STRATUM_BUDGET_MODE=warn` to get past the pre-commit gate's
+plain-lint check on this known intermediate state, same convention as
+slice 1. The final slice (extracting graph-construction) brings it to
+3 layers.
+
+## Testing Plan
+
+1. `clj-kondo` clean on all three touched files.
+2. stratum-lint: `trust.clj` passes SL003 outright (3 layers);
+   `pack_dependency_validation.clj` intentionally still over budget (4
+   layers) until slice 3 lands — expected and tracked, not a defect.
+3. Directly verified the five affected test namespaces (`bb test`
+   change-scope takes ~30 min in this repo and its truncated log
+   doesn't reliably show policy-pack-specific results, so this was run
+   directly): `cd` to the repo root, `clojure -M:dev:test -e
+   "(require 'ai.miniforge.policy-pack.rules.pack-version-constraint-test
+   'ai.miniforge.policy-pack.rules.pack-dependency-graph-test
+   'ai.miniforge.policy-pack.rules.pack-depth-limit-test
+   'ai.miniforge.policy-pack.rules.pack-validation-test
+   'ai.miniforge.policy-pack.governance-test)
+   (clojure.test/run-tests ...)"` — 23 tests, 78 assertions, 0
+   failures, 0 errors.
+4. `loader.clj` and `knowledge-safety`/`knowledge-safety.detectors`
+   (the two non-test callers) confirmed to `require` cleanly (no
+   compile error from the moved symbol).
+5. Adversarial self-review: diffed the full top-level `defn`/`def` set
+   before and after — exactly 4 relocated, 0 added/removed/altered in
+   behavior; `validate-pack-dependencies`'s body is unchanged except
+   the one qualified call.
+
+## Deployment Plan
+
+Merges to `main` as part of the ongoing 3-PR train. The final slice
+(graph-construction extraction) rebases onto this once merged.
+
+## Related Issues/PRs
+
+- Slice 1: [#1770](https://github.com/miniforge-ai/miniforge/pull/1770)
+- Precedent: [mdc-compiler split, #1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1743)
+- Precedent: [workflow-runner split, #1662](https://github.com/miniforge-ai/miniforge/pull/1662)
+- Part of the stratum-lint rule-210 remediation program (Wave 2, policy-pack batch 2)
+
+## Checklist
+
+- [x] Fan-in re-confirmed via fully-qualified-namespace grep before
+      starting (7 external callers, not zero fan-in)
+- [x] Pure code motion — no behavior change, no logic altered
+- [x] `clj-kondo` clean
+- [x] Tests directly verified (23/23, 78 assertions); loader +
+      knowledge-safety callers confirmed loadable
+- [x] Commit-diff budget checked (single commit, well under 200)
+- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
+      expected intermediate over-budget state
+- [x] One external test call site (`governance_test.clj`) updated for
+      the moved `detect-trust-violations`; the other 6 caller files
+      confirmed unaffected


### PR DESCRIPTION
<!--
  Title: Split policy-pack pack_dependency_validation.clj — extract trust (2/3)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split pack_dependency_validation.clj — extract trust (2/3)

## Overview

Slice 2 of the 3-PR split train for
`components/policy-pack/src/ai/miniforge/policy_pack/rules/pack_dependency_validation.clj`
(rule 210, SL003 — originally 6 real layers, max 3; slice 1 was
[#1770](https://github.com/miniforge-ai/miniforge/pull/1770)). This
slice extracts
`ai.miniforge.policy-pack.rules.pack-dependency-validation.trust`: the
trust-level constraint chain — `tainted-dependency?`,
`untrusted-instruction-escalation?`, `check-dependency-trust`,
`detect-trust-violations`.

## Motivation

Repo-wide fan-in check for the fully-qualified namespace (not a
symbol-prefix guess):

```bash
grep -rlE "ai\.miniforge\.policy-pack\.rules\.pack-dependency-validation\b" \
  --include='*.clj' components bases projects
```

Same 7 external callers as slice 1 (re-confirmed after rebasing onto
the post-#1770 `main`):

- `pack_dependency_graph_test.clj`, `pack_depth_limit_test.clj`,
  `pack_validation_test.clj`, `pack_version_constraint_test.clj`,
  `loader.clj`, `knowledge_safety/detectors.clj` — all call only
  `validate-pack-dependencies` / `validate-single-pack` (unchanged
  entry points). Untouched by this slice.
- `governance_test.clj` — calls `dep-val/detect-trust-violations`
  directly (5 call sites, white-box, bypassing the
  `validate-pack-dependencies` orchestration path). **Updated by this
  slice**: `detect-trust-violations` is no longer resolvable under the
  `pack-dependency-validation` namespace.
- `projects/miniforge/test/` re-checked directly — no match.

## Changes in Detail

- New file
  `rules/pack_dependency_validation/trust.clj`
  (`ai.miniforge.policy-pack.rules.pack-dependency-validation.trust`):
  `tainted-dependency?`, `untrusted-instruction-escalation?` (Layer 0,
  private), `check-dependency-trust` (Layer 1, private, over both
  Layer 0 predicates), `detect-trust-violations` (Layer 2, public —
  the only symbol crossing the namespace boundary). 3 real layers,
  stratum-lint clean. Visibility unchanged for every function — the
  two predicates and `check-dependency-trust` were already `defn-` in
  the parent; `detect-trust-violations` was already public.
- `pack_dependency_validation.clj`: the four functions removed;
  `validate-pack-dependencies` now calls
  `trust/detect-trust-violations` instead of the same-file
  `detect-trust-violations`. Ran `stratum-lint --fix` to renumber the
  remaining defs' heading/`:stratum` metadata (6 → 4 real layers after
  slices 1+2) and rewrote the namespace docstring's layer summary.
- `governance_test.clj`: replaced its `dep-val` alias (which, after
  this slice, would resolve to nothing but the moved-out symbol) with
  a direct require of the new `trust` namespace; all 5
  `dep-val/detect-trust-violations` call sites become
  `trust/detect-trust-violations`. No other symbol from the old
  `dep-val` alias was in use, so the require swap is total (not an
  addition alongside the old one).

Pure code motion — no detection logic changed, no return shapes
changed.

The parent namespace stays over budget (4 real layers) until the
final slice lands; the commit doing the removal used
`MINIFORGE_STRATUM_BUDGET_MODE=warn` to get past the pre-commit gate's
plain-lint check on this known intermediate state, same convention as
slice 1. The final slice (extracting graph-construction) brings it to
3 layers.

## Testing Plan

1. `clj-kondo` clean on all three touched files.
2. stratum-lint: `trust.clj` passes SL003 outright (3 layers);
   `pack_dependency_validation.clj` intentionally still over budget (4
   layers) until slice 3 lands — expected and tracked, not a defect.
3. Directly verified the five affected test namespaces (`bb test`
   change-scope takes ~30 min in this repo and its truncated log
   doesn't reliably show policy-pack-specific results, so this was run
   directly): `cd` to the repo root, `clojure -M:dev:test -e
   "(require 'ai.miniforge.policy-pack.rules.pack-version-constraint-test
   'ai.miniforge.policy-pack.rules.pack-dependency-graph-test
   'ai.miniforge.policy-pack.rules.pack-depth-limit-test
   'ai.miniforge.policy-pack.rules.pack-validation-test
   'ai.miniforge.policy-pack.governance-test)
   (clojure.test/run-tests ...)"` — 23 tests, 78 assertions, 0
   failures, 0 errors.
4. `loader.clj` and `knowledge-safety`/`knowledge-safety.detectors`
   (the two non-test callers) confirmed to `require` cleanly (no
   compile error from the moved symbol).
5. Adversarial self-review: diffed the full top-level `defn`/`def` set
   before and after — exactly 4 relocated, 0 added/removed/altered in
   behavior; `validate-pack-dependencies`'s body is unchanged except
   the one qualified call.

## Deployment Plan

Merges to `main` as part of the ongoing 3-PR train. The final slice
(graph-construction extraction) rebases onto this once merged.

## Related Issues/PRs

- Slice 1: [#1770](https://github.com/miniforge-ai/miniforge/pull/1770)
- Precedent: [mdc-compiler split, #1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1743)
- Precedent: [workflow-runner split, #1662](https://github.com/miniforge-ai/miniforge/pull/1662)
- Part of the stratum-lint rule-210 remediation program (Wave 2, policy-pack batch 2)

## Checklist

- [x] Fan-in re-confirmed via fully-qualified-namespace grep before
      starting (7 external callers, not zero fan-in)
- [x] Pure code motion — no behavior change, no logic altered
- [x] `clj-kondo` clean
- [x] Tests directly verified (23/23, 78 assertions); loader +
      knowledge-safety callers confirmed loadable
- [x] Commit-diff budget checked (single commit, well under 200)
- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
      expected intermediate over-budget state
- [x] One external test call site (`governance_test.clj`) updated for
      the moved `detect-trust-violations`; the other 6 caller files
      confirmed unaffected
