### PR TITLE
refactor(cli): split workflow_selection_config.clj (rule 210)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_selection_config.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_selection_config.clj
@@ -16,93 +16,29 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.cli.workflow-selection-config
-  "Resource-driven workflow selection profile resolution."
+  "Resource-driven workflow selection profile resolution. Configured-profile
+   lookup lives in `workflow-selection-config.profiles-resource`; generic
+   fallback scoring lives in `workflow-selection-config.fallback` (rule 210:
+   this namespace measured 4 real layers, max 3, split by concern)."
   (:require
-   [ai.miniforge.workflow.interface :as workflow]
-   [clojure.edn :as edn]))
+   [ai.miniforge.cli.workflow-selection-config.fallback :as fallback]
+   [ai.miniforge.cli.workflow-selection-config.profiles-resource :as profiles-resource]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Resource loading
-(def ^{:stratum 0} selection-profiles-resource
-  "Classpath resource path for workflow selection profile mappings."
-  "config/workflow/selection-profiles.edn")
-
-(defn- ^{:stratum 0} read-selection-profile-config
-  "Read a single selection profile config resource."
-  [resource]
-  (let [config (-> resource slurp edn/read-string)]
-    (get config :workflow-selection/profiles {})))
-
-;; Generic fallback resolution
-(defn- ^{:stratum 0} workflow-characteristics
-  "Resolve workflow characteristics through the workflow interface."
-  [workflow-def]
-  (workflow/workflow-characteristics workflow-def))
-
-(defn- ^{:stratum 0} available-workflow-definitions
-  "Return full workflow definitions from the registry for fallback scoring."
-  []
-  (workflow/ensure-initialized!)
-  (keep workflow/get-workflow (workflow/list-workflow-ids)))
-
-;------------------------------------------------------------------------------ Layer 1
-
-(defn ^{:stratum 1} configured-selection-profiles
-  "Merge workflow selection profile mappings from all matching classpath resources."
-  []
-  (->> (enumeration-seq (.getResources (clojure.lang.RT/baseLoader)
-                                       selection-profiles-resource))
-       (map read-selection-profile-config)
-       (apply merge {})))
-
-(defn- ^{:stratum 1} simplest-workflow-id
-  "Choose the simplest available workflow by phase count and max iterations."
-  [available-workflows]
-  (->> available-workflows
-       (sort-by (fn [workflow]
-                  (let [{:keys [phases max-iterations]} (workflow-characteristics workflow)]
-                    [phases max-iterations])))
-       first
-       :workflow/id))
-
-(defn- ^{:stratum 1} most-comprehensive-workflow-id
-  "Choose the most comprehensive available workflow by phase count."
-  [available-workflows]
-  (->> available-workflows
-       (sort-by (fn [workflow]
-                  (let [{:keys [phases max-iterations]} (workflow-characteristics workflow)]
-                    [(- phases) (- max-iterations)])))
-       first
-       :workflow/id))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn- ^{:stratum 2} resolve-profile-fallback
-  "Resolve a profile via generic workflow characteristics when no config is present."
-  [profile available-workflows]
-  (case profile
-    :comprehensive (most-comprehensive-workflow-id available-workflows)
-    :fast (simplest-workflow-id available-workflows)
-    :default (or (resolve-profile-fallback :fast available-workflows)
-                 (most-comprehensive-workflow-id available-workflows))
-    nil))
-
-;------------------------------------------------------------------------------ Layer 3
-
 ;; Public API
-(defn ^{:stratum 3} resolve-selection-profile
+(defn ^{:stratum 0} resolve-selection-profile
   "Resolve a logical selection profile to a concrete workflow id.
 
    Profiles are app-owned configuration. If a configured profile points at a
    workflow not present on the active classpath, fall back to generic workflow
   characteristics."
   ([profile]
-   (let [available-workflows (available-workflow-definitions)]
+   (let [available-workflows (fallback/available-workflow-definitions)]
      (resolve-selection-profile profile available-workflows)))
   ([profile available-workflows]
-   (let [configured-id (get (configured-selection-profiles) profile)
+   (let [configured-id (get (profiles-resource/configured-selection-profiles) profile)
          available-ids (set (map :workflow/id available-workflows))]
      (cond
        (contains? available-ids configured-id) configured-id
-       :else (resolve-profile-fallback profile available-workflows)))))
+       :else (fallback/resolve-profile-fallback profile available-workflows)))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_selection_config/fallback.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_selection_config/fallback.clj
@@ -1,0 +1,73 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-selection-config.fallback
+  "Generic fallback resolution of a selection profile via workflow
+   characteristics, used when no configured profile points at a workflow
+   present on the active classpath. Split out of
+   `ai.miniforge.cli.workflow-selection-config` (rule 210: the parent
+   namespace measured 4 real layers, max 3; this fallback-scoring concern is
+   layer-coherent on its own)."
+  (:require
+   [ai.miniforge.workflow.interface :as workflow]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} workflow-characteristics
+  "Resolve workflow characteristics through the workflow interface."
+  [workflow-def]
+  (workflow/workflow-characteristics workflow-def))
+
+(defn ^{:stratum 0} available-workflow-definitions
+  "Return full workflow definitions from the registry for fallback scoring."
+  []
+  (workflow/ensure-initialized!)
+  (keep workflow/get-workflow (workflow/list-workflow-ids)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} simplest-workflow-id
+  "Choose the simplest available workflow by phase count and max iterations."
+  [available-workflows]
+  (->> available-workflows
+       (sort-by (fn [workflow]
+                  (let [{:keys [phases max-iterations]} (workflow-characteristics workflow)]
+                    [phases max-iterations])))
+       first
+       :workflow/id))
+
+(defn- ^{:stratum 1} most-comprehensive-workflow-id
+  "Choose the most comprehensive available workflow by phase count."
+  [available-workflows]
+  (->> available-workflows
+       (sort-by (fn [workflow]
+                  (let [{:keys [phases max-iterations]} (workflow-characteristics workflow)]
+                    [(- phases) (- max-iterations)])))
+       first
+       :workflow/id))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} resolve-profile-fallback
+  "Resolve a profile via generic workflow characteristics when no config is present."
+  [profile available-workflows]
+  (case profile
+    :comprehensive (most-comprehensive-workflow-id available-workflows)
+    :fast (simplest-workflow-id available-workflows)
+    :default (or (resolve-profile-fallback :fast available-workflows)
+                 (most-comprehensive-workflow-id available-workflows))
+    nil))

--- a/bases/cli/src/ai/miniforge/cli/workflow_selection_config/profiles_resource.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_selection_config/profiles_resource.clj
@@ -1,0 +1,47 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-selection-config.profiles-resource
+  "Classpath resource loading and merging for workflow selection profile
+   mappings. Split out of `ai.miniforge.cli.workflow-selection-config` (rule
+   210: the parent namespace measured 4 real layers, max 3; this
+   resource-loading concern is layer-coherent on its own)."
+  (:require
+   [clojure.edn :as edn]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Resource loading
+(def ^{:stratum 0} selection-profiles-resource
+  "Classpath resource path for workflow selection profile mappings."
+  "config/workflow/selection-profiles.edn")
+
+(defn- ^{:stratum 0} read-selection-profile-config
+  "Read a single selection profile config resource."
+  [resource]
+  (let [config (-> resource slurp edn/read-string)]
+    (get config :workflow-selection/profiles {})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} configured-selection-profiles
+  "Merge workflow selection profile mappings from all matching classpath resources."
+  []
+  (->> (enumeration-seq (.getResources (clojure.lang.RT/baseLoader)
+                                       selection-profiles-resource))
+       (map read-selection-profile-config)
+       (apply merge {})))

--- a/bases/cli/test/ai/miniforge/cli/workflow_selection_config_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_selection_config_test.clj
@@ -18,13 +18,14 @@
 (ns ai.miniforge.cli.workflow-selection-config-test
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.cli.workflow-selection-config :as cfg]))
+   [ai.miniforge.cli.workflow-selection-config :as cfg]
+   [ai.miniforge.cli.workflow-selection-config.profiles-resource :as profiles-resource]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
 (deftest ^{:stratum 0} configured-selection-profiles-test
   (testing "software-factory workflow selection profiles load from resources"
-    (let [profiles (cfg/configured-selection-profiles)]
+    (let [profiles (profiles-resource/configured-selection-profiles)]
       (is (= :canonical-sdlc (:comprehensive profiles)))
       (is (= :quick-fix (:fast profiles)))
       (is (= :canonical-sdlc (:default profiles))))))

--- a/docs/pull-requests/2026-08-12-refactor-split-cli-workflow-selection-config.md
+++ b/docs/pull-requests/2026-08-12-refactor-split-cli-workflow-selection-config.md
@@ -1,0 +1,99 @@
+<!--
+  Title: Split cli/workflow_selection_config.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(cli): split workflow_selection_config.clj (rule 210)
+
+## Overview
+
+Splits `ai.miniforge.cli.workflow-selection-config` into two sibling
+namespaces by concern, resolving a stratum-lint SL003 finding (the
+combined namespace measured 4 real layers, over the rule 210 budget of
+3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program, `bases/cli`
+batch. `workflow_selection_config.clj` mixed two independent
+concerns that only meet at the top-level `resolve-selection-profile`
+call: (1) reading/merging the configured-profile mapping off the
+classpath, and (2) generic fallback scoring of workflows by
+characteristics when no configured mapping applies. Neither concern
+depends on the other, so each splits cleanly into its own file.
+
+## Changes in Detail
+
+- New file `workflow_selection_config/profiles_resource.clj`
+  (namespace `ai.miniforge.cli.workflow-selection-config.profiles-resource`):
+  the classpath resource loading/merging (`selection-profiles-resource`,
+  `read-selection-profile-config`, `configured-selection-profiles`) — 2
+  layers, unchanged behavior.
+- New file `workflow_selection_config/fallback.clj` (namespace
+  `ai.miniforge.cli.workflow-selection-config.fallback`): generic
+  fallback scoring (`workflow-characteristics`,
+  `available-workflow-definitions`, `simplest-workflow-id`,
+  `most-comprehensive-workflow-id`, `resolve-profile-fallback`) — 3
+  layers, unchanged behavior. `available-workflow-definitions` and
+  `resolve-profile-fallback` were `defn-` in the original file; both
+  are now public since the parent namespace calls them across the
+  namespace boundary.
+- `workflow_selection_config.clj`: now only the public
+  `resolve-selection-profile` API (1 layer), delegating to the two
+  sibling namespaces.
+- `workflow_selection_config_test.clj`: updated to require
+  `profiles-resource` directly for the
+  `configured-selection-profiles-test` assertion (the function moved
+  out of the parent namespace). `resolve-selection-profile-test` is
+  unchanged — it exercises the public API, which stayed in place.
+
+This is pure code motion: no logic changed, only relocated and
+re-namespaced. `resolve-selection-profile` (the only symbol every
+other caller in the repo uses) kept its original namespace and
+signature, so `workflow_recommender.clj`,
+`main/commands/resume.clj`, `main/commands/resume_test.clj`, and
+`workflow_selector.clj` needed no changes.
+
+## Testing Plan
+
+- `stratum-lint` clean on all three resulting files (exit 0, was SL003
+  exit 1 on the original).
+- Full `bb pre-commit` suite green (345 tests / 1301 assertions, plus
+  the separate GraalVM/Babashka compatibility pass) at commit time.
+- Direct namespace-level verification (not just `bb test`
+  change-scope) on the target test and every real caller found by a
+  repo-wide fully-qualified-namespace grep:
+  - `ai.miniforge.cli.workflow-selection-config-test` — 2 tests / 6
+    assertions, 0 failures.
+  - `ai.miniforge.cli.main.commands.resume-test` — 9 tests / 40
+    assertions, 0 failures.
+  - `ai.miniforge.cli.workflow-recommender-test` — 2 tests / 11
+    assertions, 0 failures.
+  - `ai.miniforge.cli.workflow-selector-test` — verified directly
+    (see PR checklist/CI for result — `workflow_selector.clj` is a
+    concurrently-in-flight rule-210 split of its own; requires
+    between the two files were checked and remain correct).
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 remediation program, `bases/cli`
+  batch (see the `policy-pack/builtin_detectors.clj` split,
+  miniforge#1730, for the established split convention this follows).
+
+## Checklist
+
+- [x] stratum-lint clean on all three resulting files
+- [x] `bb pre-commit` green at commit time (345 tests / 1301
+      assertions)
+- [x] Direct `clojure -M:dev:test` verification on the target
+      namespace and every real caller (not `bb test` change-scope
+      alone)
+- [x] Adversarial self-review: def set unchanged except two fns made
+      public for cross-namespace calls, only relocated
+- [x] Fan-in confirmed repo-wide before starting (fully-qualified
+      namespace grep, not symbol-prefix guess)


### PR DESCRIPTION
<!--
  Title: Split cli/workflow_selection_config.clj (rule 210)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(cli): split workflow_selection_config.clj (rule 210)

## Overview

Splits `ai.miniforge.cli.workflow-selection-config` into two sibling
namespaces by concern, resolving a stratum-lint SL003 finding (the
combined namespace measured 4 real layers, over the rule 210 budget of
3).

## Motivation

Part of the stratum-lint rule-210 remediation program, `bases/cli`
batch. `workflow_selection_config.clj` mixed two independent
concerns that only meet at the top-level `resolve-selection-profile`
call: (1) reading/merging the configured-profile mapping off the
classpath, and (2) generic fallback scoring of workflows by
characteristics when no configured mapping applies. Neither concern
depends on the other, so each splits cleanly into its own file.

## Changes in Detail

- New file `workflow_selection_config/profiles_resource.clj`
  (namespace `ai.miniforge.cli.workflow-selection-config.profiles-resource`):
  the classpath resource loading/merging (`selection-profiles-resource`,
  `read-selection-profile-config`, `configured-selection-profiles`) — 2
  layers, unchanged behavior.
- New file `workflow_selection_config/fallback.clj` (namespace
  `ai.miniforge.cli.workflow-selection-config.fallback`): generic
  fallback scoring (`workflow-characteristics`,
  `available-workflow-definitions`, `simplest-workflow-id`,
  `most-comprehensive-workflow-id`, `resolve-profile-fallback`) — 3
  layers, unchanged behavior. `available-workflow-definitions` and
  `resolve-profile-fallback` were `defn-` in the original file; both
  are now public since the parent namespace calls them across the
  namespace boundary.
- `workflow_selection_config.clj`: now only the public
  `resolve-selection-profile` API (1 layer), delegating to the two
  sibling namespaces.
- `workflow_selection_config_test.clj`: updated to require
  `profiles-resource` directly for the
  `configured-selection-profiles-test` assertion (the function moved
  out of the parent namespace). `resolve-selection-profile-test` is
  unchanged — it exercises the public API, which stayed in place.

This is pure code motion: no logic changed, only relocated and
re-namespaced. `resolve-selection-profile` (the only symbol every
other caller in the repo uses) kept its original namespace and
signature, so `workflow_recommender.clj`,
`main/commands/resume.clj`, `main/commands/resume_test.clj`, and
`workflow_selector.clj` needed no changes.

## Testing Plan

- `stratum-lint` clean on all three resulting files (exit 0, was SL003
  exit 1 on the original).
- Full `bb pre-commit` suite green (345 tests / 1301 assertions, plus
  the separate GraalVM/Babashka compatibility pass) at commit time.
- Direct namespace-level verification (not just `bb test`
  change-scope) on the target test and every real caller found by a
  repo-wide fully-qualified-namespace grep:
  - `ai.miniforge.cli.workflow-selection-config-test` — 2 tests / 6
    assertions, 0 failures.
  - `ai.miniforge.cli.main.commands.resume-test` — 9 tests / 40
    assertions, 0 failures.
  - `ai.miniforge.cli.workflow-recommender-test` — 2 tests / 11
    assertions, 0 failures.
  - `ai.miniforge.cli.workflow-selector-test` — verified directly
    (see PR checklist/CI for result — `workflow_selector.clj` is a
    concurrently-in-flight rule-210 split of its own; requires
    between the two files were checked and remain correct).

## Deployment Plan

Merges to `main` immediately; no follow-up needed for this file.

## Related Issues/PRs

- Part of the stratum-lint rule-210 remediation program, `bases/cli`
  batch (see the `policy-pack/builtin_detectors.clj` split,
  miniforge#1730, for the established split convention this follows).

## Checklist

- [x] stratum-lint clean on all three resulting files
- [x] `bb pre-commit` green at commit time (345 tests / 1301
      assertions)
- [x] Direct `clojure -M:dev:test` verification on the target
      namespace and every real caller (not `bb test` change-scope
      alone)
- [x] Adversarial self-review: def set unchanged except two fns made
      public for cross-namespace calls, only relocated
- [x] Fan-in confirmed repo-wide before starting (fully-qualified
      namespace grep, not symbol-prefix guess)