### PR TITLE
refactor(cli): split backends.clj (rule 210)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/backends.clj
+++ b/bases/cli/src/ai/miniforge/cli/backends.clj
@@ -18,37 +18,20 @@
 (ns ai.miniforge.cli.backends
   "Backend discovery and management for Miniforge CLI.
 
-   Provides functions to list, check status, and configure LLM backends."
+   Provides functions to list, check status, and configure LLM backends.
+
+   Resource-backed config lives in `ai.miniforge.cli.backends.config`;
+   status checking, info assembly, and validation live in
+   `ai.miniforge.cli.backends.status` (rule 210: the combined namespace
+   measured 7 real layers, max 3) — this namespace keeps display
+   formatting and the top-level listing/printing entry points."
   (:require
    [clojure.string :as str]
-   [ai.miniforge.cli.app-config :as app-config]
-   [ai.miniforge.cli.messages :as messages]
-   [ai.miniforge.cli.resource-config :as resource-config]
-   [babashka.process :as process]))
+   [ai.miniforge.cli.backends.config :as backend-config]
+   [ai.miniforge.cli.backends.status :as backend-status]
+   [ai.miniforge.cli.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-;; Backend specifications
-(def ^{:stratum 0} ^:private backend-config-resource
-  "Classpath resource path for backend metadata and defaults."
-  "config/cli/backends.edn")
-
-(defn- ^{:stratum 0} availability-status
-  "Build a standard backend availability status map."
-  [available status message]
-  {:available available
-   :status status
-   :message message})
-
-;; Status checking
-(defn ^{:stratum 0} check-command-available?
-  "Check if a command is available on PATH."
-  [cmd]
-  (try
-    (let [result (process/sh "which" cmd)]
-      (zero? (:exit result)))
-    (catch Exception _
-      false)))
 
 ;; Display helpers
 (defn ^{:stratum 0} status-icon
@@ -59,14 +42,38 @@
     :not-installed "❌"
     "❓"))
 
-;------------------------------------------------------------------------------ Layer 1
+(defn ^{:stratum 0} list-backends
+  "List all available backends with their status.
 
-(def ^{:stratum 1} ^:private backend-config
-  (resource-config/merged-resource-config
-   backend-config-resource
-   nil
-   {:backend/defaults {:current :codex}
-    :backend/specs {}}))
+   Returns sequence of backend info maps, sorted by availability."
+  []
+  (let [backends (map backend-status/get-backend-info (keys backend-config/backend-specs))]
+    (sort-by (juxt (comp not :available) :provider) backends)))
+
+(defn ^{:stratum 0} print-backend-error
+  "Print helpful error message when backend is not available."
+  [backend-id]
+  (let [info (backend-status/get-backend-info backend-id)
+        {:keys [status installation docs-url]} info
+        backend-name (name backend-id)]
+    (println)
+    (println (messages/t :backends/error-not-available {:backend backend-name}))
+    (println)
+    (case status
+      :not-installed
+      (do
+        (println (messages/t :backends/not-installed-intro {:backend backend-name}))
+        (println)
+        (println (messages/t :backends/not-installed-howto-header))
+        (println (messages/t :backends/not-installed-install-line {:installation installation}))
+        (when docs-url
+          (println (messages/t :backends/not-installed-docs-line {:docs-url docs-url}))))
+
+      ;; Default
+      (println (messages/t :backends/unknown-issue {:backend backend-name})))
+    (println)))
+
+;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} format-backend-status
   "Format backend status for display."
@@ -97,112 +104,11 @@
 
 ;------------------------------------------------------------------------------ Layer 2
 
-(def ^{:stratum 2} backend-specs
-  (:backend/specs backend-config))
-
-(def ^{:stratum 2} ^:private backend-defaults
-  (:backend/defaults backend-config))
-
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} check-backend-status
-  "Check the status of a backend.
-
-   Returns map with:
-   - :available - boolean
-   - :status - :available, :not-installed
-   - :message - human-readable status message"
-  [backend-id]
-  (let [spec (get backend-specs backend-id)
-        {:keys [check-type command]} spec]
-    (case check-type
-      :builtin
-      (availability-status true :available (messages/t :backends/status-builtin))
-
-      :cli
-      (if (check-command-available? command)
-        (availability-status true :available
-                             (messages/t :backends/status-cli-found {:command command}))
-        (availability-status false :not-installed
-                             (messages/t :backends/status-cli-missing {:command command})))
-
-      ;; Unknown check type
-      (availability-status false :unknown (messages/t :backends/status-unknown)))))
-
-(defn ^{:stratum 3} get-current-backend
-  "Get the currently configured backend from config or env var."
-  [config]
-  (or (:backend (:llm config))
-      (when-let [env-backend (System/getenv "MINIFORGE_LLM_BACKEND")]
-        (keyword env-backend))
-      (get backend-defaults :current :codex)))
-
-;------------------------------------------------------------------------------ Layer 4
-
-;; Backend information
-(defn ^{:stratum 4} get-backend-info
-  "Get detailed information about a backend."
-  [backend-id]
-  (let [spec (get backend-specs backend-id)
-        status (check-backend-status backend-id)]
-    (merge spec status {:backend-id backend-id})))
-
-(defn ^{:stratum 4} validate-backend
-  "Validate that a backend can be used.
-   Returns {:valid? true/false :message string}."
-  [backend-id]
-  (if-not (contains? backend-specs backend-id)
-    {:valid? false
-     :message (messages/t :backends/validate-unknown
-                          {:backend (name backend-id)
-                           :command (app-config/command-string "config backends")})}
-    (let [status (check-backend-status backend-id)]
-      (if (:available status)
-        {:valid? true
-         :message (:message status)}
-        {:valid? false
-         :message (:message status)}))))
-
-;------------------------------------------------------------------------------ Layer 5
-
-(defn ^{:stratum 5} list-backends
-  "List all available backends with their status.
-
-   Returns sequence of backend info maps, sorted by availability."
-  []
-  (let [backends (map get-backend-info (keys backend-specs))]
-    (sort-by (juxt (comp not :available) :provider) backends)))
-
-(defn ^{:stratum 5} print-backend-error
-  "Print helpful error message when backend is not available."
-  [backend-id]
-  (let [info (get-backend-info backend-id)
-        {:keys [status installation docs-url]} info
-        backend-name (name backend-id)]
-    (println)
-    (println (messages/t :backends/error-not-available {:backend backend-name}))
-    (println)
-    (case status
-      :not-installed
-      (do
-        (println (messages/t :backends/not-installed-intro {:backend backend-name}))
-        (println)
-        (println (messages/t :backends/not-installed-howto-header))
-        (println (messages/t :backends/not-installed-install-line {:installation installation}))
-        (when docs-url
-          (println (messages/t :backends/not-installed-docs-line {:docs-url docs-url}))))
-
-      ;; Default
-      (println (messages/t :backends/unknown-issue {:backend backend-name})))
-    (println)))
-
-;------------------------------------------------------------------------------ Layer 6
-
-(defn ^{:stratum 6} print-backends
+(defn ^{:stratum 2} print-backends
   "Print all backends with their status."
   [config]
   (let [backends (list-backends)
-        current (get-current-backend config)]
+        current (backend-status/get-current-backend config)]
     (println)
     (println (messages/t :backends/list-header))
     (println)

--- a/bases/cli/src/ai/miniforge/cli/backends/config.clj
+++ b/bases/cli/src/ai/miniforge/cli/backends/config.clj
@@ -1,0 +1,53 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.backends.config
+  "Resource-backed backend config for Miniforge CLI.
+
+   Split out of `ai.miniforge.cli.backends` (rule 210: the combined
+   namespace measured 7 real layers, max 3) — this namespace owns the
+   classpath-loaded config and the derived :backend/specs and
+   :backend/defaults. Status checking, backend-info assembly, and
+   validation live in sibling `ai.miniforge.cli.backends.status`;
+   display formatting and the top-level listing/printing entry points
+   stay in the parent namespace."
+  (:require
+   [ai.miniforge.cli.resource-config :as resource-config]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Backend specifications
+(def ^{:stratum 0} ^:private backend-config-resource
+  "Classpath resource path for backend metadata and defaults."
+  "config/cli/backends.edn")
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private backend-config
+  (resource-config/merged-resource-config
+   backend-config-resource
+   nil
+   {:backend/defaults {:current :codex}
+    :backend/specs {}}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} backend-specs
+  (:backend/specs backend-config))
+
+(def ^{:stratum 2} backend-defaults
+  (:backend/defaults backend-config))

--- a/bases/cli/src/ai/miniforge/cli/backends/status.clj
+++ b/bases/cli/src/ai/miniforge/cli/backends/status.clj
@@ -1,0 +1,109 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.backends.status
+  "Backend status checking, info assembly, and validation for Miniforge CLI.
+
+   Split out of `ai.miniforge.cli.backends` (rule 210: the combined
+   namespace measured 7 real layers, max 3) — resource-backed config
+   lives in sibling `ai.miniforge.cli.backends.config`; display
+   formatting and the top-level listing/printing entry points stay in
+   the parent namespace."
+  (:require
+   [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.backends.config :as backend-config]
+   [ai.miniforge.cli.messages :as messages]
+   [babashka.process :as process]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} availability-status
+  "Build a standard backend availability status map."
+  [available status message]
+  {:available available
+   :status status
+   :message message})
+
+;; Status checking
+(defn ^{:stratum 0} check-command-available?
+  "Check if a command is available on PATH."
+  [cmd]
+  (try
+    (let [result (process/sh "which" cmd)]
+      (zero? (:exit result)))
+    (catch Exception _
+      false)))
+
+(defn ^{:stratum 0} get-current-backend
+  "Get the currently configured backend from config or env var."
+  [config]
+  (or (:backend (:llm config))
+      (when-let [env-backend (System/getenv "MINIFORGE_LLM_BACKEND")]
+        (keyword env-backend))
+      (get backend-config/backend-defaults :current :codex)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} check-backend-status
+  "Check the status of a backend.
+
+   Returns map with:
+   - :available - boolean
+   - :status - :available, :not-installed
+   - :message - human-readable status message"
+  [backend-id]
+  (let [spec (get backend-config/backend-specs backend-id)
+        {:keys [check-type command]} spec]
+    (case check-type
+      :builtin
+      (availability-status true :available (messages/t :backends/status-builtin))
+
+      :cli
+      (if (check-command-available? command)
+        (availability-status true :available
+                             (messages/t :backends/status-cli-found {:command command}))
+        (availability-status false :not-installed
+                             (messages/t :backends/status-cli-missing {:command command})))
+
+      ;; Unknown check type
+      (availability-status false :unknown (messages/t :backends/status-unknown)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Backend information
+(defn ^{:stratum 2} get-backend-info
+  "Get detailed information about a backend."
+  [backend-id]
+  (let [spec (get backend-config/backend-specs backend-id)
+        status (check-backend-status backend-id)]
+    (merge spec status {:backend-id backend-id})))
+
+(defn ^{:stratum 2} validate-backend
+  "Validate that a backend can be used.
+   Returns {:valid? true/false :message string}."
+  [backend-id]
+  (if-not (contains? backend-config/backend-specs backend-id)
+    {:valid? false
+     :message (messages/t :backends/validate-unknown
+                          {:backend (name backend-id)
+                           :command (app-config/command-string "config backends")})}
+    (let [status (check-backend-status backend-id)]
+      (if (:available status)
+        {:valid? true
+         :message (:message status)}
+        {:valid? false
+         :message (:message status)}))))

--- a/bases/cli/src/ai/miniforge/cli/config.clj
+++ b/bases/cli/src/ai/miniforge/cli/config.clj
@@ -26,6 +26,8 @@
    [babashka.process :as process]
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.backends :as backends]
+   [ai.miniforge.cli.backends.config :as backend-config]
+   [ai.miniforge.cli.backends.status :as backend-status]
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.resource-config :as resource-config]))
 
@@ -132,7 +134,7 @@
   (println (messages/t :config/section-llm))
   (println (messages/t :config/llm-backend
                        {:backend (format-config-value (get-in config [:llm :backend]))
-                        :provider (or (get-in backends/backend-specs
+                        :provider (or (get-in backend-config/backend-specs
                                               [(get-in config [:llm :backend]) :provider])
                                       (messages/t :config/llm-backend-provider-unknown))}))
   (println (messages/t :config/llm-model {:model (get-in config [:llm :model])}))
@@ -268,12 +270,12 @@
         (println (messages/t :config/backend-usage {:command (app-config/command-string "config backend <name>")}))
         (println)
         (println (messages/t :config/backend-available-header))
-        (doseq [backend (keys backends/backend-specs)]
+        (doseq [backend (keys backend-config/backend-specs)]
           (println (messages/t :config/backend-item {:name (name backend)})))
         (println)
         (println (messages/t :config/backend-detail-hint {:command (app-config/command-string "config backends")})))
       (let [backend-kw (keyword backend-str)
-            validation (backends/validate-backend backend-kw)]
+            validation (backend-status/validate-backend backend-kw)]
         (if (:valid? validation)
           ;; Backend is available, set it
           (let [user-config (or (read-config-file config-path) default-config)
@@ -282,7 +284,7 @@
             (println)
             (print-success (messages/t :config/backend-set-success {:backend backend-str}))
             (println (messages/t :config/backend-saved {:path config-path}))
-            (let [info (backends/get-backend-info backend-kw)]
+            (let [info (backend-status/get-backend-info backend-kw)]
               (println (messages/t :config/backend-provider {:provider (:provider info)}))
               (when (:default-model info)
                 (println (messages/t :config/backend-model {:model (:default-model info)}))))
@@ -311,7 +313,7 @@
             (println)
             ;; Check backend validity
             (let [backend (get-in config [:llm :backend])
-                  validation (when backend (backends/validate-backend backend))]
+                  validation (when backend (backend-status/validate-backend backend))]
               (when validation
                 (if (:valid? validation)
                   (println (messages/t :config/validate-backend-available

--- a/bases/cli/test/ai/miniforge/cli/backends_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/backends_test.clj
@@ -18,14 +18,15 @@
 (ns ai.miniforge.cli.backends-test
   (:require
    [clojure.test :refer [deftest testing is]]
-   [ai.miniforge.cli.backends :as backends]))
+   [ai.miniforge.cli.backends.config :as backend-config]
+   [ai.miniforge.cli.backends.status :as backend-status]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
 ;; Resource-backed backend config
 (deftest ^{:stratum 0} backend-specs-loaded-from-resource-test
   (testing "backend specs include opencode from resource config"
-    (is (= "OpenCode" (get-in backends/backend-specs [:opencode :provider]))))
+    (is (= "OpenCode" (get-in backend-config/backend-specs [:opencode :provider]))))
 
   (testing "current backend fallback comes from resource defaults"
-    (is (= :opencode (backends/get-current-backend {})))))
+    (is (= :opencode (backend-status/get-current-backend {})))))

--- a/docs/pull-requests/2026-08-12-refactor-split-cli-backends.md
+++ b/docs/pull-requests/2026-08-12-refactor-split-cli-backends.md
@@ -1,0 +1,99 @@
+<!--
+  Title: Split bases/cli/backends.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(cli): split backends.clj (rule 210)
+
+## Overview
+
+Splits the CLI backend module's resource-backed config and status/
+validation logic out of `ai.miniforge.cli.backends` into two new
+sibling namespaces, `ai.miniforge.cli.backends.config` and
+`ai.miniforge.cli.backends.status`, resolving a stratum-lint SL003
+finding (the combined namespace measured 7 real layers, over the rule
+210 budget of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program, `bases/cli`
+batch. `backends.clj` (199 lines, dense layering for its size) was
+next up.
+
+## Changes in Detail
+
+- New file `backends/config.clj`: `backend-config-resource`,
+  `backend-config`, `backend-specs`, `backend-defaults` — the
+  classpath-loaded config and its two derived maps. 3 layers.
+  `backend-defaults` changed from `^:private` to public — it is now
+  read cross-namespace by `backends.status/get-current-backend`,
+  which is the only visibility change in this split.
+- New file `backends/status.clj`: `availability-status`,
+  `check-command-available?`, `get-current-backend`,
+  `check-backend-status`, `get-backend-info`, `validate-backend` —
+  status checks, backend-info assembly, and validation. 3 layers.
+- `backends.clj`: kept `status-icon`, `format-backend-status`,
+  `list-backends`, `print-backend-error`, `print-backends` — display
+  formatting and the top-level listing/printing entry points. Now 3
+  layers (down from 7), since the remaining functions only reference
+  `backend-config/*` and `backend-status/*` (qualified, cross-namespace)
+  rather than same-file symbols for the config/status pieces.
+- `ai.miniforge.cli.config` (the CLI's `config` command, the one real
+  external caller): `backends/backend-specs` → `backend-config/backend-specs`;
+  `backends/validate-backend` and `backends/get-backend-info` →
+  `backend-status/validate-backend` / `backend-status/get-backend-info`.
+  `backends/print-backend-error` and `backends/print-backends` are
+  unchanged — both stayed in the parent namespace, so the existing
+  `backends` alias/require is still live and unchanged.
+- `backends_test.clj`: the one test (`backend-specs-loaded-from-resource-test`)
+  called `backends/backend-specs` and `backends/get-current-backend`
+  directly — updated to `backend-config/backend-specs` and
+  `backend-status/get-current-backend`, and the now-unused
+  `ai.miniforge.cli.backends` require dropped.
+
+This is pure code motion aside from the one required visibility change
+(`backend-defaults`) and the call-site updates above — no behavior
+changed.
+
+## Testing Plan
+
+- `stratum-lint` clean on all three touched/new source files (exit 0,
+  was SL003 exit 1 on the original `backends.clj`).
+- `clj-kondo` clean on all five touched files (0 errors, 0 warnings).
+- Repo-wide grep for the fully-qualified namespace
+  (`ai\.miniforge\.cli\.backends\b`, not a symbol-prefix guess) across
+  `components/`, `bases/`, and `projects/` found exactly two real
+  callers — `bases/cli/src/ai/miniforge/cli/config.clj` and
+  `bases/cli/test/ai/miniforge/cli/backends_test.clj` — both updated
+  above. No project-level caller.
+- `clojure -M:poly check` — OK.
+- Direct namespace test runs (not relying on `bb test` change-scope
+  alone): `cd .worktrees/split-cli-backends && clojure -M:dev:test -e
+  "(require 'ai.miniforge.cli.backends-test) (clojure.test/run-tests
+  'ai.miniforge.cli.backends-test)"` — 1 test, 2 assertions, 0
+  failures; same for `ai.miniforge.cli.config-test` — 6 tests, 34
+  assertions, 0 failures.
+- All five touched/new namespaces `require` cleanly under `:dev:test`
+  (no compile errors).
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 remediation program's `bases/cli`
+  batch (see PR #1772 `loader.clj`, PR #1766 `compiler.clj`, PR #1731
+  `knowledge_safety.clj` for the established splitting convention this
+  follows).
+
+## Checklist
+
+- [x] stratum-lint clean on all resulting files
+- [x] clj-kondo clean on all touched files
+- [x] `clojure -M:poly check` OK
+- [x] Direct namespace test runs green (backends-test, config-test)
+- [x] Adversarial self-review: def set unchanged except one
+      `^:private` → public visibility flip, documented above
+- [x] Zero project-level fan-in confirmed repo-wide before starting


### PR DESCRIPTION
## Overview

Splits the CLI backend module's resource-backed config and status/
validation logic out of `ai.miniforge.cli.backends` into two new
sibling namespaces, `ai.miniforge.cli.backends.config` and
`ai.miniforge.cli.backends.status`, resolving a stratum-lint SL003
finding (the combined namespace measured 7 real layers, over the rule
210 budget of 3).

Part of the stratum-lint rule-210 remediation program, `bases/cli`
batch. Full PR doc: `docs/pull-requests/2026-08-12-refactor-split-cli-backends.md`.

## Changes

- New `backends/config.clj`: `backend-config-resource`, `backend-config`,
  `backend-specs`, `backend-defaults` (3 layers). `backend-defaults`
  changed from `^:private` to public — the only visibility change,
  needed since `backends.status/get-current-backend` now reads it
  cross-namespace.
- New `backends/status.clj`: `availability-status`,
  `check-command-available?`, `get-current-backend`,
  `check-backend-status`, `get-backend-info`, `validate-backend`
  (3 layers).
- `backends.clj`: keeps `status-icon`, `format-backend-status`,
  `list-backends`, `print-backend-error`, `print-backends` — now 3
  layers (down from 7).
- `config.clj` (the one real external caller, confirmed via a
  repo-wide grep for the fully-qualified namespace
  `ai\.miniforge\.cli\.backends\b`, not a symbol-prefix guess, across
  `components/`, `bases/`, and `projects/`): call sites for
  `backend-specs`, `validate-backend`, `get-backend-info` repointed to
  the new namespaces; `print-backend-error`/`print-backends` stayed on
  the existing `backends` alias, unchanged.
- `backends_test.clj`: repointed to the new namespaces, dropped the
  now-unused `backends` require.

Pure code motion aside from the one visibility flip and call-site
updates — no behavior change.

## Testing

- `stratum-lint` clean on all three touched/new source files.
- `clj-kondo` clean on all touched files.
- `clojure -M:poly check` OK.
- Direct namespace test runs: `ai.miniforge.cli.backends-test` (1
  test, 2 assertions) and `ai.miniforge.cli.config-test` (6 tests, 34
  assertions), both 0 failures.
- `bb pre-commit` green on both commits (commit budget, poly check,
  lint, stratum-lint, smoke tests — 345 tests/1301 assertions —
  graalvm compat — 8 tests/625 assertions).
- `config.clj` carries a pre-existing SL003 (4 layers) unrelated to
  this change, present on `origin/main` before this PR — the wire-up
  commit used `MINIFORGE_STRATUM_BUDGET_MODE=warn`, the repo's
  documented opt-out for a pre-existing over-budget file outside this
  task's scope (see `tasks/stratum.clj`). Out of scope for this PR;
  `config.clj`'s own split is a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
