### PR TITLE
fix(test): restore OPSV fixture fallback in project integration run

### DIFF
--- a/docs/pull-requests/2026-08-12-claude-miniforge-ci-test-break.md
+++ b/docs/pull-requests/2026-08-12-claude-miniforge-ci-test-break.md
@@ -1,0 +1,119 @@
+<!--
+  Title: Restore the OPSV fixture fallback in the project integration run
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix(test): restore OPSV fixture fallback in project integration run
+
+## Overview
+
+`main` has been red on the `Test` job since #1678. The miniforge
+project integration suite aborts at namespace load with:
+
+```
+Execution error (ExceptionInfo) at
+  ai.miniforge.workflow.opsv-lifecycle-support/fn
+  (opsv_lifecycle_support.clj:65).
+OPSV application fixture not found
+❌ Integration tests failed in project: miniforge
+```
+
+This restores the working-directory-relative fixture lookup that #1678
+dropped, so `ai.miniforge.workflow.opsv-lifecycle-support` loads under
+the project integration runner again.
+
+## Motivation
+
+Two runners load this fixture, and they resolve it differently:
+
+- The workspace `:test` alias lists
+  `components/phase-opsv/test-resources` in `:extra-paths`
+  (`deps.edn`), so `(io/resource "opsv/application-fixture.edn")`
+  resolves there.
+- `tasks/test_runner.clj`'s `run-project-tests!` launches
+  `clojure -Sdeps projects/miniforge/deps.edn -M -e …` with `:dir`
+  set to `projects/miniforge`. That deps.edn's `:paths` are
+  `["test" "integration" "e2e"]` and no component contributes a
+  `test-resources` path, so the classpath lookup returns `nil`.
+
+#1677 registered
+`ai.miniforge.workflow.opsv-lifecycle-integration-test` in the
+integration list and handled the second case with an `or` fallback to
+`../../components/phase-opsv/test-resources`, relative to the runner's
+working directory. #1678 then extracted the fixture out of the test
+namespace into the new `opsv_lifecycle_support.clj` and carried over
+only the `io/resource` branch — which is precisely the branch that
+never resolves under this runner. The `ex-info` guard introduced
+alongside it turned the resulting `nil` into a load-time throw, so the
+whole miniforge integration suite aborts before a single test runs.
+
+`3ba2d9f` (#1678) is the commit named in the body of issue #1679, and
+every red run since has the same signature.
+
+## Changes in Detail
+
+| File/Area | Change |
+|-----------|--------|
+| `projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_support.clj` | Restore the `project-relative` fallback beside the `io/resource` lookup; comment why both branches exist; add the attempted relative path to the `ex-info` data |
+
+The restored resolution is byte-for-byte the logic #1677 shipped green.
+Two things are new on top of it:
+
+- A comment recording that the two branches serve two different
+  runners, so the next extraction of this `def` keeps them together
+  rather than treating the fallback as redundant.
+- `:fixture/project-relative` in the `ex-data`, so a future
+  recurrence names the path it looked for instead of only the
+  classpath-relative resource name.
+
+No test logic changed; the def set of the namespace is unchanged.
+
+## Testing
+
+The full suite could not be run in this environment: `repo.clojars.org`
+is blocked by the sandbox network policy (CONNECT → 403), so the
+project's Clojars-hosted dependencies cannot resolve and neither
+`bb test` nor `bb test:integration` can start. What was verified
+instead, with a Maven-Central-only Clojure:
+
+- [x] Reader/syntax check of the edited namespace — 18 top-level forms
+      read clean.
+- [x] The fixture-resolution logic executed with the working directory
+      set to `projects/miniforge`, exactly as `run-project-tests!`
+      invokes it: `io/resource` returns `nil` (confirming the root
+      cause), the fallback resolves to
+      `../../components/phase-opsv/test-resources/opsv/application-fixture.edn`,
+      and the file parses as EDN.
+- [x] The parsed fixture carries `:experiment-pack`, the only key the
+      support namespace reads out of it (`workflow-input`,
+      `legacy-adapter-context`); the whole map is what
+      `simulated/create-adapter` receives.
+- [x] Regression bounded to this one namespace: it is the only
+      `io/resource` caller under `projects/miniforge`, and
+      `components/phase-opsv/test/…/test_support.clj` — the other
+      reader of this fixture — runs under the workspace `:test` alias,
+      where the classpath branch resolves and is untouched.
+
+CI on this PR is the real check: it runs `bb test:all`, which is the
+job that has been failing.
+
+## Deployment Plan
+
+Merge to `main`. The next fully green `main` push auto-closes #1679.
+
+## Related
+
+- Fixes the break introduced by #1678 (`3ba2d9f`)
+- Restores the fallback added in #1677 (`78bc50b`)
+- Related to #1679 (CI is red on main)
+
+## Checklist
+
+- [x] Root cause identified and attributed to a specific commit
+- [x] Fix restores previously-green behavior rather than masking the
+      symptom
+- [x] Fixture resolution verified under the failing runner's working
+      directory
+- [ ] `bb test` / `bb test:integration` — not runnable here (Clojars
+      blocked by sandbox network policy); delegated to CI on this PR

--- a/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_support.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_support.clj
@@ -58,12 +58,23 @@
 (def ^{:stratum 0} ^:private artifact-id
   #uuid "00000000-0000-0000-0000-000000000799")
 
+;; The fixture ships in components/phase-opsv/test-resources, which the
+;; workspace :test alias puts on the classpath. The project integration
+;; runner (tasks/test_runner.clj) instead launches `clojure -Sdeps
+;; projects/miniforge/deps.edn` from projects/miniforge, and that deps.edn
+;; carries no component test-resources path — so io/resource comes back nil
+;; there. Keep the working-directory-relative fallback alongside it; both
+;; branches are load-bearing, one per runner.
 (def ^{:stratum 0} ^:private fixture
   (let [resource-path "opsv/application-fixture.edn"
-        source (io/resource resource-path)]
+        project-relative (io/file "../../components/phase-opsv/test-resources"
+                                  resource-path)
+        source (or (io/resource resource-path)
+                   (when (.isFile project-relative) project-relative))]
     (when-not source
       (throw (ex-info "OPSV application fixture not found"
-                      {:fixture/path resource-path})))
+                      {:fixture/path resource-path
+                       :fixture/project-relative (.getPath project-relative)})))
     (-> source slurp edn/read-string)))
 
 (defn ^{:stratum 0} event-type-in?


### PR DESCRIPTION
## Summary

- `main` has been red on the `Test` job since #1678 — the miniforge project integration suite aborts at namespace load with `OPSV application fixture not found`, before a single test runs.
- #1678 extracted the OPSV fixture into `opsv_lifecycle_support.clj` and carried over only the `io/resource` branch, dropping the working-directory-relative fallback that #1677 had added — and that fallback is the only branch that resolves under the project integration runner.
- Restores the fallback, comments why both branches exist, and names the attempted path in the `ex-data`.

## Motivation

Two runners load `opsv/application-fixture.edn`, and they resolve it differently:

- The workspace `:test` alias lists `components/phase-opsv/test-resources` in `:extra-paths` (`deps.edn`), so `(io/resource "opsv/application-fixture.edn")` resolves.
- `tasks/test_runner.clj`'s `run-project-tests!` launches `clojure -Sdeps projects/miniforge/deps.edn -M -e …` with `:dir` set to `projects/miniforge`. That deps.edn's `:paths` are `["test" "integration" "e2e"]`, and no component contributes a `test-resources` path — so the classpath lookup returns `nil`.

#1677 (`78bc50b`) registered `ai.miniforge.workflow.opsv-lifecycle-integration-test` in the integration list and handled the second case with an `or` fallback to `../../components/phase-opsv/test-resources`. #1678 (`3ba2d9f`) then extracted the fixture `def` into the new support namespace, keeping only the classpath branch — precisely the branch that never resolves under this runner. The `ex-info` guard introduced alongside it turned the `nil` into a load-time throw.

`3ba2d9f` is the commit named in the body of #1679, and every red run since carries the same signature:

```
Execution error (ExceptionInfo) at ai.miniforge.workflow.opsv-lifecycle-support/fn
  (opsv_lifecycle_support.clj:65).
OPSV application fixture not found
❌ Integration tests failed in project: miniforge
```

## Changes

| File/Area | Change |
|-----------|--------|
| `projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_support.clj` | Restore the `project-relative` fallback beside the `io/resource` lookup; comment that the two branches serve two different runners; add `:fixture/project-relative` to the `ex-info` data |
| `docs/pull-requests/2026-08-12-claude-miniforge-ci-test-break.md` | PR doc |

The restored resolution is the logic #1677 shipped green. No test logic changed; the def set of the namespace is unchanged.

## Testing

The full suite could not be run in this environment: `repo.clojars.org` is blocked by the sandbox network policy (CONNECT → 403), so the project's Clojars-hosted dependencies cannot resolve and neither `bb test` nor `bb test:integration` can start. Verified instead with a Maven-Central-only Clojure:

- [x] Reader/syntax check of the edited namespace — 18 top-level forms read clean
- [x] The fixture-resolution logic executed with the working directory set to `projects/miniforge`, exactly as `run-project-tests!` invokes it: `io/resource` returns `nil` (confirming the root cause), the fallback resolves, and the file parses as EDN
- [x] The parsed fixture carries `:experiment-pack` — the only key the support namespace reads out of it
- [x] Blast radius bounded: this is the only `io/resource` caller under `projects/miniforge`, and `components/phase-opsv/test/…/test_support.clj` (the other reader of this fixture) runs under the workspace `:test` alias, where the classpath branch resolves and is untouched
- [ ] `bb test:all` — delegated to CI on this PR, which runs the job that has been failing

## Checklist

### Required

- [ ] All tests pass (`bb test`) — not runnable here (Clojars blocked by sandbox network policy); delegated to CI
- [x] Pre-commit validation passes (no `--no-verify`)
- [x] No commented-out tests
- [x] No giant functions
- [x] Functions are small and composable
- [x] New behavior has tests — no new behavior; this restores an existing test namespace to a loadable state, and the already-registered `opsv-lifecycle-integration-test` is the coverage

### Best Practices

- [x] Code follows development guidelines
- [ ] Linting passes (`bb lint:clj:all`) — not runnable here (no local toolchain); delegated to CI
- [x] README/docs updated if needed
- [x] PR doc created in `docs/pull-requests/2026-08-12-claude-miniforge-ci-test-break.md`
- [x] Focused PR (single concern)

## Related

- Fixes the break introduced by #1678 (`3ba2d9f`)
- Restores the fallback added in #1677 (`78bc50b`)
- Related to #1679 — the next fully green `main` push auto-closes it

---
_Generated by [Claude Code](https://claude.ai/code/session_018w71kosov9mkbD4K2juvxN)_