### PR TITLE
fix(deploy): bind exact runtime authority

### DIFF
--- a/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
+++ b/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
@@ -58,6 +58,8 @@
   "Creating {creates} resources (limit: {limit})"
   :policy/gke-node-limit
   "Creating {node-pools} node pools (limit: {limit})"
+  :policy/provision-preview-required
+  "A successful Pulumi provision preview is required before deployment"
 
   :shell/command-timeout
   "Command timed out after {timeout-ms}ms"

--- a/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
+++ b/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
@@ -11,6 +11,7 @@
   :deploy/starting               "Starting application deployment"
   :deploy/invalid-config         "Deploy configuration invalid: {error}"
   :deploy/context-unavailable    "Kubernetes current context unavailable"
+  :deploy/render-failed          "Kustomize render failed"
   :deploy/applied                "Manifests applied to cluster"
   :deploy/rollout-failed         "Deployment rollout failed"
   :deploy/complete               "Application deployment complete"

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
@@ -16,18 +16,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.phase-deployment.deploy-authority
-  "Authority for one exact Kubernetes deployment (Ariadne step 2d).
-
-   Mirrors `pr-lifecycle.merge-authority`: issue a narrow runtime-owned
-   grant, authorize the concrete scope, and decide. The runtime is the
-   principal — a phase may request a deployment, it cannot mint the
-   authority to perform one.
-
-   The preflight basis here is deployment's own: the provider dry-run
-   plus the existing `check-resource-count` and `check-gke-node-limit`.
-   Those checks already existed and were never consulted before an
-   apply; wiring them as the issuance basis is why this component reuses
-   rather than reinvents them."
+  "Runtime authority preparation for one exact Kubernetes deployment."
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.execution-grant.interface :as grant]
@@ -39,43 +28,66 @@
 ;------------------------------------------------------------------------------ Layer 0
 
 (def ^{:stratum 0} allow-decisions
-  "Envelope decisions that permit the apply. `:allow-with-obligations`
-   is included: obligations are recorded, not blocking."
   #{:allow :allow-with-obligations})
 
 (def ^{:stratum 0} empty-classification
-  "No policy-pack violations to classify — deployment's preflight is its
-   own dry-run plus the resource checks, folded in as the grant basis."
-  {:blocking [] :require-approval [] :warnings [] :audits [] :unknown []})
+  {:blocking []
+   :require-approval []
+   :warnings []
+   :audits []
+   :unknown []})
 
-(def ^{:stratum 0} unpinned-policy
-  {:pins/pack-revision nil :pins/rule-ids [] :pins/event-watermark nil})
+(def ^{:stratum 0} deployment-policy-pins
+  {:pins/pack-revision nil
+   :pins/rule-ids [:deploy/resource-count-limit :deploy/gke-node-limit]
+   :pins/event-watermark nil})
 
-(defn ^{:stratum 0} breach-dir
-  [context]
-  (or (:grant-breach-dir context)
-      (str (System/getProperty "user.home") "/.miniforge/grants")))
+(def ^{:stratum 0} default-breach-dir-property
+  ".miniforge/grant-breaches")
 
-(defn ^{:stratum 0} preflight
-  "Run the deployment checks that must precede a mutation, over the
-   provider's dry-run render.
+(defn- ^{:stratum 0} policy-warning
+  [violation]
+  {:rule-id (:violation/rule-id violation)
+   :message (:violation/message violation)})
 
-   Returns `{:preflight/result :allow|:deny :preflight/violations [...]
-   :preflight/rendered s}`. A dry-run that did not render is `:deny` —
-   we cannot show the apply is safe, and unverifiable is denied."
-  [rendered check-context]
-  (if (clojure.string/blank? (str rendered))
-    {:preflight/result :deny
-     :preflight/violations []
-     :preflight/rendered nil}
-    (let [violations (remove nil?
-                             [(policy/check-resource-count rendered check-context)
-                              (policy/check-gke-node-limit rendered check-context)])]
-      {:preflight/result (if (seq violations) :deny :allow)
-       :preflight/violations (vec violations)
-       :preflight/rendered rendered})))
+(defn- ^{:stratum 0} effect-scope
+  [request]
+  (dissoc request :workflow-run/status :effect/class :effect/preflight
+          :default-context))
+
+(defn ^{:stratum 0} request
+  "Build the closed runtime request for one preflight-approved deployment."
+  [context effect-id target]
+  {:workflow-run/id (:execution/id context)
+   :workflow-run/status :running
+   :effect/id effect-id
+   :effect/class :effect/deploy
+   :effect/preflight {:preflight/type :preflight/deploy-policy-and-dry-run
+                      :preflight/result :allow}
+   :kustomize-dir (:kustomize-dir target)
+   :context (:context target)
+   :default-context (:context target)
+   :namespace (:namespace target)
+   :deployment-name (:deployment-name target)})
 
 ;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} breach-dir
+  [context]
+  (or (:grant-breach-dir context)
+      (str (System/getProperty "user.home") "/" default-breach-dir-property)))
+
+(defn ^{:stratum 1} policy-classification
+  "Evaluate deployment policy against the Pulumi preview it was defined for."
+  [context target]
+  (let [preview (get-in context
+                        [:execution/phase-results :provision :result :output]
+                        {})
+        policy-context (:phase-config target)
+        violations (keep identity
+                         [(policy/check-resource-count preview policy-context)
+                          (policy/check-gke-node-limit preview policy-context)])]
+    (assoc empty-classification :warnings (mapv policy-warning violations))))
 
 (defn ^{:stratum 1} permitted?
   "True only when the grant check and the DecisionEnvelope both allow."
@@ -83,41 +95,36 @@
   (and (grant/authorized? authorization)
        (contains? allow-decisions (:envelope/decision envelope))))
 
-(defn ^{:stratum 1} prepare
-  "Issue, authorize, and decide authority for a preflight-approved
-   deployment. Returns an authority record, or the issuer's anomaly when
-   authority cannot be established at all."
-  [context effect-id deploy-config preflight-result ^Instant now]
-  (let [{:keys [kustomize-dir namespace context-name default-context
-                deployment-name]} deploy-config
-        request {:workflow-run/id (:run-id context)
-                 :workflow-run/status :running
-                 :effect/id effect-id
-                 :effect/class :effect/deploy
-                 :effect/preflight
-                 {:preflight/type :preflight/deploy-policy-and-dry-run
-                  :preflight/result preflight-result}
-                 :kustomize-dir kustomize-dir
-                 :context context-name
-                 :default-context default-context
-                 :namespace namespace
-                 :deployment-name deployment-name}
+(defn- ^{:stratum 1} authority-record
+  [request classification grant-record authorization envelope preflight]
+  {:effect/id (:effect/id request)
+   :effect/proposal
+   (merge (effect-scope request)
+          {:app-label (:app-label preflight)
+           :deploy/rendered-yaml (:rendered-yaml preflight)
+           :deploy/server-dry-run (:server-dry-run preflight)
+           :deploy/rollback-info (:rollback-info preflight)})
+   :authority/grant grant-record
+   :authority/authorization authorization
+   :authority/envelope envelope
+   :authority/policy classification})
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} prepare
+  "Evaluate policy, issue exact authority, and derive one deploy decision."
+  [context effect-id target preflight ^Instant now]
+  (let [request (request context effect-id target)
+        classification (policy-classification context target)
         grant-record (grant/issue-for-effect (breach-dir context) request now)]
     (if (anomaly/anomaly? grant-record)
       grant-record
-      (let [scope {:effect/id effect-id
-                   :workflow-run/id (:run-id context)
-                   :kustomize-dir kustomize-dir
-                   :context (or context-name default-context)
-                   :namespace namespace
-                   :deployment-name deployment-name}
-            authorization (grant/authorize grant-record
-                                           {:effect/scope scope :usage/count 1}
-                                           now)
-            envelope (gate/decide empty-classification unpinned-policy
+      (let [authorization (grant/authorize
+                           grant-record
+                           {:effect/scope (effect-scope request)
+                            :usage/count 1}
+                           now)
+            envelope (gate/decide classification deployment-policy-pins
                                   authorization)]
-        {:effect/id effect-id
-         :effect/proposal scope
-         :authority/grant grant-record
-         :authority/authorization authorization
-         :authority/envelope envelope}))))
+        (authority-record request classification grant-record authorization
+                          envelope preflight)))))

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
@@ -151,9 +151,18 @@
         preflight (if (map? preflight) preflight {})
         request (request context effect-id target)
         classification (policy-classification context target)
-        grant-record (grant/issue-for-effect (breach-dir context) request now)]
-    (if (anomaly/anomaly? grant-record)
+        policy-envelope (gate/decide classification deployment-policy-pins)
+        policy-allowed? (gate/decision-allowed? policy-envelope)
+        grant-record (when policy-allowed?
+                       (grant/issue-for-effect (breach-dir context) request now))]
+    (cond
+      (not policy-allowed?)
+      (authority-record request classification nil nil policy-envelope preflight)
+
+      (anomaly/anomaly? grant-record)
       grant-record
+
+      :else
       (let [authorization (grant/authorize
                            grant-record
                            {:effect/scope (effect-scope request)

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
@@ -44,7 +44,7 @@
    :pins/rule-ids [:deploy/resource-count-limit :deploy/gke-node-limit]
    :pins/event-watermark nil})
 
-(def ^{:stratum 0} default-breach-dir-property
+(def ^{:stratum 0} default-breach-dir-relative-path
   ".miniforge/grant-breaches")
 
 (defn- ^{:stratum 0} policy-blocker
@@ -111,7 +111,8 @@
 (defn ^{:stratum 1} breach-dir
   [context]
   (or (:grant-breach-dir context)
-      (str (System/getProperty "user.home") "/" default-breach-dir-property)))
+      (str (System/getProperty "user.home") "/"
+           default-breach-dir-relative-path)))
 
 (defn ^{:stratum 1} policy-classification
   "Evaluate deployment policy against the Pulumi preview it was defined for."

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
@@ -47,7 +47,7 @@
 (def ^{:stratum 0} default-breach-dir-property
   ".miniforge/grant-breaches")
 
-(defn- ^{:stratum 0} policy-warning
+(defn- ^{:stratum 0} policy-blocker
   [violation]
   {:rule-id (:violation/rule-id violation)
    :message (:violation/message violation)})
@@ -122,7 +122,7 @@
           violations (keep identity
                            [(policy/check-resource-count preview policy-context)
                             (policy/check-gke-node-limit preview policy-context)])]
-      (assoc empty-classification :warnings (mapv policy-warning violations)))
+      (assoc empty-classification :blocking (mapv policy-blocker violations)))
     (assoc empty-classification :blocking [(missing-preview-violation)])))
 
 (defn ^{:stratum 1} permitted?

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
@@ -127,8 +127,9 @@
 
 (defn ^{:stratum 1} permitted?
   "True only when the grant check and the DecisionEnvelope both allow."
-  [{:authority/keys [authorization envelope]}]
-  (and (grant/authorized? authorization)
+  [{:authority/keys [grant authorization envelope]}]
+  (and (some? grant)
+       (grant/authorized? authorization)
        (contains? allow-decisions (:envelope/decision envelope))))
 
 (defn- ^{:stratum 1} authority-record

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
@@ -21,7 +21,8 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.execution-grant.interface :as grant]
    [ai.miniforge.gate.interface :as gate]
-   [ai.miniforge.phase-deployment.policy :as policy])
+   [ai.miniforge.phase-deployment.policy :as policy]
+   [clojure.string :as str])
   (:import
    [java.time Instant]))
 
@@ -58,7 +59,7 @@
 (defn ^{:stratum 0} request
   "Build the closed runtime request for one preflight-approved deployment."
   [context effect-id target]
-  {:workflow-run/id (:execution/id context)
+  {:workflow-run/id (or (:execution/id context) (:run-id context))
    :workflow-run/status :running
    :effect/id effect-id
    :effect/class :effect/deploy
@@ -69,6 +70,24 @@
    :default-context (:context target)
    :namespace (:namespace target)
    :deployment-name (:deployment-name target)})
+
+(defn- ^{:stratum 0} exact-target
+  [target]
+  (assoc target :context (or (:context target)
+                             (:context-name target)
+                             (:default-context target))))
+
+(defn ^{:stratum 0} preflight
+  "Retain the decision input used by the not-yet-wired governed seam."
+  [rendered policy-context]
+  (if (str/blank? (str rendered))
+    {:preflight/result :deny :preflight/violations [] :preflight/rendered nil}
+    (let [violations (keep identity
+                           [(policy/check-resource-count rendered policy-context)
+                            (policy/check-gke-node-limit rendered policy-context)])]
+      {:preflight/result (if (seq violations) :deny :allow)
+       :preflight/violations (vec violations)
+       :preflight/rendered rendered})))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -114,7 +133,9 @@
 (defn ^{:stratum 2} prepare
   "Evaluate policy, issue exact authority, and derive one deploy decision."
   [context effect-id target preflight ^Instant now]
-  (let [request (request context effect-id target)
+  (let [target (exact-target target)
+        preflight (if (map? preflight) preflight {})
+        request (request context effect-id target)
         classification (policy-classification context target)
         grant-record (grant/issue-for-effect (breach-dir context) request now)]
     (if (anomaly/anomaly? grant-record)

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
@@ -56,6 +56,18 @@
   (dissoc request :workflow-run/status :effect/class :effect/preflight
           :default-context))
 
+(defn- ^{:stratum 0} preflight-evidence
+  [preflight]
+  (reduce-kv (fn [evidence source-key proposal-key]
+               (if-some [value (get preflight source-key)]
+                 (assoc evidence proposal-key value)
+                 evidence))
+             {}
+             {:app-label :app-label
+              :rendered-yaml :deploy/rendered-yaml
+              :server-dry-run :deploy/server-dry-run
+              :rollback-info :deploy/rollback-info}))
+
 (defn ^{:stratum 0} request
   "Build the closed runtime request for one preflight-approved deployment."
   [context effect-id target]
@@ -67,7 +79,7 @@
                       :preflight/result :allow}
    :kustomize-dir (:kustomize-dir target)
    :context (:context target)
-   :default-context (:context target)
+   :default-context (or (:default-context target) (:context target))
    :namespace (:namespace target)
    :deployment-name (:deployment-name target)})
 
@@ -119,10 +131,7 @@
   {:effect/id (:effect/id request)
    :effect/proposal
    (merge (effect-scope request)
-          {:app-label (:app-label preflight)
-           :deploy/rendered-yaml (:rendered-yaml preflight)
-           :deploy/server-dry-run (:server-dry-run preflight)
-           :deploy/rollback-info (:rollback-info preflight)})
+          (preflight-evidence preflight))
    :authority/grant grant-record
    :authority/authorization authorization
    :authority/envelope envelope

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
@@ -21,6 +21,7 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.execution-grant.interface :as grant]
    [ai.miniforge.gate.interface :as gate]
+   [ai.miniforge.phase-deployment.messages :as msg]
    [ai.miniforge.phase-deployment.policy :as policy]
    [clojure.string :as str])
   (:import
@@ -50,6 +51,11 @@
   [violation]
   {:rule-id (:violation/rule-id violation)
    :message (:violation/message violation)})
+
+(defn- ^{:stratum 0} missing-preview-violation
+  []
+  {:rule-id :deploy/provision-preview-required
+   :message (msg/t :policy/provision-preview-required)})
 
 (defn- ^{:stratum 0} effect-scope
   [request]
@@ -90,16 +96,13 @@
                              (:default-context target))))
 
 (defn ^{:stratum 0} preflight
-  "Retain the decision input used by the not-yet-wired governed seam."
-  [rendered policy-context]
+  "Reject an absent manifest at the legacy governed-deploy seam."
+  [rendered _policy-context]
   (if (str/blank? (str rendered))
     {:preflight/result :deny :preflight/violations [] :preflight/rendered nil}
-    (let [violations (keep identity
-                           [(policy/check-resource-count rendered policy-context)
-                            (policy/check-gke-node-limit rendered policy-context)])]
-      {:preflight/result (if (seq violations) :deny :allow)
-       :preflight/violations (vec violations)
-       :preflight/rendered rendered})))
+    {:preflight/result :allow
+     :preflight/violations []
+     :preflight/rendered rendered}))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -111,14 +114,14 @@
 (defn ^{:stratum 1} policy-classification
   "Evaluate deployment policy against the Pulumi preview it was defined for."
   [context target]
-  (let [preview (get-in context
-                        [:execution/phase-results :provision :result :output]
-                        {})
-        policy-context (:phase-config target)
-        violations (keep identity
-                         [(policy/check-resource-count preview policy-context)
-                          (policy/check-gke-node-limit preview policy-context)])]
-    (assoc empty-classification :warnings (mapv policy-warning violations))))
+  (if-some [preview (get-in context
+                            [:execution/phase-results :provision :result :output])]
+    (let [policy-context (:phase-config target)
+          violations (keep identity
+                           [(policy/check-resource-count preview policy-context)
+                            (policy/check-gke-node-limit preview policy-context)])]
+      (assoc empty-classification :warnings (mapv policy-warning violations)))
+    (assoc empty-classification :blocking [(missing-preview-violation)])))
 
 (defn ^{:stratum 1} permitted?
   "True only when the grant check and the DecisionEnvelope both allow."

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
@@ -99,7 +99,9 @@
   "Reject an absent manifest at the legacy governed-deploy seam."
   [rendered _policy-context]
   (if (str/blank? (str rendered))
-    {:preflight/result :deny :preflight/violations [] :preflight/rendered nil}
+    {:preflight/result :deny
+     :preflight/violations [(msg/t :deploy/render-failed)]
+     :preflight/rendered nil}
     {:preflight/result :allow
      :preflight/violations []
      :preflight/rendered rendered}))

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_governed.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_governed.clj
@@ -55,6 +55,12 @@
    :deploy/failure detail
    :deploy/refusal code})
 
+(defn- ^{:stratum 0} authority-evidence
+  [deploy-config preflight rollback-info]
+  {:app-label (:app-label deploy-config)
+   :rendered-yaml (:preflight/rendered preflight)
+   :rollback-info rollback-info})
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} propose!
@@ -111,7 +117,9 @@
                     (pr-str (:preflight/violations pre))))
       (let [rollback-info ((:rollback-info! provider) deploy-config)
             auth (authority/prepare context (random-uuid) deploy-config
-                                    (:preflight/result pre) now)]
+                                    (authority-evidence deploy-config pre
+                                                        rollback-info)
+                                    now)]
         (cond
           (anomaly/anomaly? auth)
           (refusal :authority :deploy/authority-unavailable (:anomaly/message auth))

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_authority_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_authority_test.clj
@@ -17,6 +17,7 @@
 ;; limitations under the License.
 (ns ai.miniforge.phase-deployment.deploy-authority-test
   (:require
+   [ai.miniforge.execution-grant.interface :as grant]
    [ai.miniforge.phase-deployment.deploy-authority :as authority]
    [ai.miniforge.phase-deployment.policy :as policy]
    [clojure.test :refer [deftest is]])
@@ -86,10 +87,13 @@
   (with-redefs [policy/check-resource-count
                 (fn [& _] {:violation/rule-id :deploy/resource-count-limit
                            :violation/message "limit exceeded"})
-                policy/check-gke-node-limit (constantly nil)]
+                policy/check-gke-node-limit (constantly nil)
+                grant/issue-for-effect
+                (fn [& _] (throw (ex-info "grant must not be issued" {})))]
     (let [prepared (authority/prepare (context) (random-uuid)
                                       target preflight now)]
       (is (not (authority/permitted? prepared)))
+      (is (nil? (:authority/grant prepared)))
       (is (= [:deploy/resource-count-limit]
              (mapv :rule-id
                    (get-in prepared [:authority/policy :blocking])))))))

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_authority_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_authority_test.clj
@@ -38,6 +38,9 @@
    :deployment-name "api"
    :phase-config {}})
 
+(def ^{:stratum 0} provision-preview
+  {:steps []})
+
 (def ^{:stratum 0} preflight
   {:app-label "api"
    :rendered-yaml "manifest"
@@ -49,7 +52,7 @@
 (defn- ^{:stratum 1} context
   []
   {:execution/id run-id
-   :execution/phase-results {:provision {:result {:output "preview"}}}
+   :execution/phase-results {:provision {:result {:output provision-preview}}}
    :grant-breach-dir
    (str (.toFile
          (Files/createTempDirectory "grant" (into-array FileAttribute []))))})
@@ -70,6 +73,15 @@
                   [:app-label :deploy/rendered-yaml
                    :deploy/server-dry-run :deploy/rollback-info]))))
 
+(deftest ^{:stratum 2} prepare-denies-when-provision-preview-is-absent-test
+  (let [prepared (authority/prepare
+                  (dissoc (context) :execution/phase-results)
+                  (random-uuid) target preflight now)]
+    (is (not (authority/permitted? prepared)))
+    (is (= :deny (get-in prepared [:authority/envelope :envelope/decision])))
+    (is (= [:deploy/provision-preview-required]
+           (mapv :rule-id (get-in prepared [:authority/policy :blocking]))))))
+
 (deftest ^{:stratum 2} prepare-records-policy-and-preflight-basis-test
   (let [checked (atom [])]
     (with-redefs [policy/check-resource-count
@@ -79,7 +91,8 @@
       (let [prepared (authority/prepare (context) (random-uuid)
                                         target preflight now)]
         (is (authority/permitted? prepared))
-        (is (= [[:resources "preview"] [:nodes "preview"]] @checked))
+        (is (= [[:resources provision-preview] [:nodes provision-preview]]
+               @checked))
         (is (= "manifest"
                (get-in prepared [:effect/proposal :deploy/rendered-yaml])))
         (is (= "validated"

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_authority_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_authority_test.clj
@@ -107,6 +107,7 @@
       (let [prepared (authority/prepare (context) (random-uuid)
                                         target preflight now)]
         (is (authority/permitted? prepared))
+        (is (not (authority/permitted? (assoc prepared :authority/grant nil))))
         (is (= [[:resources provision-preview] [:nodes provision-preview]]
                @checked))
         (is (= "manifest"

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_authority_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_authority_test.clj
@@ -57,10 +57,18 @@
 ;------------------------------------------------------------------------------ Layer 2
 
 (deftest ^{:stratum 2} request-binds-canonical-run-and-exact-target-test
-  (let [request (authority/request (context) (random-uuid) target)]
+  (let [request (authority/request (context) (random-uuid)
+                                   (assoc target :default-context "audit"))]
     (is (= run-id (:workflow-run/id request)))
     (is (= "gke-prod" (:context request)))
-    (is (= "gke-prod" (:default-context request)))))
+    (is (= "audit" (:default-context request)))))
+
+(deftest ^{:stratum 2} prepare-omits-unrecorded-preflight-evidence-test
+  (let [proposal (:effect/proposal
+                  (authority/prepare (context) (random-uuid) target {} now))]
+    (is (not-any? #(contains? proposal %)
+                  [:app-label :deploy/rendered-yaml
+                   :deploy/server-dry-run :deploy/rollback-info]))))
 
 (deftest ^{:stratum 2} prepare-records-policy-and-preflight-basis-test
   (let [checked (atom [])]

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_authority_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_authority_test.clj
@@ -82,6 +82,18 @@
     (is (= [:deploy/provision-preview-required]
            (mapv :rule-id (get-in prepared [:authority/policy :blocking]))))))
 
+(deftest ^{:stratum 2} prepare-denies-policy-violations-test
+  (with-redefs [policy/check-resource-count
+                (fn [& _] {:violation/rule-id :deploy/resource-count-limit
+                           :violation/message "limit exceeded"})
+                policy/check-gke-node-limit (constantly nil)]
+    (let [prepared (authority/prepare (context) (random-uuid)
+                                      target preflight now)]
+      (is (not (authority/permitted? prepared)))
+      (is (= [:deploy/resource-count-limit]
+             (mapv :rule-id
+                   (get-in prepared [:authority/policy :blocking])))))))
+
 (deftest ^{:stratum 2} prepare-records-policy-and-preflight-basis-test
   (let [checked (atom [])]
     (with-redefs [policy/check-resource-count

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_authority_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_authority_test.clj
@@ -1,0 +1,83 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-deployment.deploy-authority-test
+  (:require
+   [ai.miniforge.phase-deployment.deploy-authority :as authority]
+   [ai.miniforge.phase-deployment.policy :as policy]
+   [clojure.test :refer [deftest is]])
+  (:import
+   [java.nio.file Files]
+   [java.nio.file.attribute FileAttribute]
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} now (Instant/parse "2026-08-01T00:00:00Z"))
+
+(def ^{:stratum 0} run-id (random-uuid))
+
+(def ^{:stratum 0} target
+  {:kustomize-dir "/repo/k8s"
+   :context "gke-prod"
+   :namespace "prod"
+   :deployment-name "api"
+   :phase-config {}})
+
+(def ^{:stratum 0} preflight
+  {:app-label "api"
+   :rendered-yaml "manifest"
+   :server-dry-run "validated"
+   :rollback-info {:revision "3"}})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} context
+  []
+  {:execution/id run-id
+   :execution/phase-results {:provision {:result {:output "preview"}}}
+   :grant-breach-dir
+   (str (.toFile
+         (Files/createTempDirectory "grant" (into-array FileAttribute []))))})
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} request-binds-canonical-run-and-exact-target-test
+  (let [request (authority/request (context) (random-uuid) target)]
+    (is (= run-id (:workflow-run/id request)))
+    (is (= "gke-prod" (:context request)))
+    (is (= "gke-prod" (:default-context request)))))
+
+(deftest ^{:stratum 2} prepare-records-policy-and-preflight-basis-test
+  (let [checked (atom [])]
+    (with-redefs [policy/check-resource-count
+                  (fn [preview _] (swap! checked conj [:resources preview]) nil)
+                  policy/check-gke-node-limit
+                  (fn [preview _] (swap! checked conj [:nodes preview]) nil)]
+      (let [prepared (authority/prepare (context) (random-uuid)
+                                        target preflight now)]
+        (is (authority/permitted? prepared))
+        (is (= [[:resources "preview"] [:nodes "preview"]] @checked))
+        (is (= "manifest"
+               (get-in prepared [:effect/proposal :deploy/rendered-yaml])))
+        (is (= "validated"
+               (get-in prepared [:effect/proposal :deploy/server-dry-run])))
+        (is (every? some?
+                    ((juxt :effect/id
+                           #(get-in % [:authority/grant :grant/id])
+                           #(get-in % [:authority/envelope :envelope/id]))
+                     prepared)))))))

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_governed_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_governed_test.clj
@@ -22,6 +22,7 @@
    never called. A governance seam is only worth its complexity if the
    mutation genuinely does not happen."
   (:require
+   [ai.miniforge.effect-transaction.interface :as fx]
    [ai.miniforge.phase-deployment.deploy-authority :as authority]
    [ai.miniforge.phase-deployment.deploy-governed :as governed]
    [clojure.test :refer [deftest is testing]])
@@ -40,6 +41,9 @@
 (def ^{:stratum 0} rendered-manifest
   "apiVersion: apps/v1\nkind: Deployment\n")
 
+(def ^{:stratum 0} rollback-info
+  {:deployment/replicas 3})
+
 (defn- ^{:stratum 0} tmp []
   (str (.toFile (Files/createTempDirectory "deploy" (into-array FileAttribute [])))))
 
@@ -48,23 +52,24 @@
    :namespace "prod"
    :context-name "gke-prod"
    :default-context "gke-default"
+   :app-label "api"
    :deployment-name "api"})
 
-(defn- ^{:stratum 0} recording-provider
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} recording-provider
   "Records every provider call. The assertions are about absence."
   [calls & {:keys [rendered apply-failed?]
             :or {rendered rendered-manifest apply-failed? false}}]
   {:dry-run! (fn [_] (swap! calls conj :dry-run!) rendered)
    :rollback-info! (fn [_] (swap! calls conj :rollback-info!)
-                     {:deployment/replicas 3})
+                     rollback-info)
    :apply! (fn [_] (swap! calls conj :apply!)
              {:deploy/failed? apply-failed?
               :deploy/failure (when apply-failed? "apply exploded")})
    :observe! (fn [_] (swap! calls conj :observe!)
                {:provider/matched? true
                 :provider/observed {:deployment/ready? true}})})
-
-;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} context
   ([] (context {}))
@@ -125,7 +130,9 @@
   (let [calls (atom [])
         ctx (context)
         result (governed/transact! ctx deploy-config
-                                   (recording-provider calls) now)]
+                                   (recording-provider calls) now)
+        proposal (:effect/proposal
+                  (first (fx/list-records (:effect-store-dir ctx))))]
     (is (some #{:apply!} @calls) "an authorized deploy should reach the provider")
     (is (= :success (:deploy/status result)))
     (is (some? (:deploy/effect-id result)) "the effect id is reported")
@@ -134,7 +141,11 @@
              (.indexOf ^java.util.List @calls :apply!))))
     (testing "a durable record exists in the effect store"
       (is (some #(.endsWith (.getName ^java.io.File %) ".edn")
-                (file-seq (java.io.File. ^String (:effect-store-dir ctx))))))))
+                (file-seq (java.io.File. ^String (:effect-store-dir ctx))))))
+    (testing "the durable proposal contains the available preflight evidence"
+      (is (= rendered-manifest (:deploy/rendered-yaml proposal)))
+      (is (= rollback-info (:deploy/rollback-info proposal)))
+      (is (= "api" (:app-label proposal))))))
 
 (deftest ^{:stratum 2} rollback-evidence-survives-a-failed-apply-test
   ;; The old store-apply-failure discarded :evidence/rollback-info,

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_governed_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_governed_test.clj
@@ -35,9 +35,10 @@
 (def ^{:stratum 0} now (Instant/parse "2026-08-01T00:00:00Z"))
 
 (def ^{:stratum 0} clean-preview
-  "A Pulumi-shaped preview that creates nothing, so both resource checks
-   pass and the preflight is allow-class."
-  "{\"steps\":[]}")
+  {:steps []})
+
+(def ^{:stratum 0} rendered-manifest
+  "apiVersion: apps/v1\nkind: Deployment\n")
 
 (defn- ^{:stratum 0} tmp []
   (str (.toFile (Files/createTempDirectory "deploy" (into-array FileAttribute [])))))
@@ -52,7 +53,7 @@
 (defn- ^{:stratum 0} recording-provider
   "Records every provider call. The assertions are about absence."
   [calls & {:keys [rendered apply-failed?]
-            :or {rendered clean-preview apply-failed? false}}]
+            :or {rendered rendered-manifest apply-failed? false}}]
   {:dry-run! (fn [_] (swap! calls conj :dry-run!) rendered)
    :rollback-info! (fn [_] (swap! calls conj :rollback-info!)
                      {:deployment/replicas 3})
@@ -71,6 +72,8 @@
    (merge {:run-id (random-uuid)
            :effect-store-dir (tmp)
            :grant-breach-dir (tmp)
+           :execution/phase-results
+           {:provision {:result {:output clean-preview}}}
            :policy-context {}}
           overrides)))
 
@@ -92,23 +95,21 @@
           (str "no kubectl mutation may run without authority, saw: "
                (pr-str @calls))))))
 
-(deftest ^{:stratum 2} a-denied-preflight-runs-no-mutation-test
-  ;; check-resource-count and check-gke-node-limit existed in policy.clj
-  ;; and were never consulted before an apply. Now a violation stops it.
-  (testing "a preview that creates more than the limit denies the apply"
-    (let [creates (apply str (repeat 25 "{\"op\":\"create\",\"type\":\"gcp:Node\"},"))
-          preview (str "{\"steps\":[" (subs creates 0 (dec (count creates))) "]}")
-          calls (atom [])
-          result (governed/transact! (context) deploy-config
-                                     (recording-provider calls :rendered preview)
-                                     now)]
+(deftest ^{:stratum 2} missing-policy-evidence-runs-no-mutation-test
+  (testing "a deploy without its provision preview is denied"
+    (let [calls (atom [])
+          result (governed/transact! (dissoc (context)
+                                             :execution/phase-results)
+                                     deploy-config
+                                     (recording-provider calls) now)]
       (is (= :failed (:deploy/status result)))
-      (is (= :deploy/preflight-denied (:deploy/refusal result)))
-      (is (= :preflight (:deploy/stage result))
-          "a preflight denial must not report as an authority failure")
+      (is (= :deploy/authority-denied (:deploy/refusal result)))
+      (is (= :authority (:deploy/stage result)))
       (is (not (some #{:apply!} @calls))
-          (str "a denied preflight must not reach kubectl, saw: " (pr-str @calls)))))
+          (str "missing policy evidence must not reach kubectl, saw: "
+               (pr-str @calls))))))
 
+(deftest ^{:stratum 2} an-empty-preflight-runs-no-mutation-test
   (testing "a dry-run that rendered nothing is denied, not waved through"
     (let [calls (atom [])
           result (governed/transact! (context) deploy-config

--- a/docs/pull-requests/2026-08-16-fix-deploy-authority-contract.md
+++ b/docs/pull-requests/2026-08-16-fix-deploy-authority-contract.md
@@ -9,13 +9,15 @@
 ## Overview
 
 Corrects the deployment authority boundary before the live governed
-deployment flow is wired. Grants now bind the canonical execution ID and
-resolved Kubernetes context, while policy checks consume the Pulumi preview
-they were designed to inspect.
+deployment flow is wired. Grants prefer the canonical execution ID, retain a
+temporary `:run-id` fallback for the existing unwired caller, and bind the
+resolved Kubernetes context. Policy checks consume the Pulumi preview they
+were designed to inspect.
 
 ## Changes
 
-- Build the closed grant request from `:execution/id` and one resolved target.
+- Build the closed grant request from `:execution/id` (or the temporary legacy
+  `:run-id` fallback) and one resolved target.
 - Classify both deployment rules against the provision phase preview.
 - Persist rendered manifests, server dry-run output, rollback information, and
   application label in the exact effect proposal.

--- a/docs/pull-requests/2026-08-16-fix-deploy-authority-contract.md
+++ b/docs/pull-requests/2026-08-16-fix-deploy-authority-contract.md
@@ -1,0 +1,36 @@
+<!--
+  Title: Bind deployment authority to canonical runtime inputs
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix(deploy): bind exact runtime authority
+
+## Overview
+
+Corrects the deployment authority boundary before the live governed
+deployment flow is wired. Grants now bind the canonical execution ID and
+resolved Kubernetes context, while policy checks consume the Pulumi preview
+they were designed to inspect.
+
+## Changes
+
+- Build the closed grant request from `:execution/id` and one resolved target.
+- Classify both deployment rules against the provision phase preview.
+- Persist rendered manifests, server dry-run output, rollback information, and
+  application label in the exact effect proposal.
+- Pin the two deployment policy rule IDs in the DecisionEnvelope.
+- Cover the production context shape, policy inputs, preflight evidence, and
+  correlated effect, grant, and envelope identifiers.
+
+## Verification
+
+- `bb pre-commit`
+- `clojure -M:poly test brick:phase-deployment`
+- Adversarial review against Clojure, function, component, and stratified
+  design standards.
+
+## Deployment
+
+No live deployment path changes in this PR. PR #1794 consumes this corrected
+domain boundary when it wires governed deployment into `enter-deploy`.

--- a/docs/pull-requests/2026-08-16-fix-deploy-authority-contract.md
+++ b/docs/pull-requests/2026-08-16-fix-deploy-authority-contract.md
@@ -18,8 +18,8 @@ were designed to inspect.
 
 - Build the closed grant request from `:execution/id` (or the temporary legacy
   `:run-id` fallback) and one resolved target.
-- Fail closed when the successful provision phase did not retain its Pulumi
-  preview.
+- Fail closed without issuing a grant when deployment policy blocks, including
+  when the successful provision phase did not retain its Pulumi preview.
 - Classify both deployment rules against the provision phase preview.
 - Keep rendered-manifest validation separate from Pulumi-preview policy checks.
 - Persist rendered manifests, server dry-run output, rollback information, and

--- a/docs/pull-requests/2026-08-16-fix-deploy-authority-contract.md
+++ b/docs/pull-requests/2026-08-16-fix-deploy-authority-contract.md
@@ -18,7 +18,10 @@ were designed to inspect.
 
 - Build the closed grant request from `:execution/id` (or the temporary legacy
   `:run-id` fallback) and one resolved target.
+- Fail closed when the successful provision phase did not retain its Pulumi
+  preview.
 - Classify both deployment rules against the provision phase preview.
+- Keep rendered-manifest validation separate from Pulumi-preview policy checks.
 - Persist rendered manifests, server dry-run output, rollback information, and
   application label in the exact effect proposal.
 - Pin the two deployment policy rule IDs in the DecisionEnvelope.


### PR DESCRIPTION
## Summary

- bind deployment grants to the canonical execution ID and resolved Kubernetes context
- evaluate deployment policy against the Pulumi provision preview
- retain rendered, server-dry-run, and rollback evidence in the exact proposal
- preserve the existing unwired seam until PR #1794 replaces its application flow

## Validation

- bb pre-commit
- clojure -M:poly test brick:phase-deployment
- bb test (stable-derived plan; 5 projects; green in 8m48s)
- bb review (no findings in changed files; 10 pre-existing repository findings)
- 213 / 600 reportable PR lines

## Follow-up

PR #1794 consumes this corrected authority boundary and removes the migration compatibility path.