### PR TITLE
refactor(policy-pack): split pack_dependency_validation.clj — extract graph, final slice (3/3)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/rules/pack_dependency_validation.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/rules/pack_dependency_validation.clj
@@ -26,134 +26,39 @@
    - Dependency depth limit (default: 5 levels)
    - Complete dependency graph validation before loading
 
-   Slice 2/3 of a rule 210 split train (SL003: this namespace measured
-   6 real layers, max 3 -- same convention as the mdc-compiler split,
-   miniforge#1729-#1743, and the workflow-runner split, miniforge#1662).
-   Slice 1 (#1770) moved version parsing/comparison/constraint-satisfaction
-   to `ai.miniforge.policy-pack.rules.pack-dependency-validation.versions`.
-   This slice moves the trust-check chain to
-   `ai.miniforge.policy-pack.rules.pack-dependency-validation.trust`:
-   tainted-dependency?, untrusted-instruction-escalation?,
-   check-dependency-trust, detect-trust-violations. This file now
-   measures 4 real layers; the graph-construction group moves out in
-   the final slice of this train.
+   Final slice (3/3) of a rule 210 split train (SL003: this namespace
+   originally measured 6 real layers, max 3 -- same convention as the
+   mdc-compiler split, miniforge#1729-#1743, and the workflow-runner
+   split, miniforge#1662). Slice 1 (#1770) moved version
+   parsing/comparison/constraint-satisfaction to
+   `ai.miniforge.policy-pack.rules.pack-dependency-validation.versions`.
+   Slice 2 (#1777) moved the trust-check chain to
+   `ai.miniforge.policy-pack.rules.pack-dependency-validation.trust`.
+   This slice moves dependency-graph construction and
+   circular/missing/depth-limit detection to
+   `ai.miniforge.policy-pack.rules.pack-dependency-validation.graph`:
+   get-pack-dependencies, detect-circular-dependencies,
+   detect-missing-dependencies, calculate-pack-depths,
+   build-dependency-graph, detect-depth-violations. This file now
+   measures 3 real layers -- within the rule 210 budget, closing out
+   the train.
 
-   Layer 0: get-pack-dependencies, detect-circular/missing-dependencies,
-     calculate-pack-depths, detect-version-conflicts
-   Layer 1: build-dependency-graph (over get-pack-dependencies),
-     detect-depth-violations (over calculate-pack-depths)
-   Layer 2: validate-pack-dependencies (orchestrates the Layer 0-1
-     detectors plus trust/detect-trust-violations, an external call)
-   Layer 3: validate-single-pack (public entry point, over
+   Layer 0: detect-version-conflicts (over versions/satisfies-constraint?,
+     an external call)
+   Layer 1: validate-pack-dependencies (orchestrates
+     dep-graph/build-dependency-graph, dep-graph/detect-circular-dependencies,
+     dep-graph/detect-missing-dependencies, dep-graph/detect-depth-violations,
+     trust/detect-trust-violations, and the local detect-version-conflicts
+     -- all but the last are external calls)
+   Layer 2: validate-single-pack (public entry point, over
      validate-pack-dependencies)"
   (:require
-   [ai.miniforge.algorithms.interface :as alg]
+   [ai.miniforge.policy-pack.rules.pack-dependency-validation.graph :as dep-graph]
    [ai.miniforge.policy-pack.rules.pack-dependency-validation.trust :as trust]
    [ai.miniforge.policy-pack.rules.pack-dependency-validation.versions :as versions]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-;; Dependency graph construction
-(defn ^{:stratum 0} get-pack-dependencies
-  "Extract dependencies from a pack manifest.
-   Returns vector of {:pack-id string :version-constraint string}."
-  [pack]
-  (get pack :pack/extends []))
-
-;; Validation rules
-(defn ^{:stratum 0} detect-circular-dependencies
-  "Detect circular dependencies in the graph.
-   Returns vector of violation maps:
-   [{:type :circular-dependency
-     :cycle [pack-id-1 pack-id-2 ... pack-id-1]
-     :message string}]"
-  [graph]
-  (let [pack-ids (keys graph)
-        cycles (alg/dfs-collect
-                graph
-                pack-ids
-                (fn [node] (map :pack-id (:deps node)))
-                ;; Collect cycle when detected
-                (fn [pack-id path _visited _visiting]
-                  (let [cycle-start-idx (.indexOf (vec path) pack-id)
-                        cycle (if (>= cycle-start-idx 0)
-                                (conj (vec (drop cycle-start-idx path)) pack-id)
-                                [pack-id])]
-                    cycle))
-                :cycle)]
-    (->> cycles
-         (distinct)
-         (map (fn [cycle]
-                {:type :circular-dependency
-                 :cycle cycle
-                 :message (str "Circular dependency detected: "
-                              (str/join " → " cycle))}))
-         vec)))
-
-(defn ^{:stratum 0} detect-missing-dependencies
-  "Detect missing dependencies in the graph.
-   Returns vector of violation maps:
-   [{:type :missing-dependency
-     :pack-id string
-     :missing-dep string
-     :message string}]"
-  [graph by-id]
-  (let [available-ids (set (keys by-id))]
-    (->> graph
-         (mapcat (fn [[pack-id node]]
-                   (let [deps (map :pack-id (:deps node))
-                         missing (remove available-ids deps)]
-                     (map (fn [dep-id]
-                            {:type :missing-dependency
-                             :pack-id pack-id
-                             :missing-dep dep-id
-                             :message (str "Pack '" pack-id "' requires missing dependency '" dep-id "'")})
-                          missing))))
-         vec)))
-
-(defn ^{:stratum 0} calculate-pack-depths
-  "Calculate maximum depth for each pack using bottom-up traversal.
-   Returns map of pack-id -> {:depth int :chain [pack-ids]}."
-  [graph]
-  (letfn [(calc-depth [pack-id visited depths]
-            (cond
-              ;; Already calculated
-              (contains? depths pack-id)
-              [depths (get depths pack-id)]
-
-              ;; Cycle detected
-              (contains? visited pack-id)
-              [depths {:depth 0 :chain []}]
-
-              ;; Calculate depth
-              :else
-              (let [node (get graph pack-id)
-                    deps (map :pack-id (:deps node))
-                    new-visited (conj visited pack-id)]
-                (if (empty? deps)
-                  (let [result {:depth 1 :chain [pack-id]}]
-                    [(assoc depths pack-id result) result])
-                  (loop [remaining-deps deps
-                         d depths
-                         child-results []]
-                    (if (empty? remaining-deps)
-                      (let [max-child (apply max-key :depth child-results)
-                            depth (inc (:depth max-child))
-                            chain (cons pack-id (:chain max-child))
-                            result {:depth depth :chain chain}]
-                        [(assoc d pack-id result) result])
-                      (let [[d' child-result] (calc-depth (first remaining-deps) new-visited d)]
-                        (recur (rest remaining-deps)
-                               d'
-                               (conj child-results child-result)))))))))]
-    ;; Calculate depths for all packs
-    (loop [remaining-packs (keys graph)
-           depths {}]
-      (if (empty? remaining-packs)
-        depths
-        (let [[depths' _] (calc-depth (first remaining-packs) #{} depths)]
-          (recur (rest remaining-packs) depths'))))))
 
 (defn ^{:stratum 0} detect-version-conflicts
   "Detect version conflicts in the dependency tree.
@@ -201,56 +106,8 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} build-dependency-graph
-  "Build a dependency graph from a collection of packs.
-
-   Arguments:
-   - packs - Vector of pack manifests
-
-   Returns:
-   - {:graph {pack-id {:pack manifest :deps [dep...]}}
-      :by-id {pack-id pack}
-      :versions {pack-id version-string}}"
-  [packs]
-  (let [by-id (into {} (map (fn [p] [(:pack/id p) p]) packs))
-        versions (into {} (map (fn [p] [(:pack/id p) (:pack/version p)]) packs))]
-    {:graph (reduce (fn [g pack]
-                      (let [pack-id (:pack/id pack)
-                            deps (get-pack-dependencies pack)]
-                        (assoc g pack-id
-                               {:pack pack
-                                :deps deps})))
-                    {}
-                    packs)
-     :by-id by-id
-     :versions versions}))
-
-(defn ^{:stratum 1} detect-depth-violations
-  "Detect dependency chains that exceed the depth limit.
-   Returns vector of violation maps:
-   [{:type :depth-limit
-     :pack-id string
-     :depth int
-     :chain [pack-id...]
-     :message string}]"
-  [graph max-depth]
-  (let [depths (calculate-pack-depths graph)]
-    (->> depths
-         (keep (fn [[pack-id {:keys [depth chain]}]]
-                 (when (> depth max-depth)
-                   {:type :depth-limit
-                    :pack-id pack-id
-                    :depth depth
-                    :chain chain
-                    :message (str "Pack '" pack-id "' has dependency chain of depth "
-                                 depth " (exceeds limit of " max-depth "): "
-                                 (str/join " → " chain))})))
-         vec)))
-
-;------------------------------------------------------------------------------ Layer 2
-
 ;; Public API
-(defn ^{:stratum 2} validate-pack-dependencies
+(defn ^{:stratum 1} validate-pack-dependencies
   "Validate pack dependencies according to N4 §2.4.2.
 
    Checks:
@@ -277,15 +134,15 @@
   [packs & [{:keys [max-depth check-trust?]
              :or {max-depth 5
                   check-trust? false}}]]
-  (let [{:keys [graph by-id versions]} (build-dependency-graph packs)
+  (let [{:keys [graph by-id versions]} (dep-graph/build-dependency-graph packs)
 
         ;; Run all validation checks
-        circular (detect-circular-dependencies graph)
-        missing (detect-missing-dependencies graph by-id)
+        circular (dep-graph/detect-circular-dependencies graph)
+        missing (dep-graph/detect-missing-dependencies graph by-id)
         version-conflicts (detect-version-conflicts graph versions)
         trust-violations (when check-trust?
                           (trust/detect-trust-violations graph by-id))
-        depth-violations (detect-depth-violations graph max-depth)
+        depth-violations (dep-graph/detect-depth-violations graph max-depth)
 
         ;; Separate hard failures from warnings
         failures (concat circular missing version-conflicts trust-violations)
@@ -298,9 +155,9 @@
      :violations failures
      :warnings warnings}))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 3} validate-single-pack
+(defn ^{:stratum 2} validate-single-pack
   "Validate a single pack's dependencies against a registry of available packs.
 
    Arguments:

--- a/components/policy-pack/src/ai/miniforge/policy_pack/rules/pack_dependency_validation/graph.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/rules/pack_dependency_validation/graph.clj
@@ -1,0 +1,183 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.rules.pack-dependency-validation.graph
+  "Dependency-graph construction, circular/missing-dependency
+   detection, and depth-limit checking for pack dependency validation
+   (N4 §2.4.2). Split out of
+   `ai.miniforge.policy-pack.rules.pack-dependency-validation` (rule
+   210, SL003 split train, slice 3/3 — the final slice, bringing the
+   parent to 3 real layers).
+
+   Layer 0: get-pack-dependencies, detect-circular-dependencies,
+     detect-missing-dependencies, calculate-pack-depths
+   Layer 1: build-dependency-graph (over get-pack-dependencies),
+     detect-depth-violations (over calculate-pack-depths)"
+  (:require
+   [ai.miniforge.algorithms.interface :as alg]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Dependency graph construction
+(defn ^{:stratum 0} get-pack-dependencies
+  "Extract dependencies from a pack manifest.
+   Returns vector of {:pack-id string :version-constraint string}."
+  [pack]
+  (get pack :pack/extends []))
+
+;; Validation rules
+(defn ^{:stratum 0} detect-circular-dependencies
+  "Detect circular dependencies in the graph.
+   Returns vector of violation maps:
+   [{:type :circular-dependency
+     :cycle [pack-id-1 pack-id-2 ... pack-id-1]
+     :message string}]"
+  [graph]
+  (let [pack-ids (keys graph)
+        cycles (alg/dfs-collect
+                graph
+                pack-ids
+                (fn [node] (map :pack-id (:deps node)))
+                ;; Collect cycle when detected
+                (fn [pack-id path _visited _visiting]
+                  (let [cycle-start-idx (.indexOf (vec path) pack-id)
+                        cycle (if (>= cycle-start-idx 0)
+                                (conj (vec (drop cycle-start-idx path)) pack-id)
+                                [pack-id])]
+                    cycle))
+                :cycle)]
+    (->> cycles
+         (distinct)
+         (map (fn [cycle]
+                {:type :circular-dependency
+                 :cycle cycle
+                 :message (str "Circular dependency detected: "
+                              (str/join " → " cycle))}))
+         vec)))
+
+(defn ^{:stratum 0} detect-missing-dependencies
+  "Detect missing dependencies in the graph.
+   Returns vector of violation maps:
+   [{:type :missing-dependency
+     :pack-id string
+     :missing-dep string
+     :message string}]"
+  [graph by-id]
+  (let [available-ids (set (keys by-id))]
+    (->> graph
+         (mapcat (fn [[pack-id node]]
+                   (let [deps (map :pack-id (:deps node))
+                         missing (remove available-ids deps)]
+                     (map (fn [dep-id]
+                            {:type :missing-dependency
+                             :pack-id pack-id
+                             :missing-dep dep-id
+                             :message (str "Pack '" pack-id "' requires missing dependency '" dep-id "'")})
+                          missing))))
+         vec)))
+
+(defn ^{:stratum 0} calculate-pack-depths
+  "Calculate maximum depth for each pack using bottom-up traversal.
+   Returns map of pack-id -> {:depth int :chain [pack-ids]}."
+  [graph]
+  (letfn [(calc-depth [pack-id visited depths]
+            (cond
+              ;; Already calculated
+              (contains? depths pack-id)
+              [depths (get depths pack-id)]
+
+              ;; Cycle detected
+              (contains? visited pack-id)
+              [depths {:depth 0 :chain []}]
+
+              ;; Calculate depth
+              :else
+              (let [node (get graph pack-id)
+                    deps (map :pack-id (:deps node))
+                    new-visited (conj visited pack-id)]
+                (if (empty? deps)
+                  (let [result {:depth 1 :chain [pack-id]}]
+                    [(assoc depths pack-id result) result])
+                  (loop [remaining-deps deps
+                         d depths
+                         child-results []]
+                    (if (empty? remaining-deps)
+                      (let [max-child (apply max-key :depth child-results)
+                            depth (inc (:depth max-child))
+                            chain (cons pack-id (:chain max-child))
+                            result {:depth depth :chain chain}]
+                        [(assoc d pack-id result) result])
+                      (let [[d' child-result] (calc-depth (first remaining-deps) new-visited d)]
+                        (recur (rest remaining-deps)
+                               d'
+                               (conj child-results child-result)))))))))]
+    ;; Calculate depths for all packs
+    (loop [remaining-packs (keys graph)
+           depths {}]
+      (if (empty? remaining-packs)
+        depths
+        (let [[depths' _] (calc-depth (first remaining-packs) #{} depths)]
+          (recur (rest remaining-packs) depths'))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} build-dependency-graph
+  "Build a dependency graph from a collection of packs.
+
+   Arguments:
+   - packs - Vector of pack manifests
+
+   Returns:
+   - {:graph {pack-id {:pack manifest :deps [dep...]}}
+      :by-id {pack-id pack}
+      :versions {pack-id version-string}}"
+  [packs]
+  (let [by-id (into {} (map (fn [p] [(:pack/id p) p]) packs))
+        versions (into {} (map (fn [p] [(:pack/id p) (:pack/version p)]) packs))]
+    {:graph (reduce (fn [g pack]
+                      (let [pack-id (:pack/id pack)
+                            deps (get-pack-dependencies pack)]
+                        (assoc g pack-id
+                               {:pack pack
+                                :deps deps})))
+                    {}
+                    packs)
+     :by-id by-id
+     :versions versions}))
+
+(defn ^{:stratum 1} detect-depth-violations
+  "Detect dependency chains that exceed the depth limit.
+   Returns vector of violation maps:
+   [{:type :depth-limit
+     :pack-id string
+     :depth int
+     :chain [pack-id...]
+     :message string}]"
+  [graph max-depth]
+  (let [depths (calculate-pack-depths graph)]
+    (->> depths
+         (keep (fn [[pack-id {:keys [depth chain]}]]
+                 (when (> depth max-depth)
+                   {:type :depth-limit
+                    :pack-id pack-id
+                    :depth depth
+                    :chain chain
+                    :message (str "Pack '" pack-id "' has dependency chain of depth "
+                                 depth " (exceeds limit of " max-depth "): "
+                                 (str/join " → " chain))})))
+         vec)))

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-pack-dependency-validation-3.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-pack-dependency-validation-3.md
@@ -1,0 +1,153 @@
+<!--
+  Title: Split policy-pack pack_dependency_validation.clj — extract graph, final slice (3/3)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split pack_dependency_validation.clj — extract graph, final slice (3/3)
+
+## Overview
+
+Final slice (3/3) of the split train for
+`components/policy-pack/src/ai/miniforge/policy_pack/rules/pack_dependency_validation.clj`
+(rule 210, SL003 — originally 6 real layers, max 3; slices 1-2 were
+[#1770](https://github.com/miniforge-ai/miniforge/pull/1770) and
+[#1777](https://github.com/miniforge-ai/miniforge/pull/1777)). This
+slice extracts
+`ai.miniforge.policy-pack.rules.pack-dependency-validation.graph`:
+dependency-graph construction and circular/missing-dependency/depth-limit
+detection — `get-pack-dependencies`, `detect-circular-dependencies`,
+`detect-missing-dependencies`, `calculate-pack-depths`,
+`build-dependency-graph`, `detect-depth-violations`.
+
+## Motivation
+
+Repo-wide fan-in check for the fully-qualified namespace (not a
+symbol-prefix guess), re-confirmed after rebasing onto the post-#1777
+`main`:
+
+```bash
+grep -rlE "ai\.miniforge\.policy-pack\.rules\.pack-dependency-validation\b" \
+  --include='*.clj' components bases projects
+```
+
+Same 7 external callers as slices 1-2. None of the six functions
+moved in this slice had a direct external caller (confirmed by
+grepping each function name individually across
+`components`/`bases`/`projects`, both fully-qualified and via any
+`:as` alias) — every caller reaches them only indirectly, through
+`validate-pack-dependencies`/`validate-single-pack`, which are
+untouched. **No test file changes needed for this slice.**
+
+- `pack_dependency_graph_test.clj`, `pack_depth_limit_test.clj`,
+  `pack_validation_test.clj`, `pack_version_constraint_test.clj`,
+  `governance_test.clj`, `loader.clj`,
+  `knowledge_safety/detectors.clj` — all call only
+  `validate-pack-dependencies`/`validate-single-pack`/`detect-trust-violations`
+  (the latter already resolved via the `trust` namespace since slice
+  2). Untouched by this slice.
+- `projects/miniforge/test/` re-checked directly — no match.
+
+## Changes in Detail
+
+- New file
+  `rules/pack_dependency_validation/graph.clj`
+  (`ai.miniforge.policy-pack.rules.pack-dependency-validation.graph`):
+  `get-pack-dependencies`, `detect-circular-dependencies`,
+  `detect-missing-dependencies`, `calculate-pack-depths` (Layer 0),
+  `build-dependency-graph` (Layer 1, over `get-pack-dependencies`),
+  `detect-depth-violations` (Layer 1, over `calculate-pack-depths`). 2
+  real layers, stratum-lint clean. Visibility unchanged for every
+  function (all were already public `defn` in the parent).
+- `pack_dependency_validation.clj`: the six functions removed. The
+  `[ai.miniforge.algorithms.interface :as alg]` require also removed
+  — its only user, `detect-circular-dependencies`, moved out.
+  `validate-pack-dependencies` now calls
+  `dep-graph/build-dependency-graph`,
+  `dep-graph/detect-circular-dependencies`,
+  `dep-graph/detect-missing-dependencies`, and
+  `dep-graph/detect-depth-violations`. The new namespace is aliased
+  `dep-graph`, not `graph` — `validate-pack-dependencies` already
+  destructures a local `graph` binding from
+  `build-dependency-graph`'s return value
+  (`{:keys [graph by-id versions]}`), and reusing `graph` as the alias
+  would recreate the exact parameter-shadowing pattern Copilot flagged
+  on slice 1 (PR #1770, `pack-versions` rename). Ran `stratum-lint
+  --fix` — a no-op here since the docstring/heading/`:stratum`
+  updates were made by hand ahead of running it and it found nothing
+  left to fix. The file now measures 3 real layers (0-2) --
+  stratum-lint passes outright, no `MINIFORGE_STRATUM_BUDGET_MODE`
+  override needed for the first time in this train. Namespace
+  docstring rewritten to reflect the completed train (all three
+  slices summarized).
+
+This is pure code motion aside from the `dep-graph` alias-naming
+choice above (a mechanical readability precaution, not a logic
+change) — no detection logic changed, no return shapes changed.
+
+## Testing Plan
+
+1. `clj-kondo` clean on both touched files.
+2. stratum-lint: `graph.clj` passes SL003 outright (2 layers);
+   `pack_dependency_validation.clj` **passes SL003 outright too** — 3
+   real layers, within budget. First clean commit in this train, no
+   `MINIFORGE_STRATUM_BUDGET_MODE` override.
+3. A component-wide sweep confirms all four files this train touched
+   are clean:
+
+   ```text
+   $ stratum-lint pack_dependency_validation.clj \
+                   pack_dependency_validation/versions.clj \
+                   pack_dependency_validation/trust.clj \
+                   pack_dependency_validation/graph.clj
+   (0 findings)
+   ```
+
+4. Directly verified the five affected test namespaces (`bb test`
+   change-scope takes ~30 min in this repo and its truncated log
+   doesn't reliably show policy-pack-specific results, so this was run
+   directly, same as slices 1-2): `clojure -M:dev:test -e
+   "(require 'ai.miniforge.policy-pack.rules.pack-version-constraint-test
+   'ai.miniforge.policy-pack.rules.pack-dependency-graph-test
+   'ai.miniforge.policy-pack.rules.pack-depth-limit-test
+   'ai.miniforge.policy-pack.rules.pack-validation-test
+   'ai.miniforge.policy-pack.governance-test)
+   (clojure.test/run-tests ...)"` — 23 tests, 78 assertions, 0
+   failures, 0 errors (identical to slices 1-2; nothing in this
+   slice's scope touches assertions).
+5. `loader.clj`, `knowledge-safety`, and `knowledge-safety.detectors`
+   confirmed to `require` cleanly.
+6. Adversarial self-review: diffed the full top-level `defn`/`def` set
+   before and after — exactly 6 relocated, 0 added/removed/altered in
+   behavior; `validate-pack-dependencies`'s body is unchanged except
+   the four qualified calls.
+
+## Deployment Plan
+
+Merges to `main`, completing the 3-PR split train.
+`pack_dependency_validation.clj` and every namespace this train
+created (`.versions`, `.trust`, `.graph`) are within the rule 210
+3-layer budget.
+
+## Related Issues/PRs
+
+- Slice 1: [#1770](https://github.com/miniforge-ai/miniforge/pull/1770)
+- Slice 2: [#1777](https://github.com/miniforge-ai/miniforge/pull/1777)
+- Precedent: [mdc-compiler split, #1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1743)
+- Precedent: [workflow-runner split, #1662](https://github.com/miniforge-ai/miniforge/pull/1662)
+- Part of the stratum-lint rule-210 remediation program (Wave 2, policy-pack batch 2)
+
+## Checklist
+
+- [x] Fan-in re-confirmed via fully-qualified-namespace grep before
+      starting (7 external callers total; zero for the six functions
+      moved in this specific slice)
+- [x] Pure code motion — no behavior change, no logic altered
+- [x] `clj-kondo` clean
+- [x] Tests directly verified (23/23, 78 assertions); loader +
+      knowledge-safety callers confirmed loadable
+- [x] Commit-diff budget checked (well under 200)
+- [x] stratum-lint clean on `pack_dependency_validation.clj` with NO
+      budget-mode override — train complete
+- [x] No test file changes needed — verified none of the six moved
+      functions had a direct external caller


### PR DESCRIPTION
<!--
  Title: Split policy-pack pack_dependency_validation.clj — extract graph, final slice (3/3)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split pack_dependency_validation.clj — extract graph, final slice (3/3)

## Overview

Final slice (3/3) of the split train for
`components/policy-pack/src/ai/miniforge/policy_pack/rules/pack_dependency_validation.clj`
(rule 210, SL003 — originally 6 real layers, max 3; slices 1-2 were
[#1770](https://github.com/miniforge-ai/miniforge/pull/1770) and
[#1777](https://github.com/miniforge-ai/miniforge/pull/1777)). This
slice extracts
`ai.miniforge.policy-pack.rules.pack-dependency-validation.graph`:
dependency-graph construction and circular/missing-dependency/depth-limit
detection — `get-pack-dependencies`, `detect-circular-dependencies`,
`detect-missing-dependencies`, `calculate-pack-depths`,
`build-dependency-graph`, `detect-depth-violations`.

## Motivation

Repo-wide fan-in check for the fully-qualified namespace (not a
symbol-prefix guess), re-confirmed after rebasing onto the post-#1777
`main`:

```bash
grep -rlE "ai\.miniforge\.policy-pack\.rules\.pack-dependency-validation\b" \
  --include='*.clj' components bases projects
```

Same 7 external callers as slices 1-2. None of the six functions
moved in this slice had a direct external caller (confirmed by
grepping each function name individually across
`components`/`bases`/`projects`, both fully-qualified and via any
`:as` alias) — every caller reaches them only indirectly, through
`validate-pack-dependencies`/`validate-single-pack`, which are
untouched. **No test file changes needed for this slice.**

- `pack_dependency_graph_test.clj`, `pack_depth_limit_test.clj`,
  `pack_validation_test.clj`, `pack_version_constraint_test.clj`,
  `governance_test.clj`, `loader.clj`,
  `knowledge_safety/detectors.clj` — all call only
  `validate-pack-dependencies`/`validate-single-pack`/`detect-trust-violations`
  (the latter already resolved via the `trust` namespace since slice
  2). Untouched by this slice.
- `projects/miniforge/test/` re-checked directly — no match.

## Changes in Detail

- New file
  `rules/pack_dependency_validation/graph.clj`
  (`ai.miniforge.policy-pack.rules.pack-dependency-validation.graph`):
  `get-pack-dependencies`, `detect-circular-dependencies`,
  `detect-missing-dependencies`, `calculate-pack-depths` (Layer 0),
  `build-dependency-graph` (Layer 1, over `get-pack-dependencies`),
  `detect-depth-violations` (Layer 1, over `calculate-pack-depths`). 2
  real layers, stratum-lint clean. Visibility unchanged for every
  function (all were already public `defn` in the parent).
- `pack_dependency_validation.clj`: the six functions removed. The
  `[ai.miniforge.algorithms.interface :as alg]` require also removed
  — its only user, `detect-circular-dependencies`, moved out.
  `validate-pack-dependencies` now calls
  `dep-graph/build-dependency-graph`,
  `dep-graph/detect-circular-dependencies`,
  `dep-graph/detect-missing-dependencies`, and
  `dep-graph/detect-depth-violations`. The new namespace is aliased
  `dep-graph`, not `graph` — `validate-pack-dependencies` already
  destructures a local `graph` binding from
  `build-dependency-graph`'s return value
  (`{:keys [graph by-id versions]}`), and reusing `graph` as the alias
  would recreate the exact parameter-shadowing pattern Copilot flagged
  on slice 1 (PR #1770, `pack-versions` rename). Ran `stratum-lint
  --fix` — a no-op here since the docstring/heading/`:stratum`
  updates were made by hand ahead of running it and it found nothing
  left to fix. The file now measures 3 real layers (0-2) --
  stratum-lint passes outright, no `MINIFORGE_STRATUM_BUDGET_MODE`
  override needed for the first time in this train. Namespace
  docstring rewritten to reflect the completed train (all three
  slices summarized).

This is pure code motion aside from the `dep-graph` alias-naming
choice above (a mechanical readability precaution, not a logic
change) — no detection logic changed, no return shapes changed.

## Testing Plan

1. `clj-kondo` clean on both touched files.
2. stratum-lint: `graph.clj` passes SL003 outright (2 layers);
   `pack_dependency_validation.clj` **passes SL003 outright too** — 3
   real layers, within budget. First clean commit in this train, no
   `MINIFORGE_STRATUM_BUDGET_MODE` override.
3. A component-wide sweep confirms all four files this train touched
   are clean:

   ```text
   $ stratum-lint pack_dependency_validation.clj \
                   pack_dependency_validation/versions.clj \
                   pack_dependency_validation/trust.clj \
                   pack_dependency_validation/graph.clj
   (0 findings)
   ```

4. Directly verified the five affected test namespaces (`bb test`
   change-scope takes ~30 min in this repo and its truncated log
   doesn't reliably show policy-pack-specific results, so this was run
   directly, same as slices 1-2): `clojure -M:dev:test -e
   "(require 'ai.miniforge.policy-pack.rules.pack-version-constraint-test
   'ai.miniforge.policy-pack.rules.pack-dependency-graph-test
   'ai.miniforge.policy-pack.rules.pack-depth-limit-test
   'ai.miniforge.policy-pack.rules.pack-validation-test
   'ai.miniforge.policy-pack.governance-test)
   (clojure.test/run-tests ...)"` — 23 tests, 78 assertions, 0
   failures, 0 errors (identical to slices 1-2; nothing in this
   slice's scope touches assertions).
5. `loader.clj`, `knowledge-safety`, and `knowledge-safety.detectors`
   confirmed to `require` cleanly.
6. Adversarial self-review: diffed the full top-level `defn`/`def` set
   before and after — exactly 6 relocated, 0 added/removed/altered in
   behavior; `validate-pack-dependencies`'s body is unchanged except
   the four qualified calls.

## Deployment Plan

Merges to `main`, completing the 3-PR split train.
`pack_dependency_validation.clj` and every namespace this train
created (`.versions`, `.trust`, `.graph`) are within the rule 210
3-layer budget.

## Related Issues/PRs

- Slice 1: [#1770](https://github.com/miniforge-ai/miniforge/pull/1770)
- Slice 2: [#1777](https://github.com/miniforge-ai/miniforge/pull/1777)
- Precedent: [mdc-compiler split, #1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1743)
- Precedent: [workflow-runner split, #1662](https://github.com/miniforge-ai/miniforge/pull/1662)
- Part of the stratum-lint rule-210 remediation program (Wave 2, policy-pack batch 2)

## Checklist

- [x] Fan-in re-confirmed via fully-qualified-namespace grep before
      starting (7 external callers total; zero for the six functions
      moved in this specific slice)
- [x] Pure code motion — no behavior change, no logic altered
- [x] `clj-kondo` clean
- [x] Tests directly verified (23/23, 78 assertions); loader +
      knowledge-safety callers confirmed loadable
- [x] Commit-diff budget checked (well under 200)
- [x] stratum-lint clean on `pack_dependency_validation.clj` with NO
      budget-mode override — train complete
- [x] No test file changes needed — verified none of the six moved
      functions had a direct external caller
