### PR TITLE
refactor(cli): split workflow_selector.clj (rule 210)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_selector.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_selector.clj
@@ -21,106 +21,55 @@
    Analyzes workflow specs and automatically selects the appropriate workflow
    profile, then resolves that profile to the active app's workflow id.
 
-   Layer 0: Spec analysis - extract features from spec
-   Layer 1: Rule matching - apply selection rules
-   Layer 2: Workflow selection with reasoning"
+   Feature extraction and individual rule matchers live in sibling
+   `ai.miniforge.cli.workflow-selector.*` namespaces (rule 210: the
+   combined namespace measured 5 real layers, max 3) — `analyze-spec`
+   is re-exported from `spec-analysis` here so this stays the single
+   public entry point. `match-rule` itself stays here rather than in
+   `rules`: dispatching over `rules/selection-rules` is a 4th real
+   layer on top of that namespace's own 3 (selection result -> rule
+   matchers -> ordered list), and the cross-namespace call doesn't add
+   to this file's own layer depth.
+
+   Layer 0: Explanation formatting, spec-analysis re-export, rule dispatch
+   Layer 1: Workflow selection with reasoning"
   (:require
-   [clojure.string :as str]
    [ai.miniforge.cli.messages :as messages]
-   [ai.miniforge.cli.workflow-selection-config :as selection-config]))
+   [ai.miniforge.cli.workflow-selector.rules :as rules]
+   [ai.miniforge.cli.workflow-selector.spec-analysis :as spec-analysis]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Spec feature extraction
-(defn ^{:stratum 0} extract-type
-  "Extract task type from spec.
-   After normalization, :spec/intent is guaranteed to be set."
-  [spec]
-  (or (get-in spec [:spec/intent :type])
-      (get-in spec [:spec/raw-data :type])
-      :unknown))
+(def ^{:stratum 0} analyze-spec
+  "Analyze spec and extract decision features.
 
-(defn ^{:stratum 0} extract-implementation-plan
-  "Extract implementation plan details from spec."
-  [spec]
-  (or (get-in spec [:spec/raw-data :implementation-plan])
-      (get-in spec [:spec/intent :implementation-plan])
-      (:implementation-plan spec)))
+   Returns map with:
+   - :type - Task type (:feature, :refactoring, :bugfix, :docs, etc.)
+   - :implementation-plan - Implementation plan structure
+   - :pr-count - Number of PRs/phases
+   - :has-dependencies? - Whether phases have dependencies
+   - :keywords - Set of extracted keywords
+   - :size - Estimated size (:small, :medium, :large, :unknown)
+   - :constraint-mentions - Set of mentioned constraints"
+  spec-analysis/analyze-spec)
 
-(defn ^{:stratum 0} count-prs
-  "Count number of PRs/phases in implementation plan."
-  [impl-plan]
-  (when impl-plan
-    (count (filter (fn [[k _v]] (str/starts-with? (name k) "pr-"))
-                   impl-plan))))
+(defn ^{:stratum 0} match-rule
+  "Apply selection rules to features and return first match.
 
-(defn ^{:stratum 0} has-dependencies?
-  "Check if implementation plan has dependencies between phases."
-  [impl-plan]
-  (when impl-plan
-    (some (fn [[_k v]]
-            (and (map? v)
-                 (or (seq (:dependencies v))
-                     (not-empty (:base v)))))
-          impl-plan)))
+   Rules are applied in order:
+   1. Multi-phase implementation → comprehensive profile
+   2. Refactoring with stratification → comprehensive profile
+   3. Large feature → comprehensive profile
+   4. Bug fix → fast profile
+   5. Docs only → fast profile
+   6. Unknown → default profile
 
-(defn ^{:stratum 0} extract-description-keywords
-  "Extract significant keywords from spec description."
-  [spec]
-  (let [desc (str/lower-case (or (:spec/description spec) ""))
-        title (str/lower-case (or (:spec/title spec) ""))]
-    (set (concat
-          (when (or (str/includes? desc "refactor")
-                    (str/includes? title "refactor"))
-            [:refactoring])
-          (when (or (str/includes? desc "stratif")
-                    (str/includes? desc "layer"))
-            [:stratified-design])
-          (when (or (str/includes? desc "multi-phase")
-                    (str/includes? desc "multiple phase")
-                    (str/includes? desc "6 pr")
-                    (str/includes? desc "multi-pr"))
-            [:multi-phase])
-          (when (or (str/includes? desc "bug")
-                    (str/includes? desc "fix"))
-            [:bugfix])
-          (when (or (str/includes? desc "document")
-                    (str/includes? desc "docs only"))
-            [:docs-only])
-          (when (or (str/includes? desc "large")
-                    (str/includes? desc "complex")
-                    (str/includes? desc "comprehensive"))
-            [:large-scope])
-          (when (or (str/includes? desc "simple")
-                    (str/includes? desc "small")
-                    (str/includes? desc "quick"))
-            [:small-scope])))))
-
-(defn ^{:stratum 0} extract-constraints-mentions
-  "Extract constraint mentions from spec."
-  [spec]
-  (let [constraints (get spec :spec/constraints [])]
-    (set (concat
-          (when (some #(or (str/includes? (str/lower-case (str %)) "rule 720")
-                           (str/includes? (str/lower-case (str %)) "≤400"))
-                      constraints)
-            [:rule-720])
-          (when (some #(or (str/includes? (str/lower-case (str %)) "rule 210")
-                           (str/includes? (str/lower-case (str %)) "≤3 layer")
-                           (str/includes? (str/lower-case (str %)) "stratif"))
-                      constraints)
-            [:rule-210])
-          (when (some #(str/includes? (str/lower-case (str %)) "zero lint")
-                      constraints)
-            [:zero-linting])))))
-
-(defn ^{:stratum 0} selection-result
-  "Build a selection result from a logical profile."
-  [profile confidence reason]
-  {:selection-profile profile
-   :workflow-type (selection-config/resolve-selection-profile profile)
-   :confidence confidence
-   :reason reason})
+   Returns map with:
+   - :workflow-type - Selected workflow keyword
+   - :confidence - :high, :medium, or :low
+   - :reason - Human-readable explanation"
+  [features]
+  (some (fn [rule-fn] (rule-fn features)) rules/selection-rules))
 
 (defn ^{:stratum 0} explain-selection
   "Generate user-facing explanation for workflow selection.
@@ -146,135 +95,8 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} estimate-size
-  "Estimate scope size from spec."
-  [spec impl-plan]
-  (let [keywords (extract-description-keywords spec)
-        pr-count (count-prs impl-plan)]
-    (cond
-      (and pr-count (>= pr-count 5)) :large
-      (contains? keywords :large-scope) :large
-      (contains? keywords :small-scope) :small
-      (and pr-count (>= pr-count 3)) :medium
-      :else :unknown)))
-
-;; Rule matching
-(defn ^{:stratum 1} match-multi-phase-rule
-  "Multi-phase implementation → comprehensive profile"
-  [features]
-  (when (and (:pr-count features)
-             (>= (:pr-count features) 4))
-    (selection-result :comprehensive
-                      :high
-                      (messages/t :selector/reason-multi-phase
-                                  {:pr-count (:pr-count features)}))))
-
-(defn ^{:stratum 1} match-refactoring-stratification-rule
-  "Refactoring with stratification → comprehensive profile"
-  [features]
-  (when (and (or (= (:type features) :refactoring)
-                 (contains? (:keywords features) :refactoring))
-             (or (contains? (:keywords features) :stratified-design)
-                 (contains? (:constraint-mentions features) :rule-210)))
-    (selection-result :comprehensive
-                      :high
-                      (messages/t :selector/reason-refactoring-stratification))))
-
-(defn ^{:stratum 1} match-large-feature-rule
-  "Large feature → comprehensive profile"
-  [features]
-  (when (and (= (:size features) :large)
-             (not (contains? (:keywords features) :bugfix))
-             (not (contains? (:keywords features) :docs-only)))
-    (selection-result :comprehensive
-                      :medium
-                      (messages/t :selector/reason-large-feature))))
-
-(defn ^{:stratum 1} match-bugfix-rule
-  "Bug fix → fast profile"
-  [features]
-  (when (or (= (:type features) :bugfix)
-            (contains? (:keywords features) :bugfix))
-    (selection-result :fast
-                      :high
-                      (messages/t :selector/reason-bugfix))))
-
-(defn ^{:stratum 1} match-docs-only-rule
-  "Docs only → fast profile"
-  [features]
-  (when (or (= (:type features) :docs)
-            (contains? (:keywords features) :docs-only))
-    (selection-result :fast
-                      :high
-                      (messages/t :selector/reason-docs-only))))
-
-(defn ^{:stratum 1} match-unknown-rule
-  "Unknown/ambiguous → default profile"
-  [_features]
-  (selection-result :default
-                    :low
-                    (messages/t :selector/reason-unknown)))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn ^{:stratum 2} analyze-spec
-  "Analyze spec and extract decision features.
-
-   Returns map with:
-   - :type - Task type (:feature, :refactoring, :bugfix, :docs, etc.)
-   - :implementation-plan - Implementation plan structure
-   - :pr-count - Number of PRs/phases
-   - :has-dependencies? - Whether phases have dependencies
-   - :keywords - Set of extracted keywords
-   - :size - Estimated size (:small, :medium, :large, :unknown)
-   - :constraint-mentions - Set of mentioned constraints"
-  [spec]
-  (let [task-type (extract-type spec)
-        impl-plan (extract-implementation-plan spec)
-        pr-count (count-prs impl-plan)
-        keywords (extract-description-keywords spec)
-        size (estimate-size spec impl-plan)]
-    {:type task-type
-     :implementation-plan impl-plan
-     :pr-count pr-count
-     :has-dependencies? (has-dependencies? impl-plan)
-     :keywords keywords
-     :size size
-     :constraint-mentions (extract-constraints-mentions spec)}))
-
-(def ^{:stratum 2} selection-rules
-  "Ordered list of selection rules. First matching rule wins."
-  [match-multi-phase-rule
-   match-refactoring-stratification-rule
-   match-large-feature-rule
-   match-bugfix-rule
-   match-docs-only-rule
-   match-unknown-rule])
-
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} match-rule
-  "Apply selection rules to features and return first match.
-
-   Rules are applied in order:
-   1. Multi-phase implementation → comprehensive profile
-   2. Refactoring with stratification → comprehensive profile
-   3. Large feature → comprehensive profile
-   4. Bug fix → fast profile
-   5. Docs only → fast profile
-   6. Unknown → default profile
-
-   Returns map with:
-   - :workflow-type - Selected workflow keyword
-   - :confidence - :high, :medium, or :low
-   - :reason - Human-readable explanation"
-  [features]
-  (some (fn [rule-fn] (rule-fn features)) selection-rules))
-
-;------------------------------------------------------------------------------ Layer 4
-
 ;; Workflow selection with reasoning
-(defn ^{:stratum 4} select-workflow
+(defn ^{:stratum 1} select-workflow
   "Select appropriate workflow based on spec analysis.
 
    Returns map with:

--- a/bases/cli/src/ai/miniforge/cli/workflow_selector.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_selector.clj
@@ -65,6 +65,7 @@
    6. Unknown → default profile
 
    Returns map with:
+   - :selection-profile - Logical profile the rule matched (:comprehensive, :fast, or :default)
    - :workflow-type - Selected workflow keyword
    - :confidence - :high, :medium, or :low
    - :reason - Human-readable explanation"

--- a/bases/cli/src/ai/miniforge/cli/workflow_selector/rules.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_selector/rules.clj
@@ -114,3 +114,12 @@
    match-bugfix-rule
    match-docs-only-rule
    match-unknown-rule])
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (some (fn [rule-fn] (rule-fn {:type :bugfix :keywords #{:bugfix}}))
+        selection-rules)
+  ;; => {:selection-profile :fast, :workflow-type :quick-fix,
+  ;;     :confidence :high, :reason "..."}
+
+  :end)

--- a/bases/cli/src/ai/miniforge/cli/workflow_selector/rules.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_selector/rules.clj
@@ -1,0 +1,116 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-selector.rules
+  "Selection-rule matching for workflow selection.
+
+   Split out of `ai.miniforge.cli.workflow-selector` (rule 210: the
+   combined namespace measured 5 real layers, max 3) — the individual
+   rule matchers and the ordered rule list they compose into live here,
+   operating on the feature map produced by
+   `ai.miniforge.cli.workflow-selector.spec-analysis`. `match-rule`
+   itself (dispatch over `selection-rules`) stays in the parent
+   namespace: it is a 4th real layer on top of this file's 3 (selection
+   result -> matchers -> ordered list), and the cross-namespace call
+   doesn't add to this file's own layer depth.
+
+   Layer 0: Selection-result construction
+   Layer 1: Individual rule matchers
+   Layer 2: Ordered rule list"
+  (:require
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.workflow-selection-config :as selection-config]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} selection-result
+  "Build a selection result from a logical profile."
+  [profile confidence reason]
+  {:selection-profile profile
+   :workflow-type (selection-config/resolve-selection-profile profile)
+   :confidence confidence
+   :reason reason})
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Rule matching
+(defn ^{:stratum 1} match-multi-phase-rule
+  "Multi-phase implementation → comprehensive profile"
+  [features]
+  (when (and (:pr-count features)
+             (>= (:pr-count features) 4))
+    (selection-result :comprehensive
+                      :high
+                      (messages/t :selector/reason-multi-phase
+                                  {:pr-count (:pr-count features)}))))
+
+(defn ^{:stratum 1} match-refactoring-stratification-rule
+  "Refactoring with stratification → comprehensive profile"
+  [features]
+  (when (and (or (= (:type features) :refactoring)
+                 (contains? (:keywords features) :refactoring))
+             (or (contains? (:keywords features) :stratified-design)
+                 (contains? (:constraint-mentions features) :rule-210)))
+    (selection-result :comprehensive
+                      :high
+                      (messages/t :selector/reason-refactoring-stratification))))
+
+(defn ^{:stratum 1} match-large-feature-rule
+  "Large feature → comprehensive profile"
+  [features]
+  (when (and (= (:size features) :large)
+             (not (contains? (:keywords features) :bugfix))
+             (not (contains? (:keywords features) :docs-only)))
+    (selection-result :comprehensive
+                      :medium
+                      (messages/t :selector/reason-large-feature))))
+
+(defn ^{:stratum 1} match-bugfix-rule
+  "Bug fix → fast profile"
+  [features]
+  (when (or (= (:type features) :bugfix)
+            (contains? (:keywords features) :bugfix))
+    (selection-result :fast
+                      :high
+                      (messages/t :selector/reason-bugfix))))
+
+(defn ^{:stratum 1} match-docs-only-rule
+  "Docs only → fast profile"
+  [features]
+  (when (or (= (:type features) :docs)
+            (contains? (:keywords features) :docs-only))
+    (selection-result :fast
+                      :high
+                      (messages/t :selector/reason-docs-only))))
+
+(defn ^{:stratum 1} match-unknown-rule
+  "Unknown/ambiguous → default profile"
+  [_features]
+  (selection-result :default
+                    :low
+                    (messages/t :selector/reason-unknown)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} selection-rules
+  "Ordered list of selection rules. First matching rule wins."
+  [match-multi-phase-rule
+   match-refactoring-stratification-rule
+   match-large-feature-rule
+   match-bugfix-rule
+   match-docs-only-rule
+   match-unknown-rule])

--- a/bases/cli/src/ai/miniforge/cli/workflow_selector/spec_analysis.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_selector/spec_analysis.clj
@@ -1,0 +1,157 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-selector.spec-analysis
+  "Spec feature extraction for workflow selection.
+
+   Split out of `ai.miniforge.cli.workflow-selector` (rule 210: the
+   combined namespace measured 5 real layers, max 3) — the extraction
+   primitives and their `analyze-spec` composition live here; rule
+   matching and the public selection entry points stay in the parent
+   namespace.
+
+   Layer 0: Field extraction primitives
+   Layer 1: Size estimation (composes keyword/PR-count extraction)
+   Layer 2: analyze-spec - full feature-map composition"
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Spec feature extraction
+(defn ^{:stratum 0} extract-type
+  "Extract task type from spec.
+   After normalization, :spec/intent is guaranteed to be set."
+  [spec]
+  (or (get-in spec [:spec/intent :type])
+      (get-in spec [:spec/raw-data :type])
+      :unknown))
+
+(defn ^{:stratum 0} extract-implementation-plan
+  "Extract implementation plan details from spec."
+  [spec]
+  (or (get-in spec [:spec/raw-data :implementation-plan])
+      (get-in spec [:spec/intent :implementation-plan])
+      (:implementation-plan spec)))
+
+(defn ^{:stratum 0} count-prs
+  "Count number of PRs/phases in implementation plan."
+  [impl-plan]
+  (when impl-plan
+    (count (filter (fn [[k _v]] (str/starts-with? (name k) "pr-"))
+                   impl-plan))))
+
+(defn ^{:stratum 0} has-dependencies?
+  "Check if implementation plan has dependencies between phases."
+  [impl-plan]
+  (when impl-plan
+    (some (fn [[_k v]]
+            (and (map? v)
+                 (or (seq (:dependencies v))
+                     (not-empty (:base v)))))
+          impl-plan)))
+
+(defn ^{:stratum 0} extract-description-keywords
+  "Extract significant keywords from spec description."
+  [spec]
+  (let [desc (str/lower-case (or (:spec/description spec) ""))
+        title (str/lower-case (or (:spec/title spec) ""))]
+    (set (concat
+          (when (or (str/includes? desc "refactor")
+                    (str/includes? title "refactor"))
+            [:refactoring])
+          (when (or (str/includes? desc "stratif")
+                    (str/includes? desc "layer"))
+            [:stratified-design])
+          (when (or (str/includes? desc "multi-phase")
+                    (str/includes? desc "multiple phase")
+                    (str/includes? desc "6 pr")
+                    (str/includes? desc "multi-pr"))
+            [:multi-phase])
+          (when (or (str/includes? desc "bug")
+                    (str/includes? desc "fix"))
+            [:bugfix])
+          (when (or (str/includes? desc "document")
+                    (str/includes? desc "docs only"))
+            [:docs-only])
+          (when (or (str/includes? desc "large")
+                    (str/includes? desc "complex")
+                    (str/includes? desc "comprehensive"))
+            [:large-scope])
+          (when (or (str/includes? desc "simple")
+                    (str/includes? desc "small")
+                    (str/includes? desc "quick"))
+            [:small-scope])))))
+
+(defn ^{:stratum 0} extract-constraints-mentions
+  "Extract constraint mentions from spec."
+  [spec]
+  (let [constraints (get spec :spec/constraints [])]
+    (set (concat
+          (when (some #(or (str/includes? (str/lower-case (str %)) "rule 720")
+                           (str/includes? (str/lower-case (str %)) "≤400"))
+                      constraints)
+            [:rule-720])
+          (when (some #(or (str/includes? (str/lower-case (str %)) "rule 210")
+                           (str/includes? (str/lower-case (str %)) "≤3 layer")
+                           (str/includes? (str/lower-case (str %)) "stratif"))
+                      constraints)
+            [:rule-210])
+          (when (some #(str/includes? (str/lower-case (str %)) "zero lint")
+                      constraints)
+            [:zero-linting])))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} estimate-size
+  "Estimate scope size from spec."
+  [spec impl-plan]
+  (let [keywords (extract-description-keywords spec)
+        pr-count (count-prs impl-plan)]
+    (cond
+      (and pr-count (>= pr-count 5)) :large
+      (contains? keywords :large-scope) :large
+      (contains? keywords :small-scope) :small
+      (and pr-count (>= pr-count 3)) :medium
+      :else :unknown)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} analyze-spec
+  "Analyze spec and extract decision features.
+
+   Returns map with:
+   - :type - Task type (:feature, :refactoring, :bugfix, :docs, etc.)
+   - :implementation-plan - Implementation plan structure
+   - :pr-count - Number of PRs/phases
+   - :has-dependencies? - Whether phases have dependencies
+   - :keywords - Set of extracted keywords
+   - :size - Estimated size (:small, :medium, :large, :unknown)
+   - :constraint-mentions - Set of mentioned constraints"
+  [spec]
+  (let [task-type (extract-type spec)
+        impl-plan (extract-implementation-plan spec)
+        pr-count (count-prs impl-plan)
+        keywords (extract-description-keywords spec)
+        size (estimate-size spec impl-plan)]
+    {:type task-type
+     :implementation-plan impl-plan
+     :pr-count pr-count
+     :has-dependencies? (has-dependencies? impl-plan)
+     :keywords keywords
+     :size size
+     :constraint-mentions (extract-constraints-mentions spec)}))

--- a/bases/cli/src/ai/miniforge/cli/workflow_selector/spec_analysis.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_selector/spec_analysis.clj
@@ -155,3 +155,14 @@
      :keywords keywords
      :size size
      :constraint-mentions (extract-constraints-mentions spec)}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (analyze-spec {:spec/title "Fix authentication timeout"
+                 :spec/description "Fix bug where auth token expires too quickly"
+                 :spec/intent {:type :bugfix}})
+  ;; => {:type :bugfix, :implementation-plan nil, :pr-count nil,
+  ;;     :has-dependencies? nil, :keywords #{:bugfix}, :size :unknown,
+  ;;     :constraint-mentions #{}}
+
+  :end)

--- a/docs/pull-requests/2026-08-12-refactor-split-cli-workflow-selector.md
+++ b/docs/pull-requests/2026-08-12-refactor-split-cli-workflow-selector.md
@@ -37,10 +37,11 @@ own test namespace) is one of this batch.
   reported the file back over budget after an initial attempt at
   keeping it in this file).
 - `workflow_selector.clj` (parent): `explain-selection`, an
-  `analyze-spec` re-export (`def` pointing at `spec-analysis/analyze-
-  spec`), and `match-rule` (real implementation — `(some (fn [rule-fn]
-  (rule-fn features)) rules/selection-rules)`) at layer 0, plus
-  `select-workflow` at layer 1. `match-rule` stays here rather than in
+  `analyze-spec` re-export (`def` pointing at
+  `spec-analysis/analyze-spec`), and `match-rule` (real
+  implementation — `(some (fn [rule-fn] (rule-fn features))
+  rules/selection-rules)`) at layer 0, plus `select-workflow` at
+  layer 1. `match-rule` stays here rather than in
   `rules.clj` because the cross-namespace call to
   `rules/selection-rules` doesn't add to *this* file's own layer
   depth — the same technique `loader.clj`'s rule-210 split used

--- a/docs/pull-requests/2026-08-12-refactor-split-cli-workflow-selector.md
+++ b/docs/pull-requests/2026-08-12-refactor-split-cli-workflow-selector.md
@@ -1,0 +1,109 @@
+<!--
+  Title: Split cli/workflow_selector.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(cli): split workflow_selector.clj (rule 210)
+
+## Overview
+
+Splits spec-feature-extraction and rule-matching out of
+`ai.miniforge.cli.workflow-selector` into two new sibling namespaces,
+`ai.miniforge.cli.workflow-selector.spec-analysis` and
+`ai.miniforge.cli.workflow-selector.rules`, resolving a stratum-lint
+SL003 finding (the combined namespace measured 5 real layers, over
+the rule 210 budget of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program, `bases/cli`
+batch. `workflow_selector.clj` (274 lines, one caller repo-wide — its
+own test namespace) is one of this batch.
+
+## Changes in Detail
+
+- New file `workflow_selector/spec_analysis.clj`: the extraction
+  primitives (`extract-type`, `extract-implementation-plan`,
+  `count-prs`, `has-dependencies?`, `extract-description-keywords`,
+  `extract-constraints-mentions`), `estimate-size`, and their
+  composition `analyze-spec` — 3 layers.
+- New file `workflow_selector/rules.clj`: `selection-result`, the six
+  individual rule matchers (`match-multi-phase-rule` ...
+  `match-unknown-rule`), and the ordered `selection-rules` list — 3
+  layers. `match-rule` itself does **not** live here: dispatching over
+  `selection-rules` is a 4th real layer on top of these 3 (confirmed
+  by `stratum-lint --fix`, which relabeled it `^{:stratum 3}` and
+  reported the file back over budget after an initial attempt at
+  keeping it in this file).
+- `workflow_selector.clj` (parent): `explain-selection`, an
+  `analyze-spec` re-export (`def` pointing at `spec-analysis/analyze-
+  spec`), and `match-rule` (real implementation — `(some (fn [rule-fn]
+  (rule-fn features)) rules/selection-rules)`) at layer 0, plus
+  `select-workflow` at layer 1. `match-rule` stays here rather than in
+  `rules.clj` because the cross-namespace call to
+  `rules/selection-rules` doesn't add to *this* file's own layer
+  depth — the same technique `loader.clj`'s rule-210 split used
+  (miniforge#1772).
+- Kept as the single public entry point (rather than moving
+  `analyze-spec`/`match-rule` calls to `ws/spec-analysis`,
+  `ws/rules` at every call site) so the existing test namespace
+  (`bases/cli/test/.../workflow_selector_test.clj`, which calls
+  `ws/explain-selection`, `ws/analyze-spec`, `ws/match-rule`, and
+  `ws/select-workflow`) needed no changes.
+
+This is pure code motion — no behavior or detection-logic changes.
+
+## Testing Plan
+
+- `stratum-lint` clean on all three touched/new source files (`bb -m
+  stratum-lint.interface` exit 0; `--fix` made no further changes,
+  confirming the declared `^{:stratum N}` annotations match the real
+  computed layer depths).
+- `clj-kondo` clean (0 errors, 0 warnings).
+- Direct namespace verification (not just pre-commit smoke, per
+  program lesson to distrust `bb test` alone under load):
+  `clojure -M:dev:test -e "(require 'ai.miniforge.cli.workflow-
+  selector) (require 'ai.miniforge.cli.workflow-selector-test)
+  (clojure.test/run-tests 'ai.miniforge.cli.workflow-selector-test)"`
+  — 6 tests, 75 assertions, 0 failures/errors.
+- Full pre-commit gate (345 tests / 1301 assertions on the
+  change-scope smoke suite, plus 8 GraalVM/Babashka compatibility
+  tests) passed on the final wire-up commit.
+- Repo-wide grep for the fully-qualified namespace
+  (`ai\.miniforge\.cli\.workflow-selector\b`) across `components/`,
+  `bases/`, and `projects/` found exactly one caller —
+  `bases/cli/test/ai/miniforge/cli/workflow_selector_test.clj` — which
+  needed no changes since the parent namespace's public API
+  (`explain-selection`, `analyze-spec`, `match-rule`, `select-workflow`)
+  is unchanged.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file.
+`workflow_selection_config.clj` (a separate SL003 finding in the same
+directory) was being split concurrently by a sibling task — this PR
+does not touch it, though `workflow_selector.clj` requires it (via
+`rules.clj` now) and that require path was double-checked to still
+resolve correctly.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 remediation program, `bases/cli`
+  batch (see miniforge#1772 `loader.clj` and miniforge#1731
+  `knowledge_safety.clj` for the established convention this follows,
+  including the "cross-namespace calls don't count toward local layer
+  depth" technique used to keep `match-rule` in the parent file).
+
+## Checklist
+
+- [x] stratum-lint clean on all resulting files (plain check and
+      `--fix` agree, exit 0)
+- [x] Direct `clojure -M:dev:test` run green on the affected test
+      namespace (not just pre-commit smoke)
+- [x] Adversarial self-review: public API of the parent namespace
+      unchanged (all four functions the test namespace calls still
+      resolve there)
+- [x] Zero fan-in confirmed repo-wide (components/bases/projects)
+      before starting; the one caller found needed no changes
+- [x] Pure code motion — no detection/selection logic changed


### PR DESCRIPTION
## Overview

Splits spec-feature-extraction and rule-matching out of
`ai.miniforge.cli.workflow-selector` into two new sibling namespaces,
`ai.miniforge.cli.workflow-selector.spec-analysis` and
`ai.miniforge.cli.workflow-selector.rules`, resolving a stratum-lint
SL003 finding (the combined namespace measured 5 real layers, over
the rule 210 budget of 3).

Full details, testing plan, and deployment notes:
`docs/pull-requests/2026-08-12-refactor-split-cli-workflow-selector.md`

Part of the stratum-lint rule-210 remediation program, `bases/cli`
batch.

## Commit-budget note

The wire-up commit (`a85f1adc8`) used
`MINIFORGE_COMMIT_BUDGET_OVERRIDE`: `workflow_selector.clj` only drops
below the 3-layer SL003 budget once both the spec-analysis delegation
and the rules delegation land together — either alone still leaves a
4-5-layer local chain through `select-workflow`. Splitting further
would leave an intermediate commit that still fails the same
stratum-lint gate this PR exists to fix. Same pattern as PR #1772
(`loader.clj` wire commit, 363 reportable lines in one commit). PR-level
total stays well under the 600-line `pr-budget` ceiling.

## Testing

- `stratum-lint` clean on all three files (plain check and `--fix` agree, exit 0)
- `clj-kondo` clean (0 errors, 0 warnings)
- Direct `clojure -M:dev:test` run on `ai.miniforge.cli.workflow-selector-test` — 6 tests, 75 assertions, 0 failures/errors
- Full pre-commit gate (345 tests / 1301 assertions + 8 GraalVM/Babashka compat tests) green on the final commits
- Repo-wide grep for `ai\.miniforge\.cli\.workflow-selector\b` across `components/`, `bases/`, `projects/` found exactly one caller (the test namespace), which needed no changes

Pure code motion — no behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)