### PR TITLE
refactor(policy-pack): split external.clj (rule 210)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/external.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/external.clj
@@ -21,94 +21,22 @@
    Parses PR diffs into artifacts, selects applicable packs, and runs
    evaluation in read-only mode (no repair phase).
 
-   Layer 0: parse-diff-header, path-matches-glob?
-   Layer 1: parse-pr-diff, files-match-globs? (over Layer 0)
-   Layer 2: pack-applies? (over files-match-globs?)
-   Layer 3: select-applicable-packs (over pack-applies?)
-   Layer 4: evaluate-external-pr (over parse-pr-diff + select-applicable-packs)
+   Diff parsing lives in `ai.miniforge.policy-pack.external.diff`; pack
+   applicability / glob matching lives in
+   `ai.miniforge.policy-pack.external.matching` (rule 210: the combined
+   namespace measured 5 real layers, max 3). This namespace keeps pack
+   selection and the top-level evaluation entry point.
 
-   5 real strata — over the rule 210 budget of 3; a genuine namespace split
-   (Wave 2), not a labeling problem."
+   Layer 0: select-applicable-packs (over matching/pack-applies?)
+   Layer 1: evaluate-external-pr (over diff/parse-pr-diff + select-applicable-packs)"
   (:require
    [ai.miniforge.policy-pack.core :as core]
-   [ai.miniforge.policy-pack.registry :as registry]
-   [clojure.string :as str]))
+   [ai.miniforge.policy-pack.external.diff :as diff]
+   [ai.miniforge.policy-pack.external.matching :as matching]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Diff parsing
-(defn ^{:stratum 0} parse-diff-header
-  "Parse a diff header to extract the file path.
-   Handles 'diff --git a/path b/path' format."
-  [header-line]
-  (when-let [[_ path] (re-find #"^diff --git a/.+ b/(.+)$" header-line)]
-    path))
-
-;; Pack selection
-(defn ^{:stratum 0} path-matches-glob?
-  "Test a single path against a single glob pattern."
-  [glob-fn glob path]
-  (try (glob-fn glob path) (catch Exception _ false)))
-
-;------------------------------------------------------------------------------ Layer 1
-
-(defn ^{:stratum 1} parse-pr-diff
-  "Parse a unified diff into a vector of artifact maps.
-
-   Arguments:
-   - diff-content - String containing unified diff output
-
-   Returns:
-   [{:artifact/path string
-     :artifact/content string   ;; the new file content (+ lines)
-     :artifact/diff string}]    ;; the raw diff hunk"
-  [diff-content]
-  (when (and diff-content (not (str/blank? diff-content)))
-    (let [lines (str/split-lines diff-content)
-          ;; Split on diff headers
-          segments (reduce
-                    (fn [acc line]
-                      (if (str/starts-with? line "diff --git")
-                        (conj acc {:header line :lines []})
-                        (if (seq acc)
-                          (update-in acc [(dec (count acc)) :lines] conj line)
-                          acc)))
-                    []
-                    lines)]
-      (vec
-       (keep (fn [{:keys [header lines]}]
-               (when-let [path (parse-diff-header header)]
-                 (let [diff-text (str/join "\n" lines)
-                       ;; Extract added lines (content approximation)
-                       added-lines (->> lines
-                                        (filter #(str/starts-with? % "+"))
-                                        (remove #(str/starts-with? % "+++"))
-                                        (map #(subs % 1)))]
-                   {:artifact/path path
-                    :artifact/content (str/join "\n" added-lines)
-                    :artifact/diff diff-text})))
-             segments)))))
-
-(defn ^{:stratum 1} files-match-globs?
-  "True if any path in `paths` matches any pattern in `globs`."
-  [paths globs]
-  (some (fn [path]
-          (some #(path-matches-glob? registry/glob-matches? % path) globs))
-        paths))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn ^{:stratum 2} pack-applies?
-  "True if a pack applies to the given changed files.
-   Packs with no :file-globs constraint apply to everything."
-  [changed-files pack]
-  (let [file-globs (get-in pack [:pack/applies-to :file-globs])]
-    (or (not (seq file-globs))
-        (files-match-globs? changed-files file-globs))))
-
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} select-applicable-packs
+(defn ^{:stratum 0} select-applicable-packs
   "Select packs applicable to a PR based on metadata.
 
    Arguments:
@@ -118,12 +46,12 @@
    Returns: Vector of applicable packs."
   [packs pr-meta]
   (let [changed-files (get pr-meta :changed-files [])]
-    (filterv (partial pack-applies? changed-files) packs)))
+    (filterv (partial matching/pack-applies? changed-files) packs)))
 
-;------------------------------------------------------------------------------ Layer 4
+;------------------------------------------------------------------------------ Layer 1
 
 ;; Evaluation and reporting
-(defn ^{:stratum 4} evaluate-external-pr
+(defn ^{:stratum 1} evaluate-external-pr
   "Evaluate an external PR against policy packs in read-only mode.
 
    Arguments:
@@ -146,7 +74,7 @@
   (let [packs-vec (if (vector? packs) packs [packs])
         applicable (select-applicable-packs packs-vec pr-data)
         artifacts (or (:artifacts pr-data)
-                      (parse-pr-diff (:diff pr-data))
+                      (diff/parse-pr-diff (:diff pr-data))
                       [])
         context {:read-only? true
                  :phase :review
@@ -170,7 +98,7 @@
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; Parse a diff
-  (parse-pr-diff
+  (diff/parse-pr-diff
    "diff --git a/main.tf b/main.tf
 --- a/main.tf
 +++ b/main.tf

--- a/components/policy-pack/src/ai/miniforge/policy_pack/external/diff.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/external/diff.clj
@@ -1,0 +1,75 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.external.diff
+  "Unified-diff parsing for external PR evaluation. Split out of
+   `ai.miniforge.policy-pack.external` (rule 210: the combined namespace
+   measured 5 real layers, max 3) — pack matching/selection and the
+   top-level evaluation entry point stay in the parent namespace and its
+   `matching` sibling; the diff-to-artifact parsing they run against
+   lives here."
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Diff parsing
+(defn ^{:stratum 0} parse-diff-header
+  "Parse a diff header to extract the file path.
+   Handles 'diff --git a/path b/path' format."
+  [header-line]
+  (when-let [[_ path] (re-find #"^diff --git a/.+ b/(.+)$" header-line)]
+    path))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} parse-pr-diff
+  "Parse a unified diff into a vector of artifact maps.
+
+   Arguments:
+   - diff-content - String containing unified diff output
+
+   Returns:
+   [{:artifact/path string
+     :artifact/content string   ;; the new file content (+ lines)
+     :artifact/diff string}]    ;; the raw diff hunk"
+  [diff-content]
+  (when (and diff-content (not (str/blank? diff-content)))
+    (let [lines (str/split-lines diff-content)
+          ;; Split on diff headers
+          segments (reduce
+                    (fn [acc line]
+                      (if (str/starts-with? line "diff --git")
+                        (conj acc {:header line :lines []})
+                        (if (seq acc)
+                          (update-in acc [(dec (count acc)) :lines] conj line)
+                          acc)))
+                    []
+                    lines)]
+      (vec
+       (keep (fn [{:keys [header lines]}]
+               (when-let [path (parse-diff-header header)]
+                 (let [diff-text (str/join "\n" lines)
+                       ;; Extract added lines (content approximation)
+                       added-lines (->> lines
+                                        (filter #(str/starts-with? % "+"))
+                                        (remove #(str/starts-with? % "+++"))
+                                        (map #(subs % 1)))]
+                   {:artifact/path path
+                    :artifact/content (str/join "\n" added-lines)
+                    :artifact/diff diff-text})))
+             segments)))))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/external/matching.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/external/matching.clj
@@ -1,0 +1,53 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.external.matching
+  "Pack-applicability / glob-matching helpers for external PR evaluation.
+   Split out of `ai.miniforge.policy-pack.external` (rule 210: the
+   combined namespace measured 5 real layers, max 3) — diff parsing
+   lives in the `diff` sibling and pack selection plus the top-level
+   evaluation entry point stay in the parent namespace; the glob
+   matching a pack's :file-globs are tested against lives here."
+  (:require
+   [ai.miniforge.policy-pack.registry :as registry]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Pack selection
+(defn ^{:stratum 0} path-matches-glob?
+  "Test a single path against a single glob pattern."
+  [glob-fn glob path]
+  (try (glob-fn glob path) (catch Exception _ false)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} files-match-globs?
+  "True if any path in `paths` matches any pattern in `globs`."
+  [paths globs]
+  (some (fn [path]
+          (some #(path-matches-glob? registry/glob-matches? % path) globs))
+        paths))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} pack-applies?
+  "True if a pack applies to the given changed files.
+   Packs with no :file-globs constraint apply to everything."
+  [changed-files pack]
+  (let [file-globs (get-in pack [:pack/applies-to :file-globs])]
+    (or (not (seq file-globs))
+        (files-match-globs? changed-files file-globs))))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/builders.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/builders.clj
@@ -19,7 +19,8 @@
   "Policy-pack builders, rule resolution, and external-PR evaluation."
   (:require
    [ai.miniforge.policy-pack.builders :as builders]
-   [ai.miniforge.policy-pack.external :as external]))
+   [ai.miniforge.policy-pack.external :as external]
+   [ai.miniforge.policy-pack.external.diff :as external-diff]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -109,4 +110,4 @@
   "Parse a unified diff string into artifact maps. (parse-pr-diff diff-content)
    returns a vector of {:artifact/path :artifact/content (added lines)
    :artifact/diff (raw hunk)}, or nil for blank input."
-  external/parse-pr-diff)
+  external-diff/parse-pr-diff)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/software_factory.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/software_factory.clj
@@ -18,7 +18,8 @@
 (ns ai.miniforge.policy-pack.software-factory
   "Software-factory specific policy helpers built on the generic policy-pack SDK."
   (:require
-   [ai.miniforge.policy-pack.external :as external]))
+   [ai.miniforge.policy-pack.external :as external]
+   [ai.miniforge.policy-pack.external.diff :as external-diff]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -28,4 +29,4 @@
 
 (def ^{:stratum 0} parse-pr-diff
   "Parse a unified diff into artifact-like inputs for external evaluation."
-  external/parse-pr-diff)
+  external-diff/parse-pr-diff)

--- a/components/policy-pack/test/ai/miniforge/policy_pack/external_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/external_test.clj
@@ -19,6 +19,7 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.policy-pack.external :as external]
+   [ai.miniforge.policy-pack.external.diff :as diff]
    [ai.miniforge.policy-pack.builders :as builders]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -28,24 +29,24 @@
 ;; ============================================================================
 (deftest ^{:stratum 0} parse-pr-diff-test
   (testing "parses single-file diff"
-    (let [diff "diff --git a/main.tf b/main.tf\n--- a/main.tf\n+++ b/main.tf\n@@ -1,3 +1,4 @@\n resource \"aws_vpc\" \"main\" {\n+  enable_dns = true\n   cidr_block = var.vpc_cidr\n }"
-          result (external/parse-pr-diff diff)]
+    (let [diff-content "diff --git a/main.tf b/main.tf\n--- a/main.tf\n+++ b/main.tf\n@@ -1,3 +1,4 @@\n resource \"aws_vpc\" \"main\" {\n+  enable_dns = true\n   cidr_block = var.vpc_cidr\n }"
+          result (diff/parse-pr-diff diff-content)]
       (is (= 1 (count result)))
       (is (= "main.tf" (:artifact/path (first result))))
       (is (string? (:artifact/content (first result))))
       (is (string? (:artifact/diff (first result))))))
 
   (testing "parses multi-file diff"
-    (let [diff (str "diff --git a/a.tf b/a.tf\n--- a/a.tf\n+++ b/a.tf\n@@ -1 +1,2 @@\n+added line\n"
-                    "diff --git a/b.tf b/b.tf\n--- a/b.tf\n+++ b/b.tf\n@@ -1 +1,2 @@\n+another line\n")
-          result (external/parse-pr-diff diff)]
+    (let [diff-content (str "diff --git a/a.tf b/a.tf\n--- a/a.tf\n+++ b/a.tf\n@@ -1 +1,2 @@\n+added line\n"
+                            "diff --git a/b.tf b/b.tf\n--- a/b.tf\n+++ b/b.tf\n@@ -1 +1,2 @@\n+another line\n")
+          result (diff/parse-pr-diff diff-content)]
       (is (= 2 (count result)))
       (is (= "a.tf" (:artifact/path (first result))))
       (is (= "b.tf" (:artifact/path (second result))))))
 
   (testing "returns nil for blank input"
-    (is (nil? (external/parse-pr-diff "")))
-    (is (nil? (external/parse-pr-diff nil)))))
+    (is (nil? (diff/parse-pr-diff "")))
+    (is (nil? (diff/parse-pr-diff nil)))))
 
 ;; ============================================================================
 ;; Read-only mode tests

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-external.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-external.md
@@ -35,10 +35,10 @@ and `software_factory.clj` both re-export its `evaluate-external-pr` and
   calls `diff/parse-pr-diff`) — 2 layers (down from 5).
 - `interface/builders.clj` and `software_factory.clj`: both re-exported
   `parse-pr-diff` from `external`; that def moved to `external.diff`, so
-  both now additionally require `ai.miniforge.policy-pack.external.diff
-  :as external-diff` and point their `parse-pr-diff` re-export there.
-  `evaluate-external-pr` stayed in `external.clj`, so those re-exports
-  are unchanged.
+  both now additionally require
+  `[ai.miniforge.policy-pack.external.diff :as external-diff]` and
+  point their `parse-pr-diff` re-export there. `evaluate-external-pr`
+  stayed in `external.clj`, so those re-exports are unchanged.
 - `external_test.clj`: the diff-parsing tests
   (`parse-pr-diff-test`) called `external/parse-pr-diff` directly
   (white-box); updated to require `external.diff` and call

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-external.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-external.md
@@ -1,0 +1,79 @@
+<!--
+  Title: Split policy-pack/external.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split external.clj (rule 210)
+
+## Overview
+
+Splits `ai.miniforge.policy-pack.external` into three namespaces,
+resolving a stratum-lint SL003 finding (the combined namespace measured
+5 real layers, over the rule 210 budget of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program, policy-pack Wave
+2 batch 2. `external.clj` (189 lines) implements the external PR
+read-only evaluation workflow and has real fan-in — `interface/builders.clj`
+and `software_factory.clj` both re-export its `evaluate-external-pr` and
+`parse-pr-diff`.
+
+## Changes in Detail
+
+- New file `external/diff.clj`
+  (`ai.miniforge.policy-pack.external.diff`): `parse-diff-header` (Layer
+  0), `parse-pr-diff` (Layer 1) — unified-diff-to-artifact parsing, 2
+  layers.
+- New file `external/matching.clj`
+  (`ai.miniforge.policy-pack.external.matching`): `path-matches-glob?`
+  (Layer 0), `files-match-globs?` (Layer 1), `pack-applies?` (Layer 2) —
+  pack-applicability / glob matching, 3 layers.
+- `external.clj`: keeps `select-applicable-packs` (Layer 0, now calls
+  `matching/pack-applies?`) and `evaluate-external-pr` (Layer 1, now
+  calls `diff/parse-pr-diff`) — 2 layers (down from 5).
+- `interface/builders.clj` and `software_factory.clj`: both re-exported
+  `parse-pr-diff` from `external`; that def moved to `external.diff`, so
+  both now additionally require `ai.miniforge.policy-pack.external.diff
+  :as external-diff` and point their `parse-pr-diff` re-export there.
+  `evaluate-external-pr` stayed in `external.clj`, so those re-exports
+  are unchanged.
+- `external_test.clj`: the diff-parsing tests
+  (`parse-pr-diff-test`) called `external/parse-pr-diff` directly
+  (white-box); updated to require `external.diff` and call
+  `diff/parse-pr-diff`. The `evaluate-external-pr` tests are untouched.
+
+This is pure code motion — no detection/evaluation logic changed, no
+`def` added, removed, or renamed (only relocated).
+
+## Testing Plan
+
+- `stratum-lint` clean on all five touched/added source files (exit 0;
+  `external.clj` alone was SL003 exit 1 before this change).
+- Repo-wide grep for the fully-qualified namespace
+  (`ai\.miniforge\.policy-pack\.external\b`) across `components`,
+  `bases`, and `projects` found exactly the three call sites listed
+  above (plus the file itself); no `projects/` integration-test caller
+  exists for this namespace.
+- `bb test` (change-scope) green on the policy-pack component.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 Wave 2 continuation (see
+  `workflow_runner.clj` splits miniforge#1662-#1667 and
+  `knowledge_safety.clj` #1731 for the established convention this
+  follows).
+
+## Checklist
+
+- [x] stratum-lint clean on all resulting files
+- [x] `bb test` green (policy-pack change-scope)
+- [x] Adversarial self-review: def set unchanged, relocated only
+- [x] All three external call sites updated (2 src re-exports + 1 test)
+- [x] Fan-in confirmed repo-wide (components/bases/projects) before
+      starting; zero `projects/` callers found


### PR DESCRIPTION
Reopened as a fresh PR object — the original (#1763) got its check-suite dispatch stuck after a docs-only follow-up push (confirmed via the Actions API: sibling PRs in this batch kept getting fresh CI runs at the same time, this one stopped entirely). Same branch, same commits, no code changes.

## Overview

Splits `ai.miniforge.policy-pack.external` into three namespaces, resolving a stratum-lint SL003 finding (the combined namespace measured 5 real layers, over the rule 210 budget of 3).

## Motivation

Part of the stratum-lint rule-210 remediation program, policy-pack Wave 2 batch 2. `external.clj` (189 lines) implements the external PR read-only evaluation workflow and has real fan-in — `interface/builders.clj` and `software_factory.clj` both re-export its `evaluate-external-pr` and `parse-pr-diff`.

## Changes in Detail

- New file `external/diff.clj` (`ai.miniforge.policy-pack.external.diff`): `parse-diff-header` (Layer 0), `parse-pr-diff` (Layer 1) — unified-diff-to-artifact parsing, 2 layers.
- New file `external/matching.clj` (`ai.miniforge.policy-pack.external.matching`): `path-matches-glob?` (Layer 0), `files-match-globs?` (Layer 1), `pack-applies?` (Layer 2) — pack-applicability / glob matching, 3 layers.
- `external.clj`: keeps `select-applicable-packs` (Layer 0, now calls `matching/pack-applies?`) and `evaluate-external-pr` (Layer 1, now calls `diff/parse-pr-diff`) — 2 layers (down from 5).
- `interface/builders.clj` and `software_factory.clj`: both re-exported `parse-pr-diff` from `external`; that def moved to `external.diff`, so both now additionally require `[ai.miniforge.policy-pack.external.diff :as external-diff]` and point their `parse-pr-diff` re-export there. `evaluate-external-pr` stayed in `external.clj`, so those re-exports are unchanged.
- `external_test.clj`: the diff-parsing tests (`parse-pr-diff-test`) called `external/parse-pr-diff` directly (white-box); updated to require `external.diff` and call `diff/parse-pr-diff`. The `evaluate-external-pr` tests are untouched.

Pure code motion — no `def` added, removed, or renamed (only relocated), no detection/evaluation logic changed.

## Testing Plan

- `stratum-lint` clean on all five touched/added source files (exit 0; `external.clj` alone was SL003 exit 1 before this change).
- Repo-wide grep for the fully-qualified namespace (`ai\.miniforge\.policy-pack\.external\b`) across `components`, `bases`, and `projects` found exactly the three call sites listed above (plus the file itself); no `projects/` integration-test caller exists for this namespace.
- `clj-kondo` clean (0 errors, 0 warnings) on all six touched files.
- `bb test` (since-stable, full run): green except one unrelated, pre-existing failure in `ai.miniforge.workflow.merge-parent-branches-integration-test` (a git-worktree-creation error under heavy concurrent load from sibling rule-210 batch PRs running `bb test` in parallel worktrees at the same time). `components/workflow` has zero dependency on `policy-pack`, and the test passes cleanly (13 tests, 50 assertions, 0 failures) re-run in isolation. `ai.miniforge.policy-pack.external-test` itself passed both times it ran (4 tests, 27 assertions, 0 failures).
- Original PR #1763 got a full green CI run (Lint, Test, Test-Windows, Build, PR Size, Structure, all `pass`) against commit `11e079aa3`, before the docs-only follow-up commit that triggered this PR's webhook stall.

## Deployment Plan

Merges to `main` immediately; no follow-up needed for this file.

## Related Issues/PRs

Part of the stratum-lint rule-210 Wave 2 continuation (see `workflow_runner.clj` splits miniforge#1662-#1667 and `knowledge_safety.clj` #1731 for the established convention this follows). Supersedes #1763 (closed due to the webhook stall described above).

## Checklist

- [x] stratum-lint clean on all resulting files
- [x] `bb test` green (one unrelated pre-existing flaky failure, diagnosed and confirmed unrelated — see Testing Plan)
- [x] Adversarial self-review: def set unchanged, relocated only
- [x] All three external call sites updated (2 src re-exports + 1 test)
- [x] Fan-in confirmed repo-wide (components/bases/projects) before starting; zero `projects/` callers found
- [x] Copilot's one comment on #1763 (a code-span line-wrap in the PR doc) fixed and resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)