### PR TITLE
refactor(cli): split commands/events.clj (rule 210)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/events.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/events.clj
@@ -16,106 +16,27 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.cli.main.commands.events
-  "CLI `events show <workflow-id>` subcommand.
+  "CLI `events show <workflow-id>` subcommand entry point.
 
-   Reads the local file-sink event log for a workflow and renders a
-   human-readable timeline.  Works entirely offline — no network calls.
+   Parses/validates opts, resolves the events directory, and maps the result
+   of `ai.miniforge.cli.main.commands.events.show/events-show` to CLI output
+   and exit codes. See that namespace for the read/render behaviour (event
+   log resolution, --raw, --gap-threshold).
 
-   Key behaviours:
-   - Resolves events directory via app-config/events-dir (same root as main.clj).
-   - Probes archived → live → legacy directory layouts via the event-stream
-     interface (read-workflow-events-by-id).
-   - Renders via event-stream interface (render-timeline).
-   - Optional --raw flag dumps parsed events as EDN (debug aid).
-   - Optional --gap-threshold <seconds> (default 60) tunes gap detection.
-   - Exits 0 on success, 1 when the workflow-id is unknown or the
-     events directory is absent."
+   Exits 0 on success, 1 when the workflow-id is unknown or the events
+   directory is absent."
   (:require
-   [babashka.fs :as fs]
-   [clojure.pprint :as pprint]
    [clojure.string :as str]
    [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.main.commands.events.show :as show]
    [ai.miniforge.cli.main.commands.shared :as shared]
    [ai.miniforge.cli.main.display :as display]
-   [ai.miniforge.cli.messages :as messages]
-   [ai.miniforge.event-stream.interface :as es]))
+   [ai.miniforge.cli.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Constants
-(def ^{:stratum 0} ^:private default-gap-threshold-secs
-  "Gap detection threshold in seconds used when --gap-threshold is absent."
-  60)
-
-;------------------------------------------------------------------------------ Layer 1
-
-;; Pure helpers
-(defn- ^{:stratum 1} gap-threshold-ms
-  "Convert a seconds threshold to milliseconds, falling back to the default."
-  [threshold-secs]
-  (* (or threshold-secs default-gap-threshold-secs) 1000))
-
-;------------------------------------------------------------------------------ Layer 2
-
-;; Core (testable) implementation
-(defn ^{:stratum 2} events-show
-  "Read and render the event log for `workflow-id` under `base-dir`.
-
-   Arguments:
-   - `base-dir`    — base events directory (string or java.io.File);
-                     matches what app-config/events-dir returns.
-   - `workflow-id` — workflow UUID string.
-   - `opts`        — map of {:gap-threshold <secs> :raw <boolean>}.
-
-   Returns one of:
-     {:status :ok    :output <string>}
-     {:status :error :message <string> :exit-code 1}
-
-  Pure in structure — all IO is isolated to es/read-workflow-events-by-id
-   which is easy to stub in tests."
-  [base-dir workflow-id {:keys [gap-threshold raw]}]
-  (try
-    (cond
-      (str/blank? workflow-id)
-      {:status :error
-       :message (messages/t :events/workflow-id-required)
-       :exit-code 1}
-
-      (not (fs/exists? base-dir))
-      {:status    :error
-       :message   (messages/t :events/dir-not-found {:base-dir (str base-dir)})
-       :exit-code 1}
-
-      :else
-      (let [wf-id-str (str workflow-id)
-            events    (es/read-workflow-events-by-id base-dir wf-id-str)]
-        (cond
-          (nil? events)
-          {:status    :error
-           :message   (messages/t :events/no-events
-                                  {:workflow-id wf-id-str
-                                   :base-dir    (str base-dir)})
-           :exit-code 1}
-
-          raw
-          {:status :ok
-           :output (with-out-str (pprint/pprint events))}
-
-          :else
-          (let [rendered (es/render-timeline events {:gap-threshold-ms (gap-threshold-ms gap-threshold)})]
-            {:status :ok
-             :output (if (str/blank? rendered)
-                       (messages/t :events/no-renderable-events {:workflow-id wf-id-str})
-                       rendered)}))))
-    (catch Exception e
-      {:status :error
-       :message (messages/t :events/read-failed {:error (.getMessage e)})
-       :exit-code 1})))
-
-;------------------------------------------------------------------------------ Layer 3
-
 ;; CLI command entry point
-(defn ^{:stratum 3} events-show-cmd
+(defn ^{:stratum 0} events-show-cmd
   "CLI handler for `miniforge events show <workflow-id>`.
 
    Accepted opts (injected by babashka.cli dispatch):
@@ -131,9 +52,9 @@
         (display/print-error (messages/t :events/usage))
         (shared/exit! 1))
       (let [events-dir (app-config/events-dir)
-            result     (events-show events-dir workflow-id
-                                    {:gap-threshold gap-threshold
-                                     :raw           (boolean raw)})]
+            result     (show/events-show events-dir workflow-id
+                                         {:gap-threshold gap-threshold
+                                          :raw           (boolean raw)})]
         (case (:status result)
           :ok
           (println (:output result))

--- a/bases/cli/src/ai/miniforge/cli/main/commands/events/show.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/events/show.clj
@@ -1,0 +1,123 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.main.commands.events.show
+  "Core (testable) implementation for the `events show` CLI subcommand. Split
+   out of `ai.miniforge.cli.main.commands.events` (rule 210: the parent
+   measured 4 layers, max 3) — this namespace holds the IO-isolated read +
+   render logic; CLI opts parsing, error display, and exit codes stay in the
+   parent.
+
+   Key behaviours:
+   - Resolves events directory via app-config/events-dir (same root as main.clj) —
+     the parent passes the resolved `base-dir` in.
+   - Probes archived → live → legacy directory layouts via the event-stream
+     interface (read-workflow-events-by-id).
+   - Renders via event-stream interface (render-timeline).
+   - Optional --raw flag dumps parsed events as EDN (debug aid).
+   - Optional --gap-threshold <seconds> (default 60) tunes gap detection."
+  (:require
+   [babashka.fs :as fs]
+   [clojure.pprint :as pprint]
+   [clojure.string :as str]
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.event-stream.interface :as es]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Constants
+(def ^{:stratum 0} ^:private default-gap-threshold-secs
+  "Gap detection threshold in seconds used when --gap-threshold is absent."
+  60)
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Pure helpers
+(defn- ^{:stratum 1} gap-threshold-ms
+  "Convert a seconds threshold to milliseconds, falling back to the default."
+  [threshold-secs]
+  (* (or threshold-secs default-gap-threshold-secs) 1000))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Core (testable) implementation
+(defn ^{:stratum 2} events-show
+  "Read and render the event log for `workflow-id` under `base-dir`.
+
+   Arguments:
+   - `base-dir`    — base events directory (string or java.io.File);
+                     matches what app-config/events-dir returns.
+   - `workflow-id` — workflow UUID string.
+   - `opts`        — map of {:gap-threshold <secs> :raw <boolean>}.
+
+   Returns one of:
+     {:status :ok    :output <string>}
+     {:status :error :message <string> :exit-code 1}
+
+  Pure in structure — all IO is isolated to es/read-workflow-events-by-id
+   which is easy to stub in tests."
+  [base-dir workflow-id {:keys [gap-threshold raw]}]
+  (try
+    (cond
+      (str/blank? workflow-id)
+      {:status :error
+       :message (messages/t :events/workflow-id-required)
+       :exit-code 1}
+
+      (not (fs/exists? base-dir))
+      {:status    :error
+       :message   (messages/t :events/dir-not-found {:base-dir (str base-dir)})
+       :exit-code 1}
+
+      :else
+      (let [wf-id-str (str workflow-id)
+            events    (es/read-workflow-events-by-id base-dir wf-id-str)]
+        (cond
+          (nil? events)
+          {:status    :error
+           :message   (messages/t :events/no-events
+                                  {:workflow-id wf-id-str
+                                   :base-dir    (str base-dir)})
+           :exit-code 1}
+
+          raw
+          {:status :ok
+           :output (with-out-str (pprint/pprint events))}
+
+          :else
+          (let [rendered (es/render-timeline events {:gap-threshold-ms (gap-threshold-ms gap-threshold)})]
+            {:status :ok
+             :output (if (str/blank? rendered)
+                       (messages/t :events/no-renderable-events {:workflow-id wf-id-str})
+                       rendered)}))))
+    (catch Exception e
+      {:status :error
+       :message (messages/t :events/read-failed {:error (.getMessage e)})
+       :exit-code 1})))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Try against your local event store
+  (events-show "/path/to/events" "paste-your-uuid-here" {})
+
+  ;; Raw EDN dump
+  (events-show "/path/to/events" "paste-your-uuid-here" {:raw true})
+
+  ;; Tight gap threshold (5 s)
+  (events-show "/path/to/events" "paste-your-uuid-here" {:gap-threshold 5})
+
+  :end)

--- a/bases/cli/src/ai/miniforge/cli/main/commands/events/show.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/events/show.clj
@@ -68,8 +68,10 @@
      {:status :ok    :output <string>}
      {:status :error :message <string> :exit-code 1}
 
-  Pure in structure — all IO is isolated to es/read-workflow-events-by-id
-   which is easy to stub in tests."
+  Pure in structure — event-log IO is isolated to
+   es/read-workflow-events-by-id and es/render-timeline, both easy to stub
+   in tests; the only other IO is the fs/exists? existence check on
+   `base-dir`."
   [base-dir workflow-id {:keys [gap-threshold raw]}]
   (try
     (cond

--- a/bases/cli/test/ai/miniforge/cli/main/commands/events_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/events_test.clj
@@ -19,12 +19,12 @@
   "Unit / integration tests for the `events show` CLI command.
 
    Strategy:
-   - events-show (pure core) tested with synthetic event vectors via
-     with-redefs on es/read-workflow-events-by-id.  The base-dir is passed
-     as a real temp directory so the fs/exists? check passes without further
-     stubbing.
-   - events-show-cmd (CLI handler) tested via with-redefs on app-config/events-dir
-     and es/read-workflow-events-by-id.
+   - events-show (pure core, in the sibling `events.show` namespace) tested
+     with synthetic event vectors via with-redefs on
+     es/read-workflow-events-by-id.  The base-dir is passed as a real temp
+     directory so the fs/exists? check passes without further stubbing.
+   - events-show-cmd (CLI handler, in `sut`) tested via with-redefs on
+     app-config/events-dir and es/read-workflow-events-by-id.
    - shared/exit! is always stubbed to prevent JVM termination during tests."
   (:require
    [clojure.test :refer [deftest testing is use-fixtures]]
@@ -32,6 +32,7 @@
    [babashka.fs :as fs]
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.main.commands.events :as sut]
+   [ai.miniforge.cli.main.commands.events.show :as show]
    [ai.miniforge.cli.main.commands.shared :as shared]
    [ai.miniforge.event-stream.interface :as es]))
 
@@ -94,13 +95,13 @@
 
 (deftest ^{:stratum 1} events-show-errors-when-workflow-id-blank
   (testing "pure command returns :error when workflow-id is blank"
-    (let [result (sut/events-show *tmp-dir* " " {})]
+    (let [result (show/events-show *tmp-dir* " " {})]
       (is (= :error (:status result)))
       (is (= 1 (:exit-code result))))))
 
 (deftest ^{:stratum 1} events-show-errors-when-base-dir-missing
   (testing "returns :error when the events base directory does not exist"
-    (let [result (sut/events-show nonexistent-base-dir "any-wf-id" {})]
+    (let [result (show/events-show nonexistent-base-dir "any-wf-id" {})]
       (is (= :error (:status result)))
       (is (pos-int? (:exit-code result)))
       (is (str/includes? (:message result) "not found")))))
@@ -108,7 +109,7 @@
 (deftest ^{:stratum 1} events-show-errors-when-workflow-not-found
   (testing "returns :error when reader returns nil (workflow-id unknown)"
     (let [result (with-redefs [es/read-workflow-events-by-id (fn [_ _] nil)]
-                   (sut/events-show *tmp-dir* "ghost-wf-id" {}))]
+                   (show/events-show *tmp-dir* "ghost-wf-id" {}))]
       (is (= :error (:status result)))
       (is (pos-int? (:exit-code result)))
       (is (str/includes? (:message result) "ghost-wf-id")))))
@@ -116,14 +117,14 @@
 (deftest ^{:stratum 1} events-show-empty-rendered-timeline-has-fallback
   (let [result (with-redefs [es/read-workflow-events-by-id (fn [_ _] [])
                              es/render-timeline (fn [_ _] "")]
-                 (sut/events-show *tmp-dir* "test-wf-abc123" {}))]
+                 (show/events-show *tmp-dir* "test-wf-abc123" {}))]
     (is (= :ok (:status result)))
     (is (str/includes? (:output result) "no renderable events"))))
 
 (deftest ^{:stratum 1} events-show-reader-exception-is-error
   (let [result (with-redefs [es/read-workflow-events-by-id
                              (fn [_ _] (throw (ex-info "broken reader" {})))]
-                 (sut/events-show *tmp-dir* "test-wf-abc123" {}))]
+                 (show/events-show *tmp-dir* "test-wf-abc123" {}))]
     (is (= :error (:status result)))
     (is (= 1 (:exit-code result)))
     (is (str/includes? (:message result) "broken reader"))))
@@ -161,7 +162,7 @@
                                (fn [_ _] synthetic-events)
                                es/render-timeline
                                (fn [_ _] "rendered timeline")]
-                   (sut/events-show *tmp-dir* "test-wf-abc123" {}))]
+                   (show/events-show *tmp-dir* "test-wf-abc123" {}))]
       (is (= :ok (:status result)))
       (is (= "rendered timeline" (:output result))))))
 
@@ -169,7 +170,7 @@
   (testing ":raw true produces EDN output containing the event type keyword"
     (let [result (with-redefs [es/read-workflow-events-by-id
                                (fn [_ _] synthetic-events)]
-                   (sut/events-show *tmp-dir* "test-wf-abc123" {:raw true}))]
+                   (show/events-show *tmp-dir* "test-wf-abc123" {:raw true}))]
       (is (= :ok (:status result)))
       (is (str/includes? (:output result) "workflow/started"))
       (is (str/includes? (:output result) "workflow/completed")))))
@@ -181,7 +182,7 @@
                                es/render-timeline
                                (fn [_ opts]
                                  (str "gap=" (:gap-threshold-ms opts)))]
-                   (sut/events-show *tmp-dir* "test-wf-abc123" {:gap-threshold 5}))]
+                   (show/events-show *tmp-dir* "test-wf-abc123" {:gap-threshold 5}))]
       (is (= :ok (:status result)))
       (is (= "gap=5000" (:output result))))))
 

--- a/docs/pull-requests/2026-08-12-refactor-split-cli-cmd-events.md
+++ b/docs/pull-requests/2026-08-12-refactor-split-cli-cmd-events.md
@@ -1,0 +1,76 @@
+<!--
+  Title: Split cli/main/commands/events.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(cli): split commands/events.clj (rule 210)
+
+## Overview
+
+Splits the `events show` core read/render logic out of
+`ai.miniforge.cli.main.commands.events` into its own sibling namespace,
+`ai.miniforge.cli.main.commands.events.show`, resolving a stratum-lint
+SL003 finding (the combined namespace measured 4 real layers, over the
+rule 210 budget of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program, `bases/cli`
+batch (13 concurrent `main/commands/*.clj` splits). `events.clj` (115
+lines) mixed two concerns at different layers: pure/IO-isolated event
+reading + timeline rendering (3 layers) and CLI opts/exit-code wiring
+(1 layer on top) — together 4 layers, over budget.
+
+## Changes in Detail
+
+- New file `commands/events/show.clj`
+  (`ai.miniforge.cli.main.commands.events.show`): the core logic
+  (`default-gap-threshold-secs`, `gap-threshold-ms`, `events-show`) —
+  3 layers, unchanged behavior.
+- `commands/events.clj`: now only the CLI entry point
+  (`events-show-cmd`, renumbered stratum 3 → stratum 0 since it is the
+  sole layer remaining) — delegates to `show/events-show`.
+- `commands/events_test.clj`: updated requires/call sites so direct
+  `events-show` tests call `show/events-show` (new namespace) while
+  `events-show-cmd` tests keep calling `sut/events-show-cmd` (name
+  unchanged, since `main.clj` still requires
+  `ai.miniforge.cli.main.commands.events` for the command entry
+  point — no caller-facing change there).
+
+This is pure code motion: no logic changed, only relocated and
+re-namespaced.
+
+## Testing Plan
+
+- `stratum-lint` clean on both resulting files (exit 0, was SL003
+  exit 1 on the original).
+- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.main.commands.events-test) (clojure.test/run-tests 'ai.miniforge.cli.main.commands.events-test)"`
+  — 14 tests, 29 assertions, 0 failures, 0 errors.
+- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.main)"` — confirms
+  `main.clj` (the only non-test caller) still resolves the updated
+  dependency chain cleanly.
+- `bb lint:clj` clean on the 3 changed files.
+- Fan-in check: `ai.miniforge.cli.main.commands.events` is referenced
+  only by `main.clj` (`events-show-cmd`, unchanged call site) and
+  `events_test.clj` (updated); no `projects/` references found.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 program, `bases/cli`
+  `main/commands` batch (13 concurrent per-file splits); follows the
+  convention established by
+  `components/policy-pack/builtin_detectors.clj` (#1730).
+
+## Checklist
+
+- [x] stratum-lint clean on both resulting files
+- [x] Direct namespace test run green (14/14, 0 failures/errors)
+- [x] `bb lint:clj` clean
+- [x] Adversarial self-review: def set unchanged, only relocated
+- [x] Fan-in confirmed repo-wide (main.clj + test file only) before starting
+- [x] Commit budget: 193/200 reportable lines


### PR DESCRIPTION
## Overview

Splits the `events show` core read/render logic out of
`ai.miniforge.cli.main.commands.events` into a sibling namespace,
`ai.miniforge.cli.main.commands.events.show`, resolving a stratum-lint
SL003 finding (the combined namespace measured 4 real layers, over the
rule 210 budget of 3).

## Motivation

Part of the stratum-lint rule-210 remediation program, `bases/cli`
batch (13 concurrent `main/commands/*.clj` splits). `events.clj` (115
lines) mixed two concerns at different layers: pure/IO-isolated event
reading + timeline rendering (3 layers) and CLI opts/exit-code wiring
(1 layer on top) — together 4 layers, over budget.

## Changes in Detail

- New file `commands/events/show.clj`
  (`ai.miniforge.cli.main.commands.events.show`): the core logic
  (`default-gap-threshold-secs`, `gap-threshold-ms`, `events-show`) —
  3 layers, unchanged behavior.
- `commands/events.clj`: now only the CLI entry point
  (`events-show-cmd`, renumbered stratum 3 → stratum 0 since it is the
  sole layer remaining) — delegates to `show/events-show`.
- `commands/events_test.clj`: updated requires/call sites so direct
  `events-show` tests call `show/events-show` (new namespace) while
  `events-show-cmd` tests keep calling `sut/events-show-cmd` (name
  unchanged — `main.clj` still requires
  `ai.miniforge.cli.main.commands.events` for the command entry
  point, no caller-facing change there).

Pure code motion: no logic changed, only relocated and re-namespaced.

## Testing Plan

- `stratum-lint` clean on both resulting files (exit 0, was SL003 exit
  1 on the original).
- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.main.commands.events-test) (clojure.test/run-tests 'ai.miniforge.cli.main.commands.events-test)"`
  — 14 tests, 29 assertions, 0 failures, 0 errors.
- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.main)"` — confirms
  `main.clj` (the only non-test caller) still resolves the updated
  dependency chain cleanly.
- `bb lint:clj` clean on the 3 changed files.
- `bb pre-commit` full local gate green (commit budget, `poly check`,
  lint, stratum-lint, fmt:md, 345-test smoke suite, 8-test GraalVM
  compat suite — all 0 failures/errors).
- Fan-in check: `ai.miniforge.cli.main.commands.events` is referenced
  only by `main.clj` (`events-show-cmd`, unchanged call site) and
  `events_test.clj` (updated); no `projects/` references found.

## Deployment Plan

Merges to `main` immediately; no follow-up needed for this file.

## Related Issues/PRs

- Part of the stratum-lint rule-210 program, `bases/cli`
  `main/commands` batch (13 concurrent per-file splits); follows the
  convention established by
  `components/policy-pack/builtin_detectors.clj` (#1730).

## Checklist

- [x] stratum-lint clean on both resulting files
- [x] Direct namespace test run green (14/14, 0 failures/errors)
- [x] `bb lint:clj` clean
- [x] `bb pre-commit` full gate green
- [x] Adversarial self-review: def set unchanged, only relocated
- [x] Fan-in confirmed repo-wide (main.clj + test file only) before starting
- [x] Commit budget: 193/200 reportable lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)