### PR TITLE
refactor(cli): split workflow_recommender.clj (rule 210)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_recommender.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_recommender.clj
@@ -22,99 +22,24 @@
    the most appropriate workflow, complementing rule-based selection.
 
    Returns follow the anomaly system pattern - successful recommendations
-   are plain maps, failures are anomaly maps with :anomaly/category."
+   are plain maps, failures are anomaly maps with :anomaly/category.
+
+   Prompt construction and LLM invocation/parsing live in sibling
+   `ai.miniforge.cli.workflow-recommender.*` namespaces (rule 210: the
+   combined namespace measured 5 real layers, max 3). Splitting them out
+   also shortened this namespace's own in-file call chain — those hops
+   no longer count toward its local layer depth, so the remaining
+   fallback/orchestration code here now measures 2 real layers on its
+   own, within budget."
   (:require
-   [clojure.string :as str]
-   [cheshire.core :as json]
    [ai.miniforge.cli.messages :as messages]
-   [ai.miniforge.cli.workflow-recommendation-config :as recommendation-config]
+   [ai.miniforge.cli.workflow-recommender.llm :as llm]
+   [ai.miniforge.cli.workflow-recommender.prompt :as prompt]
    [ai.miniforge.cli.workflow-selection-config :as selection-config]
-   [ai.miniforge.llm.interface :as llm]
-   [ai.miniforge.workflow.interface :as workflow]
-   [ai.miniforge.response.interface :as response]))
+   [ai.miniforge.response.interface :as response]
+   [ai.miniforge.workflow.interface :as workflow]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-;; Prompt templates
-(defn ^{:stratum 0} build-workflow-summary
-  "Build a concise summary of a workflow for LLM prompt.
-
-   Arguments:
-     workflow - Workflow definition map
-
-   Returns: String summary"
-  [workflow]
-  (let [chars (workflow/workflow-characteristics workflow)
-        summary-labels (:summary-labels
-                        (recommendation-config/recommendation-prompt-config))]
-    (str "- " (name (:id chars)) " (v" (:version chars) ")"
-         "\n  " (:name chars)
-         "\n  Complexity: " (name (:complexity chars))
-         "\n  Phases: " (:phases chars)
-         "\n  Task types: " (str/join ", " (map name (:task-types chars)))
-         (when (:has-review chars)
-           (str "\n  " (:has-review summary-labels)))
-         (when (:has-testing chars)
-           (str "\n  " (:has-testing summary-labels))))))
-
-(defn ^{:stratum 0} extract-spec-summary
-  "Extract key information from spec for LLM analysis.
-
-   Arguments:
-     spec - Task specification map
-
-   Returns: String summary"
-  [spec]
-  (let [title (:spec/title spec)
-        description (:spec/description spec)
-        intent (:spec/intent spec)
-        constraints (:spec/constraints spec)
-        workflow-type (:spec/workflow-type spec)]
-    (str "Title: " title "\n\n"
-         (when description (str "Description: " description "\n\n"))
-         (when intent (str "Intent: " (pr-str intent) "\n\n"))
-         (when constraints (str "Constraints: " (pr-str constraints) "\n\n"))
-         (when workflow-type (str "Preferred workflow: " workflow-type)))))
-
-;; LLM interaction
-(defn ^{:stratum 0} parse-llm-response
-  "Parse JSON response from LLM.
-
-   Arguments:
-     response-text - String response from LLM
-
-   Returns: Parsed map or nil"
-  [response-text]
-  (try
-    ;; Try to extract JSON from response (may have markdown code blocks)
-    ;; Use (?s) flag so . matches newlines — LLM JSON typically spans multiple lines
-    (let [json-text (if (str/includes? response-text "```")
-                      (second (re-find #"(?s)```(?:json)?\s*(\{.*?\})\s*```" response-text))
-                      response-text)
-          parsed (json/parse-string (or json-text response-text) true)]
-      ;; Convert workflow string to keyword
-      (update parsed :workflow keyword))
-    (catch Exception e
-      (println (messages/t :recommender/parse-warning {:error (ex-message e)}))
-      nil)))
-
-(defn ^{:stratum 0} call-llm-for-recommendation
-  "Call LLM to get workflow recommendation.
-
-   Arguments:
-     llm-client - LLM client (from ai.miniforge.llm.interface)
-     prompt - String prompt
-
-   Returns: LLM response map or nil"
-  [llm-client prompt]
-  (when llm-client
-    (try
-      (let [result (llm/complete llm-client {:prompt prompt :max-tokens 500})]
-        (when (:success result)
-          (:content result)))
-      (catch Exception e
-        (println (messages/t :recommender/llm-failed-warning {:error (ex-message e)}))
-        nil))))
 
 ;; Fallback recommendations
 (defn ^{:stratum 0} recommend-by-task-type
@@ -138,51 +63,8 @@
        :reasoning (messages/t :recommender/fallback-default)
        :source :fallback})))
 
-;------------------------------------------------------------------------------ Layer 1
-
-(defn ^{:stratum 1} build-workflow-summaries
-  "Build summaries for all available workflows.
-
-   Arguments:
-     workflows - Sequence of workflow definition maps
-
-   Returns: String with workflow summaries"
-  [workflows]
-  (str/join "\n\n" (map build-workflow-summary workflows)))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn ^{:stratum 2} build-recommendation-prompt
-  "Build LLM prompt for workflow recommendation.
-
-   Arguments:
-     spec - Task specification map
-     workflows - Sequence of available workflows
-
-   Returns: String prompt"
-  [spec workflows]
-  (let [prompt-config (recommendation-config/recommendation-prompt-config)
-        analysis-dimensions (:analysis-dimensions prompt-config)]
-    (str (:system-intro prompt-config) "\n\n"
-         (:task-instruction prompt-config) "\n\n"
-         (:available-workflows-header prompt-config) "\n\n"
-         (build-workflow-summaries workflows)
-         "\n\n"
-         (:task-spec-header prompt-config) "\n\n"
-         (extract-spec-summary spec)
-         "\n\n"
-         (:analysis-intro prompt-config) "\n"
-         (->> analysis-dimensions
-              (map-indexed (fn [idx dimension]
-                             (str (inc idx) ". " dimension)))
-              (str/join "\n"))
-         "\n\n"
-         (:json-instruction prompt-config))))
-
-;------------------------------------------------------------------------------ Layer 3
-
 ;; Recommendation logic
-(defn ^{:stratum 3} recommend-workflow
+(defn ^{:stratum 0} recommend-workflow
   "Recommend a workflow using LLM semantic analysis.
 
    Arguments:
@@ -200,14 +82,14 @@
                            {:operation :recommend-workflow
                             :spec-title (:spec/title spec)})
     (try
-      (let [prompt (build-recommendation-prompt spec available-workflows)
-            response-text (call-llm-for-recommendation llm-client prompt)]
+      (let [prompt-text (prompt/build-recommendation-prompt spec available-workflows)
+            response-text (llm/call-llm-for-recommendation llm-client prompt-text)]
         (if-not response-text
           (response/make-anomaly :anomalies/unavailable
                                  (messages/t :recommender/no-response)
                                  {:operation :recommend-workflow
                                   :spec-title (:spec/title spec)})
-          (if-let [parsed (parse-llm-response response-text)]
+          (if-let [parsed (llm/parse-llm-response response-text)]
             (let [recommendation (assoc parsed :source :llm)]
               ;; Validate against schema
               (if (workflow/valid-recommendation? recommendation)
@@ -224,9 +106,9 @@
       (catch Exception e
         (response/from-exception e)))))
 
-;------------------------------------------------------------------------------ Layer 4
+;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 4} recommend-workflow-with-fallback
+(defn ^{:stratum 1} recommend-workflow-with-fallback
   "Recommend workflow with LLM, falling back to rule-based if needed.
 
    Arguments:

--- a/bases/cli/src/ai/miniforge/cli/workflow_recommender/llm.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_recommender/llm.clj
@@ -1,0 +1,66 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-recommender.llm
+  "LLM invocation and response parsing for workflow recommendation."
+  (:require
+   [clojure.string :as str]
+   [cheshire.core :as json]
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.llm.interface :as llm]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; LLM interaction
+(defn ^{:stratum 0} parse-llm-response
+  "Parse JSON response from LLM.
+
+   Arguments:
+     response-text - String response from LLM
+
+   Returns: Parsed map or nil"
+  [response-text]
+  (try
+    ;; Try to extract JSON from response (may have markdown code blocks)
+    ;; Use (?s) flag so . matches newlines — LLM JSON typically spans multiple lines
+    (let [json-text (if (str/includes? response-text "```")
+                      (second (re-find #"(?s)```(?:json)?\s*(\{.*?\})\s*```" response-text))
+                      response-text)
+          parsed (json/parse-string (or json-text response-text) true)]
+      ;; Convert workflow string to keyword
+      (update parsed :workflow keyword))
+    (catch Exception e
+      (println (messages/t :recommender/parse-warning {:error (ex-message e)}))
+      nil)))
+
+(defn ^{:stratum 0} call-llm-for-recommendation
+  "Call LLM to get workflow recommendation.
+
+   Arguments:
+     llm-client - LLM client (from ai.miniforge.llm.interface)
+     prompt - String prompt
+
+   Returns: LLM response map or nil"
+  [llm-client prompt]
+  (when llm-client
+    (try
+      (let [result (llm/complete llm-client {:prompt prompt :max-tokens 500})]
+        (when (:success result)
+          (:content result)))
+      (catch Exception e
+        (println (messages/t :recommender/llm-failed-warning {:error (ex-message e)}))
+        nil))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_recommender/prompt.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_recommender/prompt.clj
@@ -1,0 +1,110 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-recommender.prompt
+  "Prompt construction for LLM-based workflow recommendation.
+
+   Builds per-workflow summaries and assembles the full LLM analysis
+   prompt from a task spec and the available workflows."
+  (:require
+   [clojure.string :as str]
+   [ai.miniforge.cli.workflow-recommendation-config :as recommendation-config]
+   [ai.miniforge.workflow.interface :as workflow]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Prompt templates
+(defn ^{:stratum 0} build-workflow-summary
+  "Build a concise summary of a workflow for LLM prompt.
+
+   Arguments:
+     workflow - Workflow definition map
+
+   Returns: String summary"
+  [workflow]
+  (let [chars (workflow/workflow-characteristics workflow)
+        summary-labels (:summary-labels
+                        (recommendation-config/recommendation-prompt-config))]
+    (str "- " (name (:id chars)) " (v" (:version chars) ")"
+         "\n  " (:name chars)
+         "\n  Complexity: " (name (:complexity chars))
+         "\n  Phases: " (:phases chars)
+         "\n  Task types: " (str/join ", " (map name (:task-types chars)))
+         (when (:has-review chars)
+           (str "\n  " (:has-review summary-labels)))
+         (when (:has-testing chars)
+           (str "\n  " (:has-testing summary-labels))))))
+
+(defn ^{:stratum 0} extract-spec-summary
+  "Extract key information from spec for LLM analysis.
+
+   Arguments:
+     spec - Task specification map
+
+   Returns: String summary"
+  [spec]
+  (let [title (:spec/title spec)
+        description (:spec/description spec)
+        intent (:spec/intent spec)
+        constraints (:spec/constraints spec)
+        workflow-type (:spec/workflow-type spec)]
+    (str "Title: " title "\n\n"
+         (when description (str "Description: " description "\n\n"))
+         (when intent (str "Intent: " (pr-str intent) "\n\n"))
+         (when constraints (str "Constraints: " (pr-str constraints) "\n\n"))
+         (when workflow-type (str "Preferred workflow: " workflow-type)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} build-workflow-summaries
+  "Build summaries for all available workflows.
+
+   Arguments:
+     workflows - Sequence of workflow definition maps
+
+   Returns: String with workflow summaries"
+  [workflows]
+  (str/join "\n\n" (map build-workflow-summary workflows)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} build-recommendation-prompt
+  "Build LLM prompt for workflow recommendation.
+
+   Arguments:
+     spec - Task specification map
+     workflows - Sequence of available workflows
+
+   Returns: String prompt"
+  [spec workflows]
+  (let [prompt-config (recommendation-config/recommendation-prompt-config)
+        analysis-dimensions (:analysis-dimensions prompt-config)]
+    (str (:system-intro prompt-config) "\n\n"
+         (:task-instruction prompt-config) "\n\n"
+         (:available-workflows-header prompt-config) "\n\n"
+         (build-workflow-summaries workflows)
+         "\n\n"
+         (:task-spec-header prompt-config) "\n\n"
+         (extract-spec-summary spec)
+         "\n\n"
+         (:analysis-intro prompt-config) "\n"
+         (->> analysis-dimensions
+              (map-indexed (fn [idx dimension]
+                             (str (inc idx) ". " dimension)))
+              (str/join "\n"))
+         "\n\n"
+         (:json-instruction prompt-config))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_recommender_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_recommender_test.clj
@@ -19,7 +19,8 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.workflow-recommendation-config :as cfg]
-   [ai.miniforge.cli.workflow-recommender :as recommender]))
+   [ai.miniforge.cli.workflow-recommender :as recommender]
+   [ai.miniforge.cli.workflow-recommender.prompt :as prompt]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -33,34 +34,34 @@
         (with-redefs [cfg/recommendation-prompt-config
                       (fn []
                         prompt-config)
-                      recommender/build-workflow-summaries
+                      prompt/build-workflow-summaries
                       (fn [_workflows]
                         (str "- workflow\n  "
                              (get-in prompt-config [:summary-labels :has-review]) "\n  "
                              (get-in prompt-config [:summary-labels :has-testing])))]
-          (let [prompt (recommender/build-recommendation-prompt
-                        {:spec/title "Fix flaky test"}
-                        available-workflows)]
-            (is (.contains prompt (last (:analysis-dimensions prompt-config))))
-            (is (.contains prompt (get-in prompt-config [:summary-labels :has-review])))
-            (is (.contains prompt (get-in prompt-config [:summary-labels :has-testing])))))))
+          (let [built-prompt (prompt/build-recommendation-prompt
+                              {:spec/title "Fix flaky test"}
+                              available-workflows)]
+            (is (.contains built-prompt (last (:analysis-dimensions prompt-config))))
+            (is (.contains built-prompt (get-in prompt-config [:summary-labels :has-review])))
+            (is (.contains built-prompt (get-in prompt-config [:summary-labels :has-testing])))))))
 
     (testing "generic fallback vocabulary is available when no app config is present"
       (let [prompt-config (cfg/default-prompt-config)]
         (with-redefs [cfg/recommendation-prompt-config
                       (fn []
                         prompt-config)
-                      recommender/build-workflow-summaries
+                      prompt/build-workflow-summaries
                       (fn [_workflows]
                         (str "- workflow\n  "
                              (get-in prompt-config [:summary-labels :has-review]) "\n  "
                              (get-in prompt-config [:summary-labels :has-testing])))]
-          (let [prompt (recommender/build-recommendation-prompt
-                        {:spec/title "Run analytical workflow"}
-                        available-workflows)]
-            (is (.contains prompt (last (:analysis-dimensions prompt-config))))
-            (is (.contains prompt (get-in prompt-config [:summary-labels :has-review])))
-            (is (.contains prompt (get-in prompt-config [:summary-labels :has-testing])))))))))
+          (let [built-prompt (prompt/build-recommendation-prompt
+                              {:spec/title "Run analytical workflow"}
+                              available-workflows)]
+            (is (.contains built-prompt (last (:analysis-dimensions prompt-config))))
+            (is (.contains built-prompt (get-in prompt-config [:summary-labels :has-review])))
+            (is (.contains built-prompt (get-in prompt-config [:summary-labels :has-testing])))))))))
 
 (deftest ^{:stratum 0} recommend-by-task-type-test
   (let [available-workflows [{:workflow/id :quick-fix

--- a/docs/pull-requests/2026-08-12-refactor-split-cli-workflow-recommender.md
+++ b/docs/pull-requests/2026-08-12-refactor-split-cli-workflow-recommender.md
@@ -1,0 +1,111 @@
+<!--
+  Title: Split cli/workflow_recommender.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(cli): split workflow_recommender.clj (rule 210)
+
+## Overview
+
+Splits `ai.miniforge.cli.workflow-recommender` (227 lines) into three
+files, resolving a stratum-lint SL003 finding (the combined namespace
+measured 5 real layers, over the rule 210 budget of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program's `bases/cli`
+batch (task #31). `workflow_recommender.clj` mixed prompt construction,
+LLM invocation/parsing, and recommendation orchestration in one file,
+producing a 5-deep same-namespace call chain.
+
+## Changes in Detail
+
+- New file `workflow_recommender/prompt.clj`
+  (`ai.miniforge.cli.workflow-recommender.prompt`): `build-workflow-
+  summary`, `extract-spec-summary` (layer 0), `build-workflow-
+  summaries` (layer 1), `build-recommendation-prompt` (layer 2) — 3
+  layers, within budget.
+- New file `workflow_recommender/llm.clj`
+  (`ai.miniforge.cli.workflow-recommender.llm`): `parse-llm-response`,
+  `call-llm-for-recommendation` — 1 layer.
+- `workflow_recommender.clj`: `recommend-by-task-type` and
+  `recommend-workflow` now reference only sibling-namespace functions
+  (`prompt/build-recommendation-prompt`, `llm/call-llm-for-
+  recommendation`, `llm/parse-llm-response`) rather than same-file
+  symbols, so both sit at layer 0; only `recommend-workflow-with-
+  fallback` (depends on both, locally) is layer 1. 2 layers total,
+  down from 5.
+- One cosmetic local-var rename inside `recommend-workflow`: the
+  `prompt` let-binding became `prompt-text`, to avoid shadowing the
+  new `prompt` namespace alias required in the same file. No behavior
+  change — same value, same call sites, new name only.
+- `workflow_recommender_test.clj`: `build-recommendation-prompt-test`
+  used `with-redefs` on `recommender/build-workflow-summaries` to stub
+  the summary step while calling `recommender/build-recommendation-
+  prompt`. Both functions moved to the `prompt` namespace, and
+  `with-redefs` must target the exact var the code under test actually
+  calls internally — updated to `prompt/build-workflow-summaries` and
+  `prompt/build-recommendation-prompt`. `recommend-by-task-type-test`
+  is unchanged; that function stays in the main namespace.
+
+This is pure code motion aside from the one cosmetic rename above — no
+detection, prompt, or recommendation logic changed.
+
+## Fan-in Check
+
+Grepped the fully-qualified namespace
+(`ai\.miniforge\.cli\.workflow-recommender\b`) across `components/`,
+`bases/`, and `projects/`. Two real callers found beyond the file
+itself:
+
+- `bases/cli/test/ai/miniforge/cli/workflow_recommender_test.clj` —
+  updated (see above).
+- `bases/cli/src/ai/miniforge/cli/workflow_runner/setup.clj` — calls
+  only `recommender/recommend-workflow-with-fallback`, which did not
+  move. No update needed; verified it still compiles and resolves
+  against the split namespaces (see Testing Plan).
+
+No project-level callers found under `projects/`.
+
+## Testing Plan
+
+- `stratum-lint` clean on all three resulting files (exit 0, was
+  SL003 exit 1 on the original) and on both callers
+  (`workflow_runner/setup.clj`, `workflow_recommender_test.clj`).
+- `clj-kondo` clean on all five touched/new files.
+- `clojure -M:poly check` — OK.
+- `bb pre-commit` (commit-budget, lint, stratum-lint, 345-test smoke
+  suite, GraalVM/Babashka compatibility suite) — green on both
+  commits.
+- Direct namespace verification (not just `bb test` change-scope,
+  which can miss project-level callers and is unreliable under load
+  per this program's established lessons):
+  `clojure -M:dev:test -e "(require 'ai.miniforge.cli.workflow-
+  recommender-test) (clojure.test/run-tests 'ai.miniforge.cli.
+  workflow-recommender-test)"` — 2 tests, 11 assertions, 0 failures,
+  0 errors.
+  `clojure -M:dev:test -e "(require 'ai.miniforge.cli.workflow-
+  runner.setup)"` — loads cleanly, confirming the one production
+  caller still resolves against the split namespaces.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 program, `bases/cli` batch (task
+  #31). Follows the sibling-namespace-under-a-subdirectory convention
+  established by `loader.clj` (miniforge#1772) and `knowledge_safety.clj`
+  (miniforge#1731).
+
+## Checklist
+
+- [x] stratum-lint clean on all resulting files
+- [x] `bb pre-commit` green (commit-budget, poly check, lint,
+      stratum-lint, smoke tests, GraalVM compat)
+- [x] Adversarial self-review: def set unchanged except one cosmetic
+      local-var rename, documented above
+- [x] Test call sites updated for the `with-redefs`-based prompt test
+- [x] Zero unaccounted-for fan-in confirmed repo-wide before starting


### PR DESCRIPTION
<!--
  Title: Split cli/workflow_recommender.clj (rule 210)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(cli): split workflow_recommender.clj (rule 210)

## Overview

Splits `ai.miniforge.cli.workflow-recommender` (227 lines) into three
files, resolving a stratum-lint SL003 finding (the combined namespace
measured 5 real layers, over the rule 210 budget of 3).

## Motivation

Part of the stratum-lint rule-210 remediation program's `bases/cli`
batch (task #31). `workflow_recommender.clj` mixed prompt construction,
LLM invocation/parsing, and recommendation orchestration in one file,
producing a 5-deep same-namespace call chain.

## Changes in Detail

- New file `workflow_recommender/prompt.clj`
  (`ai.miniforge.cli.workflow-recommender.prompt`): `build-workflow-
  summary`, `extract-spec-summary` (layer 0), `build-workflow-
  summaries` (layer 1), `build-recommendation-prompt` (layer 2) — 3
  layers, within budget.
- New file `workflow_recommender/llm.clj`
  (`ai.miniforge.cli.workflow-recommender.llm`): `parse-llm-response`,
  `call-llm-for-recommendation` — 1 layer.
- `workflow_recommender.clj`: `recommend-by-task-type` and
  `recommend-workflow` now reference only sibling-namespace functions
  (`prompt/build-recommendation-prompt`, `llm/call-llm-for-
  recommendation`, `llm/parse-llm-response`) rather than same-file
  symbols, so both sit at layer 0; only `recommend-workflow-with-
  fallback` (depends on both, locally) is layer 1. 2 layers total,
  down from 5.
- One cosmetic local-var rename inside `recommend-workflow`: the
  `prompt` let-binding became `prompt-text`, to avoid shadowing the
  new `prompt` namespace alias required in the same file. No behavior
  change — same value, same call sites, new name only.
- `workflow_recommender_test.clj`: `build-recommendation-prompt-test`
  used `with-redefs` on `recommender/build-workflow-summaries` to stub
  the summary step while calling `recommender/build-recommendation-
  prompt`. Both functions moved to the `prompt` namespace, and
  `with-redefs` must target the exact var the code under test actually
  calls internally — updated to `prompt/build-workflow-summaries` and
  `prompt/build-recommendation-prompt`. `recommend-by-task-type-test`
  is unchanged; that function stays in the main namespace.

This is pure code motion aside from the one cosmetic rename above — no
detection, prompt, or recommendation logic changed.

## Fan-in Check

Grepped the fully-qualified namespace
(`ai\.miniforge\.cli\.workflow-recommender\b`) across `components/`,
`bases/`, and `projects/`. Two real callers found beyond the file
itself:

- `bases/cli/test/ai/miniforge/cli/workflow_recommender_test.clj` —
  updated (see above).
- `bases/cli/src/ai/miniforge/cli/workflow_runner/setup.clj` — calls
  only `recommender/recommend-workflow-with-fallback`, which did not
  move. No update needed; verified it still compiles and resolves
  against the split namespaces (see Testing Plan).

No project-level callers found under `projects/`.

## Testing Plan

- `stratum-lint` clean on all three resulting files (exit 0, was
  SL003 exit 1 on the original) and on both callers
  (`workflow_runner/setup.clj`, `workflow_recommender_test.clj`).
- `clj-kondo` clean on all five touched/new files.
- `clojure -M:poly check` — OK.
- `bb pre-commit` (commit-budget, lint, stratum-lint, 345-test smoke
  suite, GraalVM/Babashka compatibility suite) — green on both
  commits.
- Direct namespace verification (not just `bb test` change-scope,
  which can miss project-level callers and is unreliable under load
  per this program's established lessons):
  `clojure -M:dev:test -e "(require 'ai.miniforge.cli.workflow-
  recommender-test) (clojure.test/run-tests 'ai.miniforge.cli.
  workflow-recommender-test)"` — 2 tests, 11 assertions, 0 failures,
  0 errors.
  `clojure -M:dev:test -e "(require 'ai.miniforge.cli.workflow-
  runner.setup)"` — loads cleanly, confirming the one production
  caller still resolves against the split namespaces.

## Deployment Plan

Merges to `main` immediately; no follow-up needed for this file.

## Related Issues/PRs

- Part of the stratum-lint rule-210 program, `bases/cli` batch (task
  #31). Follows the sibling-namespace-under-a-subdirectory convention
  established by `loader.clj` (miniforge#1772) and `knowledge_safety.clj`
  (miniforge#1731).

## Checklist

- [x] stratum-lint clean on all resulting files
- [x] `bb pre-commit` green (commit-budget, poly check, lint,
      stratum-lint, smoke tests, GraalVM compat)
- [x] Adversarial self-review: def set unchanged except one cosmetic
      local-var rename, documented above
- [x] Test call sites updated for the `with-redefs`-based prompt test
- [x] Zero unaccounted-for fan-in confirmed repo-wide before starting