### PR TITLE
refactor(policy-pack): split mdc_to_pack_mapping_test.clj — extract naming (4/4, final)

### DIFF
--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test.clj
@@ -31,30 +31,12 @@
   (:require
    [ai.miniforge.policy-pack.mdc-to-pack-mapping-test.dewey :as dewey]
    [ai.miniforge.policy-pack.mdc-to-pack-mapping-test.fields :as fields]
-   [ai.miniforge.policy-pack.mdc-to-pack-mapping-test.inventory :as inventory]
-   [clojure.test :refer [deftest testing is are]]
+   [ai.miniforge.policy-pack.mdc-to-pack-mapping-test.naming :as naming]
+   [clojure.test :refer [deftest testing is]]
    [clojure.string :as str]
    [clojure.set :as set]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-;; ---------------------------------------------------------------------------
-;; Test helpers: Pure functions implementing the mapping spec
-;; ---------------------------------------------------------------------------
-(defn ^{:stratum 0} slug-from-filename
-  "Strip .mdc extension from filename (not full path).
-   'foundations/stratified-design.mdc' → 'stratified-design'"
-  [filepath]
-  (let [filename (last (str/split filepath #"/"))]
-    (str/replace filename #"\.mdc$" "")))
-
-(defn ^{:stratum 0} title-from-slug
-  "Derive title from slug: hyphens → spaces, title-case each word.
-   'pre-commit-discipline' → 'Pre Commit Discipline'"
-  [slug]
-  (->> (str/split slug #"-")
-       (map str/capitalize)
-       (str/join " ")))
 
 (defn ^{:stratum 0} build-applies-to
   "Build :rule/applies-to from dewey + optional globs."
@@ -66,50 +48,6 @@
       base)))
 
 ;------------------------------------------------------------------------------ Layer 1
-
-(defn ^{:stratum 1} rule-id-from-filepath
-  "Derive :rule/id from .mdc filepath.
-   Prefix slug with :std/ namespace.
-   'foundations/stratified-design.mdc' → :std/stratified-design"
-  [filepath]
-  (keyword "std" (slug-from-filename filepath)))
-
-(defn ^{:stratum 1} derive-title
-  "Get :rule/title from frontmatter description or fallback to slug."
-  [frontmatter filepath]
-  (let [desc (get frontmatter "description")]
-    (if (and desc (not (str/blank? desc)))
-      desc
-      (title-from-slug (slug-from-filename filepath)))))
-
-(deftest ^{:stratum 1} slug-from-filename-test
-  (testing "Strips .mdc extension from filename only"
-    (are [filepath expected]
-         (= expected (slug-from-filename filepath))
-      "foundations/stratified-design.mdc" "stratified-design"
-      "index.mdc"                        "index"
-      "languages/clojure.mdc"            "clojure"
-      "workflows/pr-layering.mdc"        "pr-layering"))
-
-  (testing "Handles nested directory paths"
-    (is (= "foo" (slug-from-filename "a/b/c/foo.mdc")))))
-
-(deftest ^{:stratum 1} title-from-slug-test
-  (testing "Converts hyphens to spaces and title-cases"
-    (are [slug expected]
-         (= expected (title-from-slug slug))
-      "code-quality"            "Code Quality"
-      "pre-commit-discipline"   "Pre Commit Discipline"
-      "index"                   "Index"
-      "stratified-design"       "Stratified Design"
-      "git-branch-management"   "Git Branch Management")))
-
-(deftest ^{:stratum 1} edge-case-duplicate-slugs-test
-  (testing "Duplicate filename slugs must be detectable"
-    (let [files ["foundations/foo.mdc" "workflows/foo.mdc"]
-          slugs (map slug-from-filename files)]
-      (is (not= (count slugs) (count (set slugs)))
-          "Duplicate slugs should be detected by ETL"))))
 
 ;; ===========================================================================
 ;; Section 6: Applies-To (Phases + Globs) Tests
@@ -132,55 +70,12 @@
             :file-globs [".cursor/rules/**/*.mdc"]}
            (build-applies-to "900" [".cursor/rules/**/*.mdc"])))))
 
-;------------------------------------------------------------------------------ Layer 2
-
-;; ===========================================================================
-;; Section 1: Rule ID Derivation Tests
-;; ===========================================================================
-(deftest ^{:stratum 2} rule-id-derivation-test
-  (testing "Rule ID is derived from filename slug with :std/ namespace"
-    (are [filepath expected-id]
-         (= expected-id (rule-id-from-filepath filepath))
-      "foundations/stratified-design.mdc"       :std/stratified-design
-      "languages/clojure.mdc"                   :std/clojure
-      "workflows/pre-commit-discipline.mdc"     :std/pre-commit-discipline
-      "testing/standards.mdc"                   :std/standards
-      "index.mdc"                               :std/index
-      "meta/rule-format.mdc"                    :std/rule-format
-      "project/header-copyright.mdc"            :std/header-copyright))
-
-  (testing "Directory path is NOT included in the id"
-    (is (= :std/clojure (rule-id-from-filepath "languages/clojure.mdc")))
-    (is (= :std/clojure (rule-id-from-filepath "deeply/nested/path/clojure.mdc"))))
-
-  (testing "Complete inventory matches expected IDs"
-    (doseq [[filepath expected-id] inventory/complete-inventory]
-      (is (= expected-id (rule-id-from-filepath filepath))
-          (str "ID mismatch for " filepath)))))
-
-;; ===========================================================================
-;; Section 2: Title Derivation Tests
-;; ===========================================================================
-(deftest ^{:stratum 2} title-derivation-test
-  (testing "Uses description frontmatter verbatim when present"
-    (let [fm {"description" "Stratified Design — enforce one-way dependencies"}]
-      (is (= "Stratified Design — enforce one-way dependencies"
-             (derive-title fm "foundations/stratified-design.mdc")))))
-
-  (testing "Falls back to title-cased slug when description missing"
-    (is (= "Code Quality" (derive-title {} "foundations/code-quality.mdc")))
-    (is (= "Pre Commit Discipline" (derive-title {} "workflows/pre-commit-discipline.mdc"))))
-
-  (testing "Falls back to title-cased slug when description is blank"
-    (is (= "Code Quality" (derive-title {"description" ""} "foundations/code-quality.mdc")))
-    (is (= "Code Quality" (derive-title {"description" "  "} "foundations/code-quality.mdc")))))
-
-(defn ^{:stratum 2} compile-rule
+(defn ^{:stratum 1} compile-rule
   "Compile a single MDC file representation into a pack rule map.
    This is the reference implementation of the spec's field mapping."
   [{:keys [filepath frontmatter body]}]
   (let [dewey       (get frontmatter "dewey" "000")
-        title       (derive-title frontmatter filepath)
+        title       (naming/derive-title frontmatter filepath)
         description (fields/derive-description dewey title)
         always-apply (get frontmatter "alwaysApply")
         globs       (get frontmatter "globs")
@@ -189,7 +84,7 @@
         knowledge   (when (and trimmed-body (not (str/blank? trimmed-body)))
                       trimmed-body)]
     (merge
-     {:rule/id                (rule-id-from-filepath filepath)
+     {:rule/id                (naming/rule-id-from-filepath filepath)
       :rule/title             title
       :rule/description       description
       :rule/severity          severity
@@ -201,12 +96,12 @@
      (when knowledge
        {:rule/knowledge-content knowledge}))))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 2
 
 ;; ===========================================================================
 ;; Section 7: Constant/Default Fields Tests
 ;; ===========================================================================
-(deftest ^{:stratum 3} constant-fields-test
+(deftest ^{:stratum 2} constant-fields-test
   (testing "Non-alwaysApply severity is :low"
     (let [rule (compile-rule {:filepath "test.mdc"
                               :frontmatter {"dewey" "001"}
@@ -239,7 +134,7 @@
 ;; ===========================================================================
 ;; Section 8: Knowledge Content Tests
 ;; ===========================================================================
-(deftest ^{:stratum 3} knowledge-content-test
+(deftest ^{:stratum 2} knowledge-content-test
   (testing "Body text preserved as :rule/knowledge-content"
     (let [body "# Heading\n\nSome content here."
           rule (compile-rule {:filepath "test.mdc"
@@ -274,7 +169,7 @@
 ;; ===========================================================================
 ;; Section 10: Worked Example A — Foundation alwaysApply Rule
 ;; ===========================================================================
-(deftest ^{:stratum 3} worked-example-a-stratified-design-test
+(deftest ^{:stratum 2} worked-example-a-stratified-design-test
   (let [rule (compile-rule
               {:filepath    "foundations/stratified-design.mdc"
                :frontmatter {"dewey"       "001"
@@ -321,7 +216,7 @@
 ;; ===========================================================================
 ;; Section 11: Worked Example B — Language Rule with Globs
 ;; ===========================================================================
-(deftest ^{:stratum 3} worked-example-b-clojure-test
+(deftest ^{:stratum 2} worked-example-b-clojure-test
   (let [globs ["components/**/src/**/*.clj"
                "components/**/src/**/*.cljc"
                "bases/**/src/**/*.clj"
@@ -360,7 +255,7 @@
 ;; ===========================================================================
 ;; Section 12: Worked Example C — Meta Rule (Not Injected)
 ;; ===========================================================================
-(deftest ^{:stratum 3} worked-example-c-meta-rule-test
+(deftest ^{:stratum 2} worked-example-c-meta-rule-test
   (let [rule (compile-rule
               {:filepath    "meta/rule-format.mdc"
                :frontmatter {"dewey"       "900"
@@ -385,7 +280,7 @@
 ;; ===========================================================================
 ;; Section 13: Worked Example D — Testing Rule (alwaysApply)
 ;; ===========================================================================
-(deftest ^{:stratum 3} worked-example-d-testing-rule-test
+(deftest ^{:stratum 2} worked-example-d-testing-rule-test
   (let [rule (compile-rule
               {:filepath    "testing/standards.mdc"
                :frontmatter {"dewey"       "400"
@@ -411,7 +306,7 @@
 ;; ===========================================================================
 ;; Section 14: Edge Case Tests
 ;; ===========================================================================
-(deftest ^{:stratum 3} edge-case-missing-dewey-test
+(deftest ^{:stratum 2} edge-case-missing-dewey-test
   (testing "Missing dewey → default to '000', phases all"
     (let [rule (compile-rule {:filepath "test.mdc"
                               :frontmatter {}
@@ -420,14 +315,14 @@
       (is (= dewey/all-phases
              (get-in rule [:rule/applies-to :phases]))))))
 
-(deftest ^{:stratum 3} edge-case-missing-description-test
+(deftest ^{:stratum 2} edge-case-missing-description-test
   (testing "Missing description → title derived from slug"
     (let [rule (compile-rule {:filepath "foundations/code-quality.mdc"
                               :frontmatter {"dewey" "001"}
                               :body "content"})]
       (is (= "Code Quality" (:rule/title rule))))))
 
-(deftest ^{:stratum 3} edge-case-empty-body-test
+(deftest ^{:stratum 2} edge-case-empty-body-test
   (testing "Empty body → knowledge-content omitted, rule still valid"
     (let [rule (compile-rule {:filepath "stub.mdc"
                               :frontmatter {"dewey" "001"
@@ -437,7 +332,7 @@
       (is (= :std/stub (:rule/id rule)))
       (is (= "Stub rule" (:rule/title rule))))))
 
-(deftest ^{:stratum 3} edge-case-always-apply-meta-test
+(deftest ^{:stratum 2} edge-case-always-apply-meta-test
   (testing "alwaysApply: true + dewey 900 → always-inject true but empty phases"
     (let [rule (compile-rule {:filepath "meta/weird.mdc"
                               :frontmatter {"dewey"       "900"
@@ -447,7 +342,7 @@
       (is (true? (:rule/always-inject? rule)))
       (is (= #{} (get-in rule [:rule/applies-to :phases]))))))
 
-(deftest ^{:stratum 3} edge-case-globs-string-instead-of-list-test
+(deftest ^{:stratum 2} edge-case-globs-string-instead-of-list-test
   (testing "String globs normalized to vector"
     (let [rule (compile-rule {:filepath "test.mdc"
                               :frontmatter {"dewey" "210"
@@ -455,7 +350,7 @@
                               :body "content"})]
       (is (= ["*.clj"] (get-in rule [:rule/applies-to :file-globs]))))))
 
-(deftest ^{:stratum 3} edge-case-index-mdc-test
+(deftest ^{:stratum 2} edge-case-index-mdc-test
   (testing "index.mdc compiled like any other file, ID :std/index"
     (let [rule (compile-rule {:filepath "index.mdc"
                               :frontmatter {"dewey" "000"
@@ -467,7 +362,7 @@
       ;; alwaysApply false → always-inject? omitted
       (is (not (contains? rule :rule/always-inject?))))))
 
-(deftest ^{:stratum 3} all-rule-schema-fields-produced-test
+(deftest ^{:stratum 2} all-rule-schema-fields-produced-test
   (testing "Compiled rule produces all required schema fields"
     (let [rule (compile-rule {:filepath "test/example.mdc"
                               :frontmatter {"dewey"       "210"
@@ -481,7 +376,7 @@
       (is (set/subset? required-keys (set (keys rule)))
           (str "Missing required keys: " (set/difference required-keys (set (keys rule))))))))
 
-(deftest ^{:stratum 3} optional-fields-conditionally-present-test
+(deftest ^{:stratum 2} optional-fields-conditionally-present-test
   (testing ":rule/always-inject? present only when alwaysApply is true"
     (let [rule-with    (compile-rule {:filepath "a.mdc" :frontmatter {"alwaysApply" true} :body "x"})
           rule-without (compile-rule {:filepath "b.mdc" :frontmatter {} :body "x"})]
@@ -497,7 +392,7 @@
 ;; ===========================================================================
 ;; Section 18: Schema Compatibility Tests
 ;; ===========================================================================
-(deftest ^{:stratum 3} compiled-rule-matches-schema-shape-test
+(deftest ^{:stratum 2} compiled-rule-matches-schema-shape-test
   (testing "Compiled rule has correct value types for schema fields"
     (let [rule (compile-rule {:filepath "foundations/stratified-design.mdc"
                               :frontmatter {"dewey" "001"
@@ -530,7 +425,7 @@
       (is (boolean? (:rule/always-inject? rule)))
       (is (string? (:rule/knowledge-content rule))))))
 
-(deftest ^{:stratum 3} always-inject-does-not-override-phases-test
+(deftest ^{:stratum 2} always-inject-does-not-override-phases-test
   (testing "alwaysApply controls injection, phases control which roles"
     (let [rule (compile-rule {:filepath "testing/standards.mdc"
                               :frontmatter {"dewey" "400"

--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/naming.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/naming.clj
@@ -1,0 +1,72 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.mdc-to-pack-mapping-test.naming
+  "Filename/slug/title derivation, part of the reference implementation
+   for the MDC-to-Pack Rule Field Mapping acceptance spec (Sections 1
+   and 2 of work/designs/mdc-to-pack-field-mapping.edn): deriving
+   :rule/id and :rule/title from an .mdc filepath and its frontmatter.
+
+   Split out of `ai.miniforge.policy-pack.mdc-to-pack-mapping-test`
+   (rule 210: slice 4/7 of a stratum-lint SL003 split train — see
+   `mdc-to-pack-mapping-test.dewey` for slice 1 and the full train
+   rationale). `rule-id-from-filepath` and `derive-title` both call
+   `slug-from-filename`; `derive-title` also calls `title-from-slug`.
+   That's a 2-layer same-file chain, so this file was already within
+   budget on its own — moving it out shrinks the parent file's bulk
+   and (together with slice 6, which moves `compile-rule`) removes
+   `derive-title`/`rule-id-from-filepath` from the parent's deepest
+   chain.
+
+   Layer 0: slug-from-filename, title-from-slug
+   Layer 1: rule-id-from-filepath, derive-title"
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} slug-from-filename
+  "Strip .mdc extension from filename (not full path).
+   'foundations/stratified-design.mdc' → 'stratified-design'"
+  [filepath]
+  (let [filename (last (str/split filepath #"/"))]
+    (str/replace filename #"\.mdc$" "")))
+
+(defn ^{:stratum 0} title-from-slug
+  "Derive title from slug: hyphens → spaces, title-case each word.
+   'pre-commit-discipline' → 'Pre Commit Discipline'"
+  [slug]
+  (->> (str/split slug #"-")
+       (map str/capitalize)
+       (str/join " ")))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} rule-id-from-filepath
+  "Derive :rule/id from .mdc filepath.
+   Prefix slug with :std/ namespace.
+   'foundations/stratified-design.mdc' → :std/stratified-design"
+  [filepath]
+  (keyword "std" (slug-from-filename filepath)))
+
+(defn ^{:stratum 1} derive-title
+  "Get :rule/title from frontmatter description or fallback to slug."
+  [frontmatter filepath]
+  (let [desc (get frontmatter "description")]
+    (if (and desc (not (str/blank? desc)))
+      desc
+      (title-from-slug (slug-from-filename filepath)))))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/naming.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/naming.clj
@@ -22,7 +22,7 @@
    :rule/id and :rule/title from an .mdc filepath and its frontmatter.
 
    Split out of `ai.miniforge.policy-pack.mdc-to-pack-mapping-test`
-   (rule 210: slice 4/7 of a stratum-lint SL003 split train — see
+   (rule 210: slice 4/4, final, of a stratum-lint SL003 split train — see
    `mdc-to-pack-mapping-test.dewey` for slice 1 and the full train
    rationale). `rule-id-from-filepath` and `derive-title` both call
    `slug-from-filename`; `derive-title` also calls `title-from-slug`.

--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/naming_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/naming_test.clj
@@ -1,0 +1,101 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.mdc-to-pack-mapping-test.naming-test
+  "Acceptance tests for filename/slug/title derivation (Sections 1 and
+   2 of work/designs/mdc-to-pack-field-mapping.edn).
+
+   Split out of `ai.miniforge.policy-pack.mdc-to-pack-mapping-test`
+   (rule 210 split train, slice 4/7). Assertions are unchanged from the
+   parent namespace — only the deftest forms and their dependency on
+   `mdc-to-pack-mapping-test.naming` moved."
+  (:require
+   [ai.miniforge.policy-pack.mdc-to-pack-mapping-test.inventory :as inventory]
+   [ai.miniforge.policy-pack.mdc-to-pack-mapping-test.naming :as naming]
+   [clojure.test :refer [are deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} slug-from-filename-test
+  (testing "Strips .mdc extension from filename only"
+    (are [filepath expected]
+         (= expected (naming/slug-from-filename filepath))
+      "foundations/stratified-design.mdc" "stratified-design"
+      "index.mdc"                        "index"
+      "languages/clojure.mdc"            "clojure"
+      "workflows/pr-layering.mdc"        "pr-layering"))
+
+  (testing "Handles nested directory paths"
+    (is (= "foo" (naming/slug-from-filename "a/b/c/foo.mdc")))))
+
+(deftest ^{:stratum 0} title-from-slug-test
+  (testing "Converts hyphens to spaces and title-cases"
+    (are [slug expected]
+         (= expected (naming/title-from-slug slug))
+      "code-quality"            "Code Quality"
+      "pre-commit-discipline"   "Pre Commit Discipline"
+      "index"                   "Index"
+      "stratified-design"       "Stratified Design"
+      "git-branch-management"   "Git Branch Management")))
+
+(deftest ^{:stratum 0} edge-case-duplicate-slugs-test
+  (testing "Duplicate filename slugs must be detectable"
+    (let [files ["foundations/foo.mdc" "workflows/foo.mdc"]
+          slugs (map naming/slug-from-filename files)]
+      (is (not= (count slugs) (count (set slugs)))
+          "Duplicate slugs should be detected by ETL"))))
+
+;; ===========================================================================
+;; Section 1: Rule ID Derivation Tests
+;; ===========================================================================
+(deftest ^{:stratum 0} rule-id-derivation-test
+  (testing "Rule ID is derived from filename slug with :std/ namespace"
+    (are [filepath expected-id]
+         (= expected-id (naming/rule-id-from-filepath filepath))
+      "foundations/stratified-design.mdc"       :std/stratified-design
+      "languages/clojure.mdc"                   :std/clojure
+      "workflows/pre-commit-discipline.mdc"     :std/pre-commit-discipline
+      "testing/standards.mdc"                   :std/standards
+      "index.mdc"                               :std/index
+      "meta/rule-format.mdc"                    :std/rule-format
+      "project/header-copyright.mdc"            :std/header-copyright))
+
+  (testing "Directory path is NOT included in the id"
+    (is (= :std/clojure (naming/rule-id-from-filepath "languages/clojure.mdc")))
+    (is (= :std/clojure (naming/rule-id-from-filepath "deeply/nested/path/clojure.mdc"))))
+
+  (testing "Complete inventory matches expected IDs"
+    (doseq [[filepath expected-id] inventory/complete-inventory]
+      (is (= expected-id (naming/rule-id-from-filepath filepath))
+          (str "ID mismatch for " filepath)))))
+
+;; ===========================================================================
+;; Section 2: Title Derivation Tests
+;; ===========================================================================
+(deftest ^{:stratum 0} title-derivation-test
+  (testing "Uses description frontmatter verbatim when present"
+    (let [fm {"description" "Stratified Design — enforce one-way dependencies"}]
+      (is (= "Stratified Design — enforce one-way dependencies"
+             (naming/derive-title fm "foundations/stratified-design.mdc")))))
+
+  (testing "Falls back to title-cased slug when description missing"
+    (is (= "Code Quality" (naming/derive-title {} "foundations/code-quality.mdc")))
+    (is (= "Pre Commit Discipline" (naming/derive-title {} "workflows/pre-commit-discipline.mdc"))))
+
+  (testing "Falls back to title-cased slug when description is blank"
+    (is (= "Code Quality" (naming/derive-title {"description" ""} "foundations/code-quality.mdc")))
+    (is (= "Code Quality" (naming/derive-title {"description" "  "} "foundations/code-quality.mdc")))))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/naming_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/naming_test.clj
@@ -20,7 +20,7 @@
    2 of work/designs/mdc-to-pack-field-mapping.edn).
 
    Split out of `ai.miniforge.policy-pack.mdc-to-pack-mapping-test`
-   (rule 210 split train, slice 4/7). Assertions are unchanged from the
+   (rule 210 split train, slice 4/4, final). Assertions are unchanged from the
    parent namespace — only the deftest forms and their dependency on
    `mdc-to-pack-mapping-test.naming` moved."
   (:require

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-mdc-to-pack-mapping-test-4.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-mdc-to-pack-mapping-test-4.md
@@ -1,0 +1,120 @@
+<!--
+  Title: Split policy-pack mdc_to_pack_mapping_test.clj — extract naming (4/4, final)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split mdc_to_pack_mapping_test.clj — extract naming (4/4, final)
+
+## Overview
+
+Final slice of the split of
+`components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test.clj`
+(stratum-lint SL003, rule 210, `standards/miniforge`). See
+[slice 1, miniforge#1758](https://github.com/miniforge-ai/miniforge/pull/1758)
+for the original train rationale and precedent links.
+
+This slice extracts `ai.miniforge.policy-pack.mdc-to-pack-mapping-test.naming`:
+filename/slug/title derivation (`slug-from-filename`, `title-from-slug`,
+`rule-id-from-filepath`, `derive-title`) — and, with it, **closes out
+the split train at 4 PRs instead of the originally estimated 7**. See
+"Why the train ends here" below.
+
+## Motivation
+
+Zero fan-in confirmed for the parent test namespace before slice 1
+(see miniforge#1758); this slice doesn't change that.
+
+## Changes in Detail
+
+- New file `mdc_to_pack_mapping_test/naming.clj`: the four functions
+  above, moved verbatim. `rule-id-from-filepath` and `derive-title`
+  both call `slug-from-filename`; `derive-title` also calls
+  `title-from-slug` — a 2-layer same-file chain, so this file was
+  already within its own budget before extraction.
+- New file `mdc_to_pack_mapping_test/naming_test.clj`: the `deftest`
+  forms that exercise them (`slug-from-filename-test`,
+  `title-from-slug-test`, `edge-case-duplicate-slugs-test`,
+  `rule-id-derivation-test`, `title-derivation-test`) — assertions
+  unchanged, call sites now go through the `naming` alias.
+  `rule-id-derivation-test`'s "Complete inventory matches expected
+  IDs" subtest requires `mdc-to-pack-mapping-test.inventory` directly
+  (slice 3), same as it did in the parent file.
+- `mdc_to_pack_mapping_test.clj`: the four functions and five tests
+  removed; `compile-rule` now calls `naming/derive-title` and
+  `naming/rule-id-from-filepath` across the namespace boundary. Also
+  dropped the now-unused `inventory` require and `are` refer — their
+  only callers in this file were the tests that just moved out. Ran
+  `stratum-lint --fix`: **the file is now within budget at 3 real
+  layers** (0: `build-applies-to`; 1: `applies-to-test`,
+  `compile-rule`; 2: the `compile-rule`-dependent tests) — plain
+  `stratum-lint` passes clean, no `MINIFORGE_STRATUM_BUDGET_MODE`
+  override needed for this commit (the only slice in this train where
+  that was true).
+
+## Why the train ends here
+
+The plan in miniforge#1758 anticipated up to 7 slices, following the
+`mdc_compiler.clj` precedent's 6-PR train. That file's SL003 finding
+came from **two independent chains** both feeding `mdc->rule`
+(frontmatter/dewey and rule-config), needing two extraction passes
+plus incidentals. This file's finding turned out to come from **one**
+deepest chain: `dewey` → `naming`'s `build-applies-to`/`compile-rule`
+→ the `compile-rule`-dependent tests. Moving the dewey chain (slice 1)
+and then the naming chain (this slice) onto namespace boundaries
+removed both segments feeding `compile-rule`'s depth, so the
+remaining ~120-line `build-applies-to`/`compile-rule`/tests block
+never needed its own extraction to fit the 3-layer budget.
+`fields.clj` and `inventory.clj` (slices 2-3) were layer-0 islands
+moved to shrink the file's line count, not because they sat on the
+deepest chain — with hindsight they weren't strictly required for
+SL003 compliance, but they're accurate, reviewable extractions of
+real cohesive concerns and left the file smaller regardless.
+
+## Testing Plan
+
+1. `clj-kondo` clean on all three touched/new files (including the
+   `inventory`/`are` unused-require cleanup in the parent file).
+2. stratum-lint: `naming.clj` and `naming_test.clj` pass SL003
+   outright; `mdc_to_pack_mapping_test.clj` **now passes SL003
+   outright too** (3 real layers) — the train's goal, achieved.
+3. Test/assertion count verified unchanged before and after, across
+   all five namespaces combined: 39 tests / 1213 assertions, 0
+   failures — identical to the slice-3 baseline and to the original
+   single-file count before slice 1.
+4. Full pre-commit suite (`poly:check`, lint, stratum-lint, smoke
+   tests, GraalVM) passed on both commits — the second commit passed
+   the plain stratum-lint gate with no override, confirming the file
+   is genuinely within budget now, not just deferred.
+5. Adversarial self-review: diffed the full top-level `defn`/`deftest`
+   set before and after — exactly 4 functions and 5 deftest forms
+   relocated, 0 added/removed/altered in behavior; the two remaining
+   call sites (`compile-rule`) changed only their qualification
+   (`naming/...`), not their arguments or logic.
+
+PR size: 197 reportable lines (195 raw insertions / 127 raw deletions
+across 3 files, two commits of 110 and 122 reportable lines each),
+under the 600-line budget — no override needed.
+
+## Deployment Plan
+
+Merges to `main`. This is the last PR in the
+`mdc_to_pack_mapping_test.clj` split train — no further slices planned.
+
+## Related Issues/PRs
+
+- Slice 1: [miniforge#1758](https://github.com/miniforge-ai/miniforge/pull/1758)
+- Slice 2: [miniforge#1771](https://github.com/miniforge-ai/miniforge/pull/1771)
+- Slice 3: [miniforge#1775](https://github.com/miniforge-ai/miniforge/pull/1775)
+- Precedent: [mdc_compiler.clj split train, miniforge#1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1743)
+- Part of the stratum-lint rule-210 remediation program (Wave 2, policy-pack batch 2)
+
+## Checklist
+
+- [x] Zero fan-in confirmed (unchanged since slice 1)
+- [x] Pure code motion — no behavior change, no assertions altered
+- [x] `clj-kondo` clean
+- [x] Tests green (39/39 tests, 1213/1213 assertions, matches baseline)
+- [x] PR-diff and commit-diff budgets checked (197/600 PR, both commits ≤200)
+- [x] `mdc_to_pack_mapping_test.clj` passes plain stratum-lint (no
+      warn-mode override needed) — SL003 resolved


### PR DESCRIPTION
<!--
  Title: Split policy-pack mdc_to_pack_mapping_test.clj — extract naming (4/4, final)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split mdc_to_pack_mapping_test.clj — extract naming (4/4, final)

## Overview

Final slice of the split of
`components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test.clj`
(stratum-lint SL003, rule 210, `standards/miniforge`). See
[slice 1, miniforge#1758](https://github.com/miniforge-ai/miniforge/pull/1758)
for the original train rationale and precedent links.

This slice extracts `ai.miniforge.policy-pack.mdc-to-pack-mapping-test.naming`:
filename/slug/title derivation (`slug-from-filename`, `title-from-slug`,
`rule-id-from-filepath`, `derive-title`) — and, with it, **closes out
the split train at 4 PRs instead of the originally estimated 7**. See
"Why the train ends here" below.

## Motivation

Zero fan-in confirmed for the parent test namespace before slice 1
(see miniforge#1758); this slice doesn't change that.

## Changes in Detail

- New file `mdc_to_pack_mapping_test/naming.clj`: the four functions
  above, moved verbatim. `rule-id-from-filepath` and `derive-title`
  both call `slug-from-filename`; `derive-title` also calls
  `title-from-slug` — a 2-layer same-file chain, so this file was
  already within its own budget before extraction.
- New file `mdc_to_pack_mapping_test/naming_test.clj`: the `deftest`
  forms that exercise them (`slug-from-filename-test`,
  `title-from-slug-test`, `edge-case-duplicate-slugs-test`,
  `rule-id-derivation-test`, `title-derivation-test`) — assertions
  unchanged, call sites now go through the `naming` alias.
  `rule-id-derivation-test`'s "Complete inventory matches expected
  IDs" subtest requires `mdc-to-pack-mapping-test.inventory` directly
  (slice 3), same as it did in the parent file.
- `mdc_to_pack_mapping_test.clj`: the four functions and five tests
  removed; `compile-rule` now calls `naming/derive-title` and
  `naming/rule-id-from-filepath` across the namespace boundary. Also
  dropped the now-unused `inventory` require and `are` refer — their
  only callers in this file were the tests that just moved out. Ran
  `stratum-lint --fix`: **the file is now within budget at 3 real
  layers** (0: `build-applies-to`; 1: `applies-to-test`,
  `compile-rule`; 2: the `compile-rule`-dependent tests) — plain
  `stratum-lint` passes clean, no `MINIFORGE_STRATUM_BUDGET_MODE`
  override needed for this commit (the only slice in this train where
  that was true).

## Why the train ends here

The plan in miniforge#1758 anticipated up to 7 slices, following the
`mdc_compiler.clj` precedent's 6-PR train. That file's SL003 finding
came from **two independent chains** both feeding `mdc->rule`
(frontmatter/dewey and rule-config), needing two extraction passes
plus incidentals. This file's finding turned out to come from **one**
deepest chain: `dewey` → `naming`'s `build-applies-to`/`compile-rule`
→ the `compile-rule`-dependent tests. Moving the dewey chain (slice 1)
and then the naming chain (this slice) onto namespace boundaries
removed both segments feeding `compile-rule`'s depth, so the
remaining ~120-line `build-applies-to`/`compile-rule`/tests block
never needed its own extraction to fit the 3-layer budget.
`fields.clj` and `inventory.clj` (slices 2-3) were layer-0 islands
moved to shrink the file's line count, not because they sat on the
deepest chain — with hindsight they weren't strictly required for
SL003 compliance, but they're accurate, reviewable extractions of
real cohesive concerns and left the file smaller regardless.

## Testing Plan

1. `clj-kondo` clean on all three touched/new files (including the
   `inventory`/`are` unused-require cleanup in the parent file).
2. stratum-lint: `naming.clj` and `naming_test.clj` pass SL003
   outright; `mdc_to_pack_mapping_test.clj` **now passes SL003
   outright too** (3 real layers) — the train's goal, achieved.
3. Test/assertion count verified unchanged before and after, across
   all five namespaces combined: 39 tests / 1213 assertions, 0
   failures — identical to the slice-3 baseline and to the original
   single-file count before slice 1.
4. Full pre-commit suite (`poly:check`, lint, stratum-lint, smoke
   tests, GraalVM) passed on both commits — the second commit passed
   the plain stratum-lint gate with no override, confirming the file
   is genuinely within budget now, not just deferred.
5. Adversarial self-review: diffed the full top-level `defn`/`deftest`
   set before and after — exactly 4 functions and 5 deftest forms
   relocated, 0 added/removed/altered in behavior; the two remaining
   call sites (`compile-rule`) changed only their qualification
   (`naming/...`), not their arguments or logic.

PR size: 197 reportable lines (195 raw insertions / 127 raw deletions
across 3 files, two commits of 110 and 122 reportable lines each),
under the 600-line budget — no override needed.

## Deployment Plan

Merges to `main`. This is the last PR in the
`mdc_to_pack_mapping_test.clj` split train — no further slices planned.

## Related Issues/PRs

- Slice 1: [miniforge#1758](https://github.com/miniforge-ai/miniforge/pull/1758)
- Slice 2: [miniforge#1771](https://github.com/miniforge-ai/miniforge/pull/1771)
- Slice 3: [miniforge#1775](https://github.com/miniforge-ai/miniforge/pull/1775)
- Precedent: [mdc_compiler.clj split train, miniforge#1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1743)
- Part of the stratum-lint rule-210 remediation program (Wave 2, policy-pack batch 2)

## Checklist

- [x] Zero fan-in confirmed (unchanged since slice 1)
- [x] Pure code motion — no behavior change, no assertions altered
- [x] `clj-kondo` clean
- [x] Tests green (39/39 tests, 1213/1213 assertions, matches baseline)
- [x] PR-diff and commit-diff budgets checked (197/600 PR, both commits ≤200)
- [x] `mdc_to_pack_mapping_test.clj` passes plain stratum-lint (no
      warn-mode override needed) — SL003 resolved