### PR TITLE
refactor(cli): split artifact_cmds.clj (rule 210)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/artifact_cmds.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/artifact_cmds.clj
@@ -19,12 +19,17 @@
   "Artifact commands: list, provenance.
 
    Uses ai.miniforge.artifact.interface directly, falling back to filesystem
-   scanning of the configured artifacts directory when the store cannot be queried."
+   scanning of the configured artifacts directory when the store cannot be queried.
+
+   Provenance rendering (the header/fields/sections spec and its renderer)
+   lives in the sibling ai.miniforge.cli.main.commands.artifact-cmds.provenance-view
+   namespace (rule 210: kept here, it pushed this file to 4 real layers, max 3)."
   (:require
    [ai.miniforge.artifact.interface :as artifact]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.main.commands.artifact-cmds.provenance-view :as provenance-view]
    [ai.miniforge.cli.main.commands.shared :as shared]
    [ai.miniforge.cli.main.display :as display]
    [ai.miniforge.cli.messages :as messages]))
@@ -45,12 +50,6 @@
     (< bytes shared/bytes-per-kb) (str bytes "B")
     (< bytes shared/bytes-per-mb) (format "%.1fKB" (/ bytes (double shared/bytes-per-kb)))
     :else                         (format "%.1fMB" (/ bytes (double shared/bytes-per-mb)))))
-
-;; Display helpers
-(defn- ^{:stratum 0} keyword->str
-  "Convert a value to string, rendering keywords as their name."
-  [v]
-  (if (keyword? v) (name v) (str v)))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -74,24 +73,7 @@
     (artifact/get-provenance (create-artifact-store) id)
     (catch Exception _ nil)))
 
-(def ^{:stratum 1} ^:private provenance-spec
-  {:header   :artifact/provenance-header
-   :fields   [[:artifact/workflow-id :artifact/provenance-workflow {:transform keyword->str}]
-              [:artifact/phase       :artifact/provenance-phase    {:transform keyword->str}]
-              [:artifact/agent-id    :artifact/provenance-agent    {:transform keyword->str}]
-              [:artifact/git-commit  :artifact/provenance-commit   {:transform keyword->str}]
-              [:artifact/created-at  :artifact/provenance-created  {:transform keyword->str}]]
-   :sections [{:key :artifact/parent-ids :header :artifact/provenance-parents
-               :entry :artifact/provenance-parent-entry :entry-fn (fn [id] {:id id})}
-              {:key :artifact/files :header :artifact/provenance-files
-               :entry :artifact/provenance-file-entry :entry-fn (fn [p] {:path p})}]})
-
 ;------------------------------------------------------------------------------ Layer 2
-
-(defn- ^{:stratum 2} display-provenance
-  "Render the full provenance block for an artifact."
-  [id provenance]
-  (display/render-detail (assoc provenance-spec :header-params {:id id}) provenance))
 
 ;; Command implementations
 (defn ^{:stratum 2} artifact-list-cmd
@@ -127,9 +109,7 @@
           (println (messages/t :artifact/none))))))
   (println))
 
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} artifact-provenance-cmd
+(defn ^{:stratum 2} artifact-provenance-cmd
   "Show provenance chain for an artifact by ID.
 
    Provenance includes: workflow run, phase that produced it, agent,
@@ -140,7 +120,7 @@
       (shared/usage-error! :artifact/provenance-usage "artifact provenance <id>")
       (let [provenance (get-component-provenance id)]
         (if provenance
-          (display-provenance id provenance)
+          (provenance-view/display-provenance id provenance)
           ;; Fallback: look for artifact file in artifacts dir
           (let [art-file (io/file (str (artifacts-dir) "/" id))]
             (if (.exists art-file)

--- a/bases/cli/src/ai/miniforge/cli/main/commands/artifact_cmds/provenance_view.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/artifact_cmds/provenance_view.clj
@@ -1,0 +1,52 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.main.commands.artifact-cmds.provenance-view
+  "Renders a provenance detail block for the `artifact provenance` command.
+   Split out of `ai.miniforge.cli.main.commands.artifact-cmds` (rule 210: the
+   parent namespace measured 4 real layers, max 3; the header/fields/sections
+   spec for provenance and its renderer are layer-coherent on their own)."
+  (:require
+   [ai.miniforge.cli.main.display :as display]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} keyword->str
+  "Convert a value to string, rendering keywords as their name."
+  [v]
+  (if (keyword? v) (name v) (str v)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private provenance-spec
+  {:header   :artifact/provenance-header
+   :fields   [[:artifact/workflow-id :artifact/provenance-workflow {:transform keyword->str}]
+              [:artifact/phase       :artifact/provenance-phase    {:transform keyword->str}]
+              [:artifact/agent-id    :artifact/provenance-agent    {:transform keyword->str}]
+              [:artifact/git-commit  :artifact/provenance-commit   {:transform keyword->str}]
+              [:artifact/created-at  :artifact/provenance-created  {:transform keyword->str}]]
+   :sections [{:key :artifact/parent-ids :header :artifact/provenance-parents
+               :entry :artifact/provenance-parent-entry :entry-fn (fn [id] {:id id})}
+              {:key :artifact/files :header :artifact/provenance-files
+               :entry :artifact/provenance-file-entry :entry-fn (fn [p] {:path p})}]})
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} display-provenance
+  "Render the full provenance block for an artifact."
+  [id provenance]
+  (display/render-detail (assoc provenance-spec :header-params {:id id}) provenance))

--- a/docs/pull-requests/2026-08-12-refactor-split-cli-cmd-artifact-cmds.md
+++ b/docs/pull-requests/2026-08-12-refactor-split-cli-cmd-artifact-cmds.md
@@ -33,8 +33,16 @@ commands).
 
 - New file `artifact_cmds/provenance_view.clj`
   (`ai.miniforge.cli.main.commands.artifact-cmds.provenance-view`):
-  `keyword->str` (Layer 0), `provenance-spec` (Layer 1),
-  `display-provenance` (Layer 2) — unchanged behavior, 3 layers.
+  `keyword->str` (Layer 0, stays private), `provenance-spec` (Layer 1,
+  stays private), `display-provenance` (Layer 2) — unchanged behavior,
+  3 layers. `display-provenance` is now public (`defn`, not `defn-`)
+  since `artifact_cmds.clj` calls it cross-namespace as
+  `provenance-view/display-provenance`; the other two stay private,
+  used only within this file. Same shape as the reference split
+  (`builtin_detectors.clj` -> `approved_instance_types.clj`,
+  miniforge#1730), which likewise made its extracted entry point
+  public — this codebase has no `:no-doc` convention for
+  internal-but-cross-namespace vars.
 - `artifact_cmds.clj`: requires the new namespace as `provenance-view`
   and calls `provenance-view/display-provenance` in
   `artifact-provenance-cmd` where it previously called the local
@@ -42,11 +50,13 @@ commands).
   helpers; the two command entry points).
 
 This is pure code motion: no logic changed, only relocated and
-re-namespaced. Both moved private functions (`keyword->str`,
-`provenance-spec`, `display-provenance`) had no callers outside this
-file — confirmed via a fully-qualified-namespace grep
+re-namespaced (one function, `display-provenance`, made public to
+serve as the new namespace's entry point). Confirmed via a
+fully-qualified-namespace grep
 (`ai\.miniforge\.cli\.main\.commands\.artifact-cmds\b`) across
-`components/`, `bases/`, and `projects/`; the only real callers are
+`components/`, `bases/`, and `projects/` that none of the three moved
+functions had callers outside the original file; the only real
+callers of the `artifact-cmds` namespace itself are
 `bases/cli/src/ai/miniforge/cli/main.clj` (registers the two unchanged
 public command entry points) and the existing unit test, both of which
 are untouched by this split.

--- a/docs/pull-requests/2026-08-12-refactor-split-cli-cmd-artifact-cmds.md
+++ b/docs/pull-requests/2026-08-12-refactor-split-cli-cmd-artifact-cmds.md
@@ -1,0 +1,84 @@
+<!--
+  Title: Split cli/main/commands/artifact_cmds.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(cli): split artifact_cmds.clj (rule 210)
+
+## Overview
+
+Splits the provenance-rendering spec and its renderer out of
+`ai.miniforge.cli.main.commands.artifact-cmds` into a new sibling
+namespace, `ai.miniforge.cli.main.commands.artifact-cmds.provenance-view`,
+resolving a stratum-lint SL003 finding (the combined namespace measured
+4 real layers, over the rule 210 budget of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program's `bases/cli`
+`main/commands/*.clj` batch (13 command-handler files being split
+concurrently; each is an independent command module, low collision
+risk with siblings).
+
+`artifact_cmds.clj` mixed two concerns at four dependency-deep layers:
+a provenance display spec/renderer chain (`keyword->str` ->
+`provenance-spec` -> `display-provenance`) and the two command entry
+points (`artifact-list-cmd`, `artifact-provenance-cmd`) sitting above
+it. Extracting the display chain leaves the command file's own
+dependency depth at 3 (infra helpers -> store/scan helpers -> the two
+commands).
+
+## Changes in Detail
+
+- New file `artifact_cmds/provenance_view.clj`
+  (`ai.miniforge.cli.main.commands.artifact-cmds.provenance-view`):
+  `keyword->str` (Layer 0), `provenance-spec` (Layer 1),
+  `display-provenance` (Layer 2) — unchanged behavior, 3 layers.
+- `artifact_cmds.clj`: requires the new namespace as `provenance-view`
+  and calls `provenance-view/display-provenance` in
+  `artifact-provenance-cmd` where it previously called the local
+  `display-provenance`. Drops to 3 layers (infra helpers; store/scan
+  helpers; the two command entry points).
+
+This is pure code motion: no logic changed, only relocated and
+re-namespaced. Both moved private functions (`keyword->str`,
+`provenance-spec`, `display-provenance`) had no callers outside this
+file — confirmed via a fully-qualified-namespace grep
+(`ai\.miniforge\.cli\.main\.commands\.artifact-cmds\b`) across
+`components/`, `bases/`, and `projects/`; the only real callers are
+`bases/cli/src/ai/miniforge/cli/main.clj` (registers the two unchanged
+public command entry points) and the existing unit test, both of which
+are untouched by this split.
+
+## Testing Plan
+
+- `stratum-lint` clean on both resulting files (exit 0, was SL003
+  exit 1 on the original).
+- `clojure -M:dev:test` direct run of
+  `ai.miniforge.cli.main.commands.artifact-cmds-test`: 6 tests, 11
+  assertions, 0 failures/errors.
+- `clojure -M:dev:test` load of `ai.miniforge.cli.main` (the base's
+  entry namespace, which requires `artifact-cmds`): loads clean.
+- No `projects/miniforge/test/` references to this namespace (checked
+  directly; bb test's change-scope would have skipped them).
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 program's `bases/cli`
+  `main/commands/*.clj` batch. Reference split for style:
+  `components/policy-pack/src/ai/miniforge/policy_pack/builtin_detectors.clj`
+  (miniforge#1730).
+
+## Checklist
+
+- [x] stratum-lint clean on both resulting files
+- [x] Direct namespace test run green (`artifact-cmds-test`)
+- [x] `ai.miniforge.cli.main` still loads (fan-in caller unaffected)
+- [x] Adversarial self-review: def/defn set unchanged, only relocated
+- [x] Zero fan-in confirmed repo-wide before starting (only `main.clj`
+      + the existing unit test reference this namespace, both untouched)


### PR DESCRIPTION
## Overview

Splits the provenance-rendering spec and its renderer out of `ai.miniforge.cli.main.commands.artifact-cmds` into a new sibling namespace, `ai.miniforge.cli.main.commands.artifact-cmds.provenance-view`, resolving a stratum-lint SL003 finding (the combined namespace measured 4 real layers, over the rule 210 budget of 3).

Part of the stratum-lint rule-210 remediation program's `bases/cli` `main/commands/*.clj` batch (13 command-handler files being split concurrently).

## Changes

- New file `artifact_cmds/provenance_view.clj`: `keyword->str` (Layer 0), `provenance-spec` (Layer 1), `display-provenance` (Layer 2) — unchanged behavior, 3 layers.
- `artifact_cmds.clj`: requires the new namespace and calls `provenance-view/display-provenance` where it previously called the local `display-provenance`. Drops to 3 layers (infra helpers; store/scan helpers; the two command entry points).

Pure code motion — no logic changed. Zero fan-in outside `main.clj` (unchanged public command entry points) and the existing unit test, confirmed via fully-qualified namespace grep across `components/`, `bases/`, `projects/`.

Full details in `docs/pull-requests/2026-08-12-refactor-split-cli-cmd-artifact-cmds.md`.

## Testing

- `stratum-lint` clean on both files.
- `clojure -M:poly check` OK.
- clj-kondo: 0 errors, 0 warnings.
- Direct namespace test run (`ai.miniforge.cli.main.commands.artifact-cmds-test`): 6 tests, 11 assertions, 0 failures.
- `bb pre-commit` full suite green: 345 tests/1301 assertions + GraalVM compat 8 tests/624 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)