### PR TITLE
fix(cli): finish workflow_selector docstring/PR-doc polish

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_selector.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_selector.clj
@@ -101,6 +101,7 @@
   "Select appropriate workflow based on spec analysis.
 
    Returns map with:
+   - :selection-profile - Logical profile the rule matched (:comprehensive, :fast, or :default)
    - :workflow-type - Selected workflow keyword
    - :confidence - :high, :medium, or :low
    - :reason - Human-readable explanation

--- a/docs/pull-requests/2026-08-12-refactor-split-cli-workflow-selector.md
+++ b/docs/pull-requests/2026-08-12-refactor-split-cli-workflow-selector.md
@@ -63,11 +63,13 @@ This is pure code motion — no behavior or detection-logic changes.
   computed layer depths).
 - `clj-kondo` clean (0 errors, 0 warnings).
 - Direct namespace verification (not just pre-commit smoke, per
-  program lesson to distrust `bb test` alone under load):
-  `clojure -M:dev:test -e "(require 'ai.miniforge.cli.workflow-
-  selector) (require 'ai.miniforge.cli.workflow-selector-test)
-  (clojure.test/run-tests 'ai.miniforge.cli.workflow-selector-test)"`
-  — 6 tests, 75 assertions, 0 failures/errors.
+  program lesson to distrust `bb test` alone under load) — 6 tests, 75
+  assertions, 0 failures/errors:
+
+  ```sh
+  clojure -M:dev:test -e "(require 'ai.miniforge.cli.workflow-selector) (require 'ai.miniforge.cli.workflow-selector-test) (clojure.test/run-tests 'ai.miniforge.cli.workflow-selector-test)"
+  ```
+
 - Full pre-commit gate (345 tests / 1301 assertions on the
   change-scope smoke suite, plus 8 GraalVM/Babashka compatibility
   tests) passed on the final wire-up commit.


### PR DESCRIPTION
Small follow-up to #1790, which the repo's auto-merge bot merged
(5836b2e1c) before this second round of GitHub Copilot's *suppressed*
(informational, not blocking) comments landed on the branch:

- `select-workflow` docstring now lists `:selection-profile` too —
  same omission class as `match-rule`'s docstring, already fixed for
  `match-rule` in #1790 itself.
- PR doc: fixes a second markdown line-wrap issue in the Testing
  Plan's `clojure -M:dev:test` invocation — moved to a fenced code
  block (language tag + surrounding blank lines, per markdownlint
  MD040/MD031) instead of a wrapped inline code span.

Docs-only + a docstring addition; no behavior change. Verified:
`clj-kondo` clean, `stratum-lint` clean, `markdownlint` clean, full
pre-commit gate green (345 tests / 1301 assertions + 8 GraalVM compat
tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)