### PR TITLE
refactor(cli): split evidence.clj (rule 210)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/evidence.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/evidence.clj
@@ -19,142 +19,28 @@
   "Evidence bundle commands: show, export, list.
 
    Delegates to ai.miniforge.evidence-bundle.interface when available.
-   Falls back to filesystem scanning of ~/.miniforge/evidence/."
+   Falls back to filesystem scanning of ~/.miniforge/evidence/.
+
+   Bundle discovery/loading and field-derivation helpers live in the
+   sibling `ai.miniforge.cli.main.commands.evidence.bundles` namespace
+   (rule 210: the combined namespace measured 5 real layers, max 3);
+   this namespace keeps the three command entry points and the
+   detail-view rendering they share."
   (:require
-   [babashka.fs :as fs]
-   [clojure.edn :as edn]
-   [clojure.java.io :as io]
-   [clojure.string :as str]
    [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.main.commands.evidence.bundles :as bundles]
    [ai.miniforge.cli.main.commands.shared :as shared]
    [ai.miniforge.cli.main.display :as display]
    [ai.miniforge.cli.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Helpers
-(defn- ^{:stratum 0} evidence-dir []
-  (str (app-config/home-dir) "/evidence"))
-
-(defn ^{:stratum 0} load-bundle-from-file
-  "Load an evidence bundle from an EDN file. Returns nil on failure."
-  [file]
-  (try
-    (when (str/ends-with? (.getName file) ".edn")
-      (edn/read-string (slurp file)))
-    (catch Exception _ nil)))
-
-;; Display helpers
-(def ^{:stratum 0} ^:private bundle-detail-spec
-  {:header   :evidence/show-header
-   :fields   [[:bundle/workflow-id :evidence/show-workflow {:default "—"}]
-              [:bundle/status      :evidence/show-status   {:default "unknown"}]
-              [:bundle/created-at  :evidence/show-created  {:default "—"}]
-              [:bundle/failure-attribution :evidence/show-failure-attribution {:default "—"}]
-              [:bundle/dependency-issues :evidence/show-dependency-issues {:default 0}]]
-   :sections [{:key :bundle/artifacts :header :evidence/show-artifacts
-               :entry :evidence/show-artifact-entry :max 10
-               :entry-fn (fn [a] {:type (get a :artifact/type "unknown")
-                                   :id   (get a :artifact/id "")})}
-              {:key :bundle/phases :header :evidence/show-phases}]})
-
-(def ^{:stratum 0} ^:private phase-evidence-keys
-  [:evidence/plan
-   :evidence/design
-   :evidence/implement
-   :evidence/verify
-   :evidence/review
-   :evidence/release
-   :evidence/observe])
-
-(defn- ^{:stratum 0} active-dependency?
-  [dependency]
-  (contains? #{:degraded :unavailable :misconfigured :operator-action-required}
-             (:dependency/status dependency)))
-
-(defn- ^{:stratum 0} label
-  [value]
-  (cond
-    (keyword? value) (name value)
-    (string? value) value
-    (nil? value) "unknown"
-    :else (str value)))
-
-;; Command implementations
-(defn- ^{:stratum 0} display-component-bundles
-  "Render bundles returned from the evidence-bundle component interface."
-  [bundles]
-  (if (seq bundles)
-    (doseq [bundle bundles]
-      (println (messages/t :evidence/bundle-entry
-                          {:id          (display/style (get bundle :bundle/id "unknown") :foreground :bold)
-                           :workflow-id (get bundle :bundle/workflow-id "—")
-                           :status      (get bundle :bundle/status "unknown")})))
-    (println (messages/t :evidence/none))))
-
-;------------------------------------------------------------------------------ Layer 1
-
-(defn- ^{:stratum 1} scan-evidence-dir []
-  (let [dir (io/file (evidence-dir))]
-    (when (.exists dir)
-      (->> (.listFiles dir)
-           (filter #(.isFile %))
-           (sort-by #(.lastModified %) >)
-           vec))))
-
-(defn- ^{:stratum 1} dependency-issue-count
-  [dependency-health]
-  (->> dependency-health
-       vals
-       (filter active-dependency?)
-       count))
-
-(defn- ^{:stratum 1} failure-attribution-summary
-  [failure-attribution]
-  (when (seq failure-attribution)
-    (let [source (or (:failure/source failure-attribution)
-                     (:dependency/source failure-attribution)
-                     :unknown)
-          vendor (or (:failure/vendor failure-attribution)
-                     (:dependency/vendor failure-attribution)
-                     (:dependency/id failure-attribution))
-          failure-class (or (:dependency/class failure-attribution)
-                            (:failure/class failure-attribution)
-                            :unknown)]
-      (str (label source) " / " (label vendor) " / " (label failure-class)))))
-
-(defn- ^{:stratum 1} canonical-phase-names
-  [bundle]
-  (->> phase-evidence-keys
-       (filter #(contains? bundle %))
-       (mapv (comp keyword name))))
-
-(defn- ^{:stratum 1} load-bundle-for-show
-  "Load a bundle from the component interface or the filesystem."
-  [id]
-  (or (shared/call-optional-provider 'ai.miniforge.evidence-bundle.interface/get-bundle id)
-      (let [f (io/file (str (evidence-dir) "/" id ".edn"))]
-        (when (.exists f) (load-bundle-from-file f)))))
-
-(defn- ^{:stratum 1} export-bundle-fallback
-  "Copy the raw EDN bundle file as-is when the export component is unavailable."
-  [id fmt]
-  (let [src (io/file (str (evidence-dir) "/" id ".edn"))]
-    (if (.exists src)
-      (let [dest (str (evidence-dir) "/" id "-export." fmt)]
-        (fs/copy (str src) dest {:replace-existing true})
-        (display/print-success (messages/t :evidence/export-raw {:path dest})))
-      (do (display/print-error (messages/t :evidence/export-not-found {:id id}))
-          (shared/exit! 1)))))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn- ^{:stratum 2} normalize-bundle-detail
+(defn- ^{:stratum 0} normalize-bundle-detail
   [bundle]
   (let [dependency-health (or (:evidence/dependency-health bundle) {})
         artifacts (or (:bundle/artifacts bundle) [])
         phases (or (:bundle/phases bundle)
-                   (canonical-phase-names bundle))
+                   (bundles/canonical-phase-names bundle))
         status (or (:bundle/status bundle)
                    (if (true? (get-in bundle [:evidence/outcome :outcome/success]))
                      "completed"
@@ -166,17 +52,17 @@
                             (:evidence-bundle/created-at bundle))
      :bundle/artifacts artifacts
      :bundle/phases phases
-     :bundle/dependency-issues (dependency-issue-count dependency-health)
-     :bundle/failure-attribution (failure-attribution-summary
+     :bundle/dependency-issues (bundles/dependency-issue-count dependency-health)
+     :bundle/failure-attribution (bundles/failure-attribution-summary
                                   (:evidence/failure-attribution bundle))}))
 
-(defn- ^{:stratum 2} display-filesystem-bundles
+(defn- ^{:stratum 0} display-filesystem-bundles
   "Render bundles discovered via filesystem scan."
   []
-  (let [files (scan-evidence-dir)]
+  (let [files (bundles/scan-evidence-dir)]
     (if (seq files)
       (doseq [f files]
-        (let [bundle (load-bundle-from-file f)
+        (let [bundle (bundles/load-bundle-from-file f)
               id     (if bundle
                        (or (some-> (:bundle/id bundle) str) (.getName f))
                        (.getName f))]
@@ -190,9 +76,9 @@
                                                "—")}))))
       (do
         (println (messages/t :evidence/none))
-        (println (messages/t :evidence/evidence-dir {:dir (evidence-dir)}))))))
+        (println (messages/t :evidence/evidence-dir {:dir (bundles/evidence-dir)}))))))
 
-(defn ^{:stratum 2} evidence-export-cmd
+(defn ^{:stratum 0} evidence-export-cmd
   "Export an evidence bundle to a file in the requested format.
 
    Supported formats: edn (default), json, html."
@@ -209,17 +95,17 @@
             (println (messages/t :evidence/export-format {:format fmt}))
             (when-let [path (:path result)]
               (println (messages/t :evidence/export-path {:path path}))))
-          (export-bundle-fallback id fmt))))))
+          (bundles/export-bundle-fallback id fmt))))))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 1
 
-(defn- ^{:stratum 3} display-bundle-detail
+(defn- ^{:stratum 1} display-bundle-detail
   "Render the detail view for a single evidence bundle."
   [id bundle]
-  (display/render-detail (assoc bundle-detail-spec :header-params {:id id})
+  (display/render-detail (assoc bundles/bundle-detail-spec :header-params {:id id})
                          (normalize-bundle-detail bundle)))
 
-(defn ^{:stratum 3} evidence-list-cmd
+(defn ^{:stratum 1} evidence-list-cmd
   "List all available evidence bundles.
 
    Shows bundles from the evidence-bundle component if available,
@@ -231,19 +117,19 @@
   (let [component-result (shared/call-optional-provider
                           'ai.miniforge.evidence-bundle.interface/list-bundles)]
     (if component-result
-      (display-component-bundles component-result)
+      (bundles/display-component-bundles component-result)
       (display-filesystem-bundles)))
   (println))
 
-;------------------------------------------------------------------------------ Layer 4
+;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 4} evidence-show-cmd
+(defn ^{:stratum 2} evidence-show-cmd
   "Show the contents of an evidence bundle by ID."
   [opts]
   (let [{:keys [id]} opts]
     (if-not id
       (shared/usage-error! :evidence/show-usage "evidence show <id>")
-      (let [bundle (load-bundle-for-show id)]
+      (let [bundle (bundles/load-bundle-for-show id)]
         (if-not bundle
           (do (display/print-error
                (messages/t :evidence/not-found

--- a/bases/cli/src/ai/miniforge/cli/main/commands/evidence/bundles.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/evidence/bundles.clj
@@ -1,0 +1,151 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.main.commands.evidence.bundles
+  "Evidence bundle discovery, loading, and field-derivation helpers.
+   Split out of `ai.miniforge.cli.main.commands.evidence` (rule 210:
+   the combined namespace measured 5 real layers, max 3) — the command
+   entry points and detail-view rendering stay in the parent
+   namespace; locating/loading bundle files (filesystem scan and the
+   optional component provider) and deriving their normalized/summary
+   fields live here."
+  (:require
+   [babashka.fs :as fs]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.main.commands.shared :as shared]
+   [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.messages :as messages]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Helpers
+(defn ^{:stratum 0} evidence-dir []
+  (str (app-config/home-dir) "/evidence"))
+
+(defn ^{:stratum 0} load-bundle-from-file
+  "Load an evidence bundle from an EDN file. Returns nil on failure."
+  [file]
+  (try
+    (when (str/ends-with? (.getName file) ".edn")
+      (edn/read-string (slurp file)))
+    (catch Exception _ nil)))
+
+;; Display helpers
+(def ^{:stratum 0} bundle-detail-spec
+  {:header   :evidence/show-header
+   :fields   [[:bundle/workflow-id :evidence/show-workflow {:default "—"}]
+              [:bundle/status      :evidence/show-status   {:default "unknown"}]
+              [:bundle/created-at  :evidence/show-created  {:default "—"}]
+              [:bundle/failure-attribution :evidence/show-failure-attribution {:default "—"}]
+              [:bundle/dependency-issues :evidence/show-dependency-issues {:default 0}]]
+   :sections [{:key :bundle/artifacts :header :evidence/show-artifacts
+               :entry :evidence/show-artifact-entry :max 10
+               :entry-fn (fn [a] {:type (get a :artifact/type "unknown")
+                                   :id   (get a :artifact/id "")})}
+              {:key :bundle/phases :header :evidence/show-phases}]})
+
+(def ^{:stratum 0} ^:private phase-evidence-keys
+  [:evidence/plan
+   :evidence/design
+   :evidence/implement
+   :evidence/verify
+   :evidence/review
+   :evidence/release
+   :evidence/observe])
+
+(defn- ^{:stratum 0} active-dependency?
+  [dependency]
+  (contains? #{:degraded :unavailable :misconfigured :operator-action-required}
+             (:dependency/status dependency)))
+
+(defn- ^{:stratum 0} label
+  [value]
+  (cond
+    (keyword? value) (name value)
+    (string? value) value
+    (nil? value) "unknown"
+    :else (str value)))
+
+;; Command implementations
+(defn ^{:stratum 0} display-component-bundles
+  "Render bundles returned from the evidence-bundle component interface."
+  [bundles]
+  (if (seq bundles)
+    (doseq [bundle bundles]
+      (println (messages/t :evidence/bundle-entry
+                          {:id          (display/style (get bundle :bundle/id "unknown") :foreground :bold)
+                           :workflow-id (get bundle :bundle/workflow-id "—")
+                           :status      (get bundle :bundle/status "unknown")})))
+    (println (messages/t :evidence/none))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} scan-evidence-dir []
+  (let [dir (io/file (evidence-dir))]
+    (when (.exists dir)
+      (->> (.listFiles dir)
+           (filter #(.isFile %))
+           (sort-by #(.lastModified %) >)
+           vec))))
+
+(defn ^{:stratum 1} dependency-issue-count
+  [dependency-health]
+  (->> dependency-health
+       vals
+       (filter active-dependency?)
+       count))
+
+(defn ^{:stratum 1} failure-attribution-summary
+  [failure-attribution]
+  (when (seq failure-attribution)
+    (let [source (or (:failure/source failure-attribution)
+                     (:dependency/source failure-attribution)
+                     :unknown)
+          vendor (or (:failure/vendor failure-attribution)
+                     (:dependency/vendor failure-attribution)
+                     (:dependency/id failure-attribution))
+          failure-class (or (:dependency/class failure-attribution)
+                            (:failure/class failure-attribution)
+                            :unknown)]
+      (str (label source) " / " (label vendor) " / " (label failure-class)))))
+
+(defn ^{:stratum 1} canonical-phase-names
+  [bundle]
+  (->> phase-evidence-keys
+       (filter #(contains? bundle %))
+       (mapv (comp keyword name))))
+
+(defn ^{:stratum 1} load-bundle-for-show
+  "Load a bundle from the component interface or the filesystem."
+  [id]
+  (or (shared/call-optional-provider 'ai.miniforge.evidence-bundle.interface/get-bundle id)
+      (let [f (io/file (str (evidence-dir) "/" id ".edn"))]
+        (when (.exists f) (load-bundle-from-file f)))))
+
+(defn ^{:stratum 1} export-bundle-fallback
+  "Copy the raw EDN bundle file as-is when the export component is unavailable."
+  [id fmt]
+  (let [src (io/file (str (evidence-dir) "/" id ".edn"))]
+    (if (.exists src)
+      (let [dest (str (evidence-dir) "/" id "-export." fmt)]
+        (fs/copy (str src) dest {:replace-existing true})
+        (display/print-success (messages/t :evidence/export-raw {:path dest})))
+      (do (display/print-error (messages/t :evidence/export-not-found {:id id}))
+          (shared/exit! 1)))))

--- a/bases/cli/test/ai/miniforge/cli/main/commands/evidence_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/evidence_test.clj
@@ -22,11 +22,12 @@
    [babashka.fs :as fs]
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.main.commands.evidence :as sut]
+   [ai.miniforge.cli.main.commands.evidence.bundles :as bundles]
    [ai.miniforge.cli.main.commands.shared :as shared]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;------------------------------------------------------------------------------ Layer 0: Fixtures & factories
+;; Fixtures & factories
 (def ^{:stratum 0} ^:dynamic *tmp-dir* nil)
 
 (defn ^{:stratum 0} tmp-dir-fixture [f]
@@ -122,7 +123,7 @@
           :evidence/failure-attribution (make-failure-attribution)}
          overrides))
 
-;------------------------------------------------------------------------------ Layer 1: Tests
+;; Tests
 (deftest ^{:stratum 1} evidence-list-cmd-no-component-empty-dir-test
   (testing "list command shows 'no bundles' when dir is empty"
     (with-redefs [shared/call-optional-provider (constantly nil)
@@ -150,12 +151,12 @@
   (testing "loads valid EDN file"
     (let [f (java.io.File. (str *tmp-dir* "/test.edn"))]
       (spit f (pr-str {:bundle/id "b-1"}))
-      (is (= {:bundle/id "b-1"} (sut/load-bundle-from-file f)))))
+      (is (= {:bundle/id "b-1"} (bundles/load-bundle-from-file f)))))
 
   (testing "returns nil for non-EDN file"
     (let [f (java.io.File. (str *tmp-dir* "/test.json"))]
       (spit f "{}")
-      (is (nil? (sut/load-bundle-from-file f))))))
+      (is (nil? (bundles/load-bundle-from-file f))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 

--- a/docs/pull-requests/2026-08-12-refactor-split-cli-cmd-evidence.md
+++ b/docs/pull-requests/2026-08-12-refactor-split-cli-cmd-evidence.md
@@ -1,0 +1,111 @@
+<!--
+  Title: Split cli/main/commands/evidence.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(cli): split evidence.clj (rule 210)
+
+## Overview
+
+Splits bundle discovery/loading and field-derivation helpers out of
+`ai.miniforge.cli.main.commands.evidence` into a new sibling
+namespace, `ai.miniforge.cli.main.commands.evidence.bundles`,
+resolving a stratum-lint SL003 finding (the combined namespace
+measured 5 real layers, over the rule 210 budget of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program's `bases/cli`
+batch — 13 `main/commands/*.clj` files are being split concurrently.
+`evidence.clj` (238 lines) is one of them.
+
+## Changes in Detail
+
+- New file `commands/evidence/bundles.clj`: `evidence-dir`,
+  `load-bundle-from-file`, `bundle-detail-spec`,
+  `phase-evidence-keys`, `active-dependency?`, `label`,
+  `display-component-bundles` (layer 0), and `scan-evidence-dir`,
+  `dependency-issue-count`, `failure-attribution-summary`,
+  `canonical-phase-names`, `load-bundle-for-show`,
+  `export-bundle-fallback` (layer 1) — 2 layers. Everything about
+  locating/loading a bundle (filesystem scan or the optional
+  `ai.miniforge.evidence-bundle.interface` component) and deriving
+  its normalized/summary fields.
+- `evidence.clj`: keeps the three command entry points
+  (`evidence-list-cmd`, `evidence-show-cmd`, `evidence-export-cmd`)
+  and the detail-view rendering they share
+  (`normalize-bundle-detail`, `display-filesystem-bundles`,
+  `display-bundle-detail`) — now 3 layers (down from 5), calling
+  `bundles/*` for everything that moved.
+- Visibility flips (`defn-` -> `defn`), the only change beyond code
+  motion and call-site qualification — each of these is now called
+  cross-namespace from `evidence.clj`: `evidence-dir`,
+  `bundle-detail-spec` (dropped `^:private`), `scan-evidence-dir`,
+  `dependency-issue-count`, `failure-attribution-summary`,
+  `canonical-phase-names`, `load-bundle-for-show`,
+  `export-bundle-fallback`, `display-component-bundles`.
+  `phase-evidence-keys`, `active-dependency?`, and `label` stay
+  private — used only internally within `bundles.clj`.
+  `load-bundle-from-file` was already public and is unchanged.
+- `evidence_test.clj`: the two `load-bundle-from-file-test`
+  assertions called the raw function directly (white-box) — updated
+  to `bundles/load-bundle-from-file` since that fn moved. Every other
+  `sut/*` call (the three command entry points) is unchanged.
+- `bases/cli/src/ai/miniforge/cli/main.clj`'s `cmd-evidence` alias is
+  unaffected — it only ever calls the three command entry points,
+  none of which moved, so no update needed there.
+
+This is pure code motion aside from the required visibility changes
+and the one test call-site update above — no behavior changed.
+
+## Testing Plan
+
+- `stratum-lint` clean on both resulting files (exit 0, was SL003
+  exit 1 on the original 5-layer file — confirmed against a control
+  copy of `main` before the split).
+- `clj-kondo` clean on all three touched files (0 errors, 0
+  warnings).
+- `ai.miniforge.cli.main.commands.evidence-test` run directly (not
+  relying on `bb test` alone): `clojure -M:dev:test -e "(require
+  'ai.miniforge.cli.main.commands.evidence-test)
+  (clojure.test/run-tests
+  'ai.miniforge.cli.main.commands.evidence-test)"` — 8 tests, 12
+  assertions, 0 failures, 0 errors. Run once before committing and
+  again after both commits landed.
+- `bb pre-commit` (commit-budget, `poly check`, clj-kondo,
+  stratum-lint, `fmt:md`, the 18-namespace pre-commit smoke suite —
+  345 tests / 1301 assertions, 0 failures — and the GraalVM
+  compatibility suite — 8 tests / 624 assertions, 0 failures) passed
+  on both commits in this PR.
+- Repo-wide grep for the fully-qualified namespace
+  (`ai\.miniforge\.cli\.main\.commands\.evidence\b`) across
+  `components/`, `bases/`, and `projects/` found exactly two callers:
+  `bases/cli/src/ai/miniforge/cli/main.clj` (unaffected, see above)
+  and `bases/cli/test/.../evidence_test.clj` (updated). No
+  project-level test callers.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file.
+Sibling `main/commands/*.clj` splits in this batch continue
+independently.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 program's `bases/cli` batch (13
+  concurrent `main/commands/*.clj` splits). Follows the convention
+  established by `gh pr diff 1772` (loader.clj) and `gh pr diff 1731`
+  (knowledge_safety.clj).
+
+## Checklist
+
+- [x] stratum-lint clean on all resulting files
+- [x] `bb pre-commit` green on both commits (full smoke + GraalVM
+      suites included)
+- [x] Adversarial self-review: def set unchanged except the nine
+      defn-/def -> public visibility flips, documented above
+- [x] Test call sites updated for the one white-box
+      `load-bundle-from-file` test
+- [x] Zero fan-in surprises confirmed repo-wide before and after the
+      split


### PR DESCRIPTION
## Overview

Splits bundle discovery/loading and field-derivation helpers out of `ai.miniforge.cli.main.commands.evidence` into a new sibling namespace, `ai.miniforge.cli.main.commands.evidence.bundles`, resolving a stratum-lint SL003 finding (the combined namespace measured 5 real layers, over the rule 210 budget of 3).

Part of the stratum-lint rule-210 remediation program's `bases/cli` batch (13 concurrent `main/commands/*.clj` splits). Full details in `docs/pull-requests/2026-08-12-refactor-split-cli-cmd-evidence.md`.

## Changes

- New `commands/evidence/bundles.clj` (2 layers): bundle discovery/loading (filesystem scan + optional `evidence-bundle` component provider) and field-derivation helpers.
- `evidence.clj` (3 layers, down from 5): keeps the three command entry points (`evidence-list-cmd`, `evidence-show-cmd`, `evidence-export-cmd`) and detail-view rendering, now calling `bundles/*`.
- Nine `defn-`/private-def -> public visibility flips (the only change beyond code motion) for functions now called cross-namespace — documented in the PR doc.
- `evidence_test.clj`: the two `load-bundle-from-file-test` assertions updated to call `bundles/load-bundle-from-file` directly (that fn moved). All other `sut/*` calls unchanged.
- `main.clj`'s `cmd-evidence` alias unaffected — it only calls the three command entry points, none of which moved.

Pure code motion; no behavior changed.

## Testing

- `stratum-lint` clean on both resulting files (was SL003 exit 1 on the original).
- `clj-kondo` clean (0 errors/warnings).
- `ai.miniforge.cli.main.commands.evidence-test` run directly via `clojure -M:dev:test`: 8 tests, 12 assertions, 0 failures — before and after committing.
- `bb pre-commit` green on all three commits, including the 18-namespace smoke suite (345 tests/1301 assertions) and GraalVM compat suite (8 tests/624 assertions).
- Repo-wide grep for the fully-qualified namespace found exactly two callers (`main.clj`, `evidence_test.clj`), both handled above. No project-level test callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)