### PR TITLE
feat(tenancy,workflow): carry the acting identity through the run (Ariadne 3b, 1/2)

### DIFF
--- a/components/tenancy/src/ai/miniforge/tenancy/acting.clj
+++ b/components/tenancy/src/ai/miniforge/tenancy/acting.clj
@@ -52,25 +52,6 @@
                        detail
                        {}))
 
-(defn ^{:stratum 0} agent-principal
-  "The principal a spawned agent acts as.
-
-   The tenant is inherited: an agent owns nothing, so there is nothing
-   for it to own things AS. The principal is its own, so 'an agent
-   instance did it' and 'the operator did it' remain distinguishable
-   after the fact.
-
-   This is the representational half of fence-not-restrain. The inner
-   agent acts under a named identity inside the boundary rather than
-   under the ambient authority of the process, which is what makes
-   revoking the lending tenant's grant end the agent's authority too."
-  [acting agent-name]
-  {:principal/id (ids/stable-id "agent-principal"
-                                (str (:acting/tenant-id acting) "/" agent-name))
-   :principal/tenant-id (:acting/tenant-id acting)
-   :principal/kind :agent-instance
-   :principal/display-name agent-name})
-
 (def ^{:stratum 0} ActingContext
   "CLOSED. The two ids that answer 'on whose behalf', and when that was
    settled.
@@ -102,6 +83,37 @@
    :acting/established-at (instant/->iso now)})
 
 ;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} agent-principal
+  "The principal a spawned agent acts as.
+
+   The tenant is inherited: an agent owns nothing, so there is nothing
+   for it to own things AS. The principal is its own, so 'an agent
+   instance did it' and 'the operator did it' remain distinguishable
+   after the fact.
+
+   This is the representational half of fence-not-restrain. The inner
+   agent acts under a named identity inside the boundary rather than
+   under the ambient authority of the process, which is what makes
+   revoking the lending tenant's grant end the agent's authority too.
+
+   Returns an anomaly rather than a Principal-shaped map when the
+   derivation does not validate — a blank agent name, or an acting
+   context with no tenant. This is public API, and a caller that has to
+   remember to validate what it was handed is a caller that eventually
+   forgets. Refusing here is the same rule the rest of this component
+   follows."
+  [acting agent-name]
+  (let [principal {:principal/id (ids/stable-id "agent-principal"
+                                                (str (:acting/tenant-id acting)
+                                                     "/" agent-name))
+                   :principal/tenant-id (:acting/tenant-id acting)
+                   :principal/kind :agent-instance
+                   :principal/display-name agent-name}]
+    (if (m/validate schema/Principal principal)
+      principal
+      (no-acting (str "cannot derive a valid agent principal for agent name "
+                      (pr-str agent-name))))))
 
 (defn ^{:stratum 1} valid?
   [x]
@@ -138,9 +150,8 @@
   (if-not (valid? acting)
     (no-acting "cannot spawn an agent from an invalid acting context")
     (let [principal (agent-principal acting agent-name)]
-      (if-not (m/validate schema/Principal principal)
-        (no-acting (str "spawned agent principal is invalid for agent name "
-                        (pr-str agent-name)))
+      (if (anomaly/anomaly? principal)
+        principal
         {:acting/tenant-id (:acting/tenant-id acting)
          :acting/principal-id (:principal/id principal)
          :acting/established-at (:acting/established-at acting)}))))

--- a/components/tenancy/src/ai/miniforge/tenancy/acting.clj
+++ b/components/tenancy/src/ai/miniforge/tenancy/acting.clj
@@ -1,0 +1,137 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.tenancy.acting
+  "The acting context — who a run is acting for (Ariadne step 3b, §2-§4).
+
+   3a answers 'who is the operator'. This answers the question every
+   record-birth site actually asks: 'on whose behalf is THIS running'.
+   Those differ the moment a run spawns an agent, because the tenant
+   stays the same and the principal does not.
+
+   WHY IDS AND NOT THE WHOLE IDENTITY. The acting context rides in the
+   execution context, which is checkpointed to disk and restored on
+   resume. Carrying whole `Tenant` and `Principal` maps would mean a
+   resumed run replays a display name captured months ago, and any
+   correction to that name would silently not apply. Ids are the stable
+   half; the records they point at are looked up when they are needed.
+
+   ESTABLISHED-AT IS NOT CREATED-AT. `:tenant/created-at` is when the
+   tenant came to exist. `:acting/established-at` is when THIS run
+   resolved it. On resume the second one is deliberately preserved from
+   the snapshot rather than re-stamped — the run is still acting under
+   the authority it was started with, and re-stamping would make a
+   resumed run look freshly authorized."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.tenancy.ids :as ids]
+   [ai.miniforge.tenancy.schema :as schema]
+   [malli.core :as m]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ActingContext
+  "CLOSED. The two ids that answer 'on whose behalf', and when that was
+   settled.
+
+   Both ids are required. A tenant without a principal cannot say who
+   did it; a principal without a tenant cannot say who owns the result."
+  [:map {:closed true}
+   [:acting/tenant-id :uuid]
+   [:acting/principal-id :uuid]
+   [:acting/established-at inst?]])
+
+(defn- ^{:stratum 0} no-acting
+  [detail]
+  (anomaly/sub-anomaly :invalid-input
+                       :anomalies.tenancy/no-acting-context
+                       detail
+                       {}))
+
+(defn ^{:stratum 0} establish
+  "Reduce a resolved `Identity` to the acting context a run carries.
+
+   Called ONCE per boundary. Downstream code reads what this produced;
+   it does not call the resolver again. Two resolutions are two answers
+   about who acted, which is worse than none."
+  [identity now]
+  {:acting/tenant-id (get-in identity [:identity/tenant :tenant/id])
+   :acting/principal-id (get-in identity [:identity/principal :principal/id])
+   :acting/established-at now})
+
+(defn ^{:stratum 0} agent-principal
+  "The principal a spawned agent acts as.
+
+   The tenant is inherited: an agent owns nothing, so there is nothing
+   for it to own things AS. The principal is its own, so 'an agent
+   instance did it' and 'the operator did it' remain distinguishable
+   after the fact.
+
+   This is the representational half of fence-not-restrain. The inner
+   agent acts under a named identity inside the boundary rather than
+   under the ambient authority of the process, which is what makes
+   revoking the lending tenant's grant end the agent's authority too."
+  [acting agent-name]
+  {:principal/id (ids/stable-id "agent-principal"
+                                (str (:acting/tenant-id acting) "/" agent-name))
+   :principal/tenant-id (:acting/tenant-id acting)
+   :principal/kind :agent-instance
+   :principal/display-name agent-name})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} valid?
+  [x]
+  (m/validate ActingContext x))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} require-acting
+  "Return the acting context held by `carrier`, or an anomaly.
+
+   Never substitutes a default and never returns nil. A record created
+   under a fabricated tenant is indistinguishable, later, from one
+   created under a real one, and the audit trail cannot be repaired
+   after the fact — so the failure belongs here, where it is still a
+   recoverable error."
+  [carrier key]
+  (let [acting (get carrier key)]
+    (cond
+      (nil? acting)
+      (no-acting (str "no acting context at " key "; refusing to proceed unowned"))
+
+      (not (valid? acting))
+      (no-acting (str "acting context at " key " is not a valid acting context"))
+
+      :else acting)))
+
+(defn ^{:stratum 2} for-agent
+  "The acting context a spawned agent runs under.
+
+   Same tenant, new principal, and the establishing instant carried
+   forward from the spawning run — the agent's authority is the run's
+   authority, not a fresh grant of its own."
+  [acting agent-name]
+  (if-not (valid? acting)
+    (no-acting "cannot spawn an agent from an invalid acting context")
+    (let [principal (agent-principal acting agent-name)]
+      (if-not (m/validate schema/Principal principal)
+        (no-acting (str "spawned agent principal is invalid for agent name "
+                        (pr-str agent-name)))
+        {:acting/tenant-id (:acting/tenant-id acting)
+         :acting/principal-id (:principal/id principal)
+         :acting/established-at (:acting/established-at acting)}))))

--- a/components/tenancy/src/ai/miniforge/tenancy/acting.clj
+++ b/components/tenancy/src/ai/miniforge/tenancy/acting.clj
@@ -112,8 +112,14 @@
                    :principal/display-name agent-name}]
     (if (m/validate schema/Principal principal)
       principal
-      (no-acting (str "cannot derive a valid agent principal for agent name "
-                      (pr-str agent-name))))))
+      ;; Name the actual cause. A refusal that blames the agent name for
+      ;; a missing tenant sends the reader to the wrong place, and a
+      ;; precise refusal is the only thing this function offers over
+      ;; returning the map and letting the caller find out later.
+      (no-acting (if (uuid? (:acting/tenant-id acting))
+                   (str "cannot derive a valid agent principal: invalid agent name "
+                        (pr-str agent-name))
+                   "cannot derive a valid agent principal: the acting context has no tenant to inherit")))))
 
 (defn ^{:stratum 1} valid?
   [x]

--- a/components/tenancy/src/ai/miniforge/tenancy/acting.clj
+++ b/components/tenancy/src/ai/miniforge/tenancy/acting.clj
@@ -39,20 +39,11 @@
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.tenancy.ids :as ids]
+   [ai.miniforge.tenancy.instant :as instant]
    [ai.miniforge.tenancy.schema :as schema]
-   [malli.core :as m])
-  (:import
-   [java.time Instant]
-   [java.util Date]))
+   [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-(defn ^{:stratum 0} iso-instant?
-  "True for a string this namespace can read back as an instant."
-  [x]
-  (and (string? x)
-       (try (Instant/parse x) true
-            (catch Exception _ false))))
 
 (defn- ^{:stratum 0} no-acting
   [detail]
@@ -80,9 +71,7 @@
    :principal/kind :agent-instance
    :principal/display-name agent-name})
 
-;------------------------------------------------------------------------------ Layer 1
-
-(def ^{:stratum 1} ActingContext
+(def ^{:stratum 0} ActingContext
   "CLOSED. The two ids that answer 'on whose behalf', and when that was
    settled.
 
@@ -99,26 +88,9 @@
   [:map {:closed true}
    [:acting/tenant-id :uuid]
    [:acting/principal-id :uuid]
-   [:acting/established-at [:fn iso-instant?]]])
+   [:acting/established-at [:fn instant/iso-instant?]]])
 
-(defn ^{:stratum 1} ->iso
-  "Normalize an instant to the canonical ISO-8601 string, or nil.
-
-   Takes `Instant` and `Date` both, because `inst?` — which every
-   instant-bearing schema here uses — admits either, so a caller holding
-   a schema-valid instant may hold either one. Assuming `Instant` and
-   calling `str` on a `Date` yields 'Sat Aug 16 ...', which is not a
-   parseable instant and would fail validation somewhere far from here."
-  [now]
-  (cond
-    (instance? Instant now) (str now)
-    (instance? Date now) (str (.toInstant ^Date now))
-    (iso-instant? now) now
-    :else nil))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn ^{:stratum 2} establish
+(defn ^{:stratum 0} establish
   "Reduce a resolved `Identity` to the acting context a run carries.
 
    Called ONCE per boundary. Downstream code reads what this produced;
@@ -127,15 +99,17 @@
   [identity now]
   {:acting/tenant-id (get-in identity [:identity/tenant :tenant/id])
    :acting/principal-id (get-in identity [:identity/principal :principal/id])
-   :acting/established-at (->iso now)})
+   :acting/established-at (instant/->iso now)})
 
-(defn ^{:stratum 2} valid?
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} valid?
   [x]
   (m/validate ActingContext x))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 3} require-acting
+(defn ^{:stratum 2} require-acting
   "Return the acting context held by `carrier`, or an anomaly.
 
    Never substitutes a default and never returns nil. A record created
@@ -154,7 +128,7 @@
 
       :else acting)))
 
-(defn ^{:stratum 3} for-agent
+(defn ^{:stratum 2} for-agent
   "The acting context a spawned agent runs under.
 
    Same tenant, new principal, and the establishing instant carried

--- a/components/tenancy/src/ai/miniforge/tenancy/acting.clj
+++ b/components/tenancy/src/ai/miniforge/tenancy/acting.clj
@@ -40,20 +40,19 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.tenancy.ids :as ids]
    [ai.miniforge.tenancy.schema :as schema]
-   [malli.core :as m]))
+   [malli.core :as m])
+  (:import
+   [java.time Instant]
+   [java.util Date]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(def ^{:stratum 0} ActingContext
-  "CLOSED. The two ids that answer 'on whose behalf', and when that was
-   settled.
-
-   Both ids are required. A tenant without a principal cannot say who
-   did it; a principal without a tenant cannot say who owns the result."
-  [:map {:closed true}
-   [:acting/tenant-id :uuid]
-   [:acting/principal-id :uuid]
-   [:acting/established-at inst?]])
+(defn ^{:stratum 0} iso-instant?
+  "True for a string this namespace can read back as an instant."
+  [x]
+  (and (string? x)
+       (try (Instant/parse x) true
+            (catch Exception _ false))))
 
 (defn- ^{:stratum 0} no-acting
   [detail]
@@ -61,17 +60,6 @@
                        :anomalies.tenancy/no-acting-context
                        detail
                        {}))
-
-(defn ^{:stratum 0} establish
-  "Reduce a resolved `Identity` to the acting context a run carries.
-
-   Called ONCE per boundary. Downstream code reads what this produced;
-   it does not call the resolver again. Two resolutions are two answers
-   about who acted, which is worse than none."
-  [identity now]
-  {:acting/tenant-id (get-in identity [:identity/tenant :tenant/id])
-   :acting/principal-id (get-in identity [:identity/principal :principal/id])
-   :acting/established-at now})
 
 (defn ^{:stratum 0} agent-principal
   "The principal a spawned agent acts as.
@@ -94,13 +82,60 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} valid?
-  [x]
-  (m/validate ActingContext x))
+(def ^{:stratum 1} ActingContext
+  "CLOSED. The two ids that answer 'on whose behalf', and when that was
+   settled.
+
+   Both ids are required. A tenant without a principal cannot say who
+   did it; a principal without a tenant cannot say who owns the result.
+
+   `:acting/established-at` is an ISO-8601 STRING, not an `inst?`. The
+   acting context is written into the workflow machine snapshot, and
+   that snapshot puts every value through `coerce/stringify-instants` —
+   so an `inst?` here is an `Instant` going in and a `String` coming
+   back, and the context would fail its own validation on resume. One
+   canonical representation that survives the round trip unchanged is
+   cheaper than a coercion at every boundary that reads it."
+  [:map {:closed true}
+   [:acting/tenant-id :uuid]
+   [:acting/principal-id :uuid]
+   [:acting/established-at [:fn iso-instant?]]])
+
+(defn ^{:stratum 1} ->iso
+  "Normalize an instant to the canonical ISO-8601 string, or nil.
+
+   Takes `Instant` and `Date` both, because `inst?` — which every
+   instant-bearing schema here uses — admits either, so a caller holding
+   a schema-valid instant may hold either one. Assuming `Instant` and
+   calling `str` on a `Date` yields 'Sat Aug 16 ...', which is not a
+   parseable instant and would fail validation somewhere far from here."
+  [now]
+  (cond
+    (instance? Instant now) (str now)
+    (instance? Date now) (str (.toInstant ^Date now))
+    (iso-instant? now) now
+    :else nil))
 
 ;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 2} require-acting
+(defn ^{:stratum 2} establish
+  "Reduce a resolved `Identity` to the acting context a run carries.
+
+   Called ONCE per boundary. Downstream code reads what this produced;
+   it does not call the resolver again. Two resolutions are two answers
+   about who acted, which is worse than none."
+  [identity now]
+  {:acting/tenant-id (get-in identity [:identity/tenant :tenant/id])
+   :acting/principal-id (get-in identity [:identity/principal :principal/id])
+   :acting/established-at (->iso now)})
+
+(defn ^{:stratum 2} valid?
+  [x]
+  (m/validate ActingContext x))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} require-acting
   "Return the acting context held by `carrier`, or an anomaly.
 
    Never substitutes a default and never returns nil. A record created
@@ -119,7 +154,7 @@
 
       :else acting)))
 
-(defn ^{:stratum 2} for-agent
+(defn ^{:stratum 3} for-agent
   "The acting context a spawned agent runs under.
 
    Same tenant, new principal, and the establishing instant carried

--- a/components/tenancy/src/ai/miniforge/tenancy/acting.clj
+++ b/components/tenancy/src/ai/miniforge/tenancy/acting.clj
@@ -41,6 +41,7 @@
    [ai.miniforge.tenancy.ids :as ids]
    [ai.miniforge.tenancy.instant :as instant]
    [ai.miniforge.tenancy.schema :as schema]
+   [clojure.string :as str]
    [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -104,12 +105,19 @@
    forgets. Refusing here is the same rule the rest of this component
    follows."
   [acting agent-name]
-  (let [principal {:principal/id (ids/stable-id "agent-principal"
+  ;; Trimmed before the id is derived, so "reviewer" and " reviewer "
+  ;; are one agent rather than two. The id is stable-derived and 3c
+  ;; stamps it onto records, so an untrimmed name would put the same
+  ;; logical actor in the audit trail twice with no way to tell they
+  ;; were ever the same. `resolve-operator` already trims for the same
+  ;; reason.
+  (let [trimmed (some-> agent-name str/trim)
+        principal {:principal/id (ids/stable-id "agent-principal"
                                                 (str (:acting/tenant-id acting)
-                                                     "/" agent-name))
+                                                     "/" trimmed))
                    :principal/tenant-id (:acting/tenant-id acting)
                    :principal/kind :agent-instance
-                   :principal/display-name agent-name}]
+                   :principal/display-name trimmed}]
     (if (m/validate schema/Principal principal)
       principal
       ;; Name the actual cause. A refusal that blames the agent name for

--- a/components/tenancy/src/ai/miniforge/tenancy/acting.clj
+++ b/components/tenancy/src/ai/miniforge/tenancy/acting.clj
@@ -118,16 +118,32 @@
                    :principal/tenant-id (:acting/tenant-id acting)
                    :principal/kind :agent-instance
                    :principal/display-name trimmed}]
-    (if (m/validate schema/Principal principal)
+    ;; Validate the acting context as well as the derived principal. A
+    ;; bare {:acting/tenant-id <uuid>} yields a schema-valid Principal
+    ;; under a tenant nobody established — an agent identity fabricated
+    ;; from a uuid a caller happened to hold. Checking only the output
+    ;; would let this function launder an unestablished tenant into a
+    ;; well-formed actor, which is the opposite of what it is for.
+    (if (and (m/validate ActingContext acting)
+             (m/validate schema/Principal principal))
       principal
       ;; Name the actual cause. A refusal that blames the agent name for
       ;; a missing tenant sends the reader to the wrong place, and a
       ;; precise refusal is the only thing this function offers over
       ;; returning the map and letting the caller find out later.
-      (no-acting (if (uuid? (:acting/tenant-id acting))
+      ;; Most specific cause first. "Never established" is true of a
+      ;; context missing its tenant too, but it sends the reader looking
+      ;; at the wrong field.
+      (no-acting (cond
+                   (not (uuid? (:acting/tenant-id acting)))
+                   "cannot derive a valid agent principal: the acting context has no tenant to inherit"
+
+                   (not (m/validate ActingContext acting))
+                   "cannot derive a valid agent principal: the acting context was never established"
+
+                   :else
                    (str "cannot derive a valid agent principal: invalid agent name "
-                        (pr-str agent-name))
-                   "cannot derive a valid agent principal: the acting context has no tenant to inherit")))))
+                        (pr-str agent-name)))))))
 
 (defn ^{:stratum 1} valid?
   [x]

--- a/components/tenancy/src/ai/miniforge/tenancy/instant.clj
+++ b/components/tenancy/src/ai/miniforge/tenancy/instant.clj
@@ -1,0 +1,56 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.tenancy.instant
+  "One canonical instant representation for identity that gets persisted.
+
+   WHY THIS EXISTS. The acting context is written into the workflow
+   machine snapshot, and that snapshot puts every value through
+   `coerce/stringify-instants`. A field typed `inst?` therefore goes in
+   an `Instant` and comes back a `String`, so a context that validated
+   on the way in fails its own validation on the way out. Rather than
+   coerce at every boundary that reads one, the stored form IS the
+   string, and this is the one place that produces and recognizes it."
+  (:import
+   [java.time Instant]
+   [java.util Date]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} iso-instant?
+  "True for a string that reads back as an instant."
+  [x]
+  (and (string? x)
+       (try (Instant/parse x) true
+            (catch Exception _ false))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} ->iso
+  "Normalize an instant to the canonical ISO-8601 string, or nil.
+
+   Takes `Instant` and `Date` both, because `inst?` — which every
+   instant-bearing schema here uses — admits either, so a caller holding
+   a schema-valid instant may hold either one. Assuming `Instant` and
+   calling `str` on a `Date` yields 'Sat Aug 16 ...', which is not a
+   parseable instant and would fail validation far from its cause."
+  [now]
+  (cond
+    (instance? Instant now) (str now)
+    (instance? Date now) (str (.toInstant ^Date now))
+    (iso-instant? now) now
+    :else nil))

--- a/components/tenancy/src/ai/miniforge/tenancy/interface.clj
+++ b/components/tenancy/src/ai/miniforge/tenancy/interface.clj
@@ -19,10 +19,11 @@
   "Public API for tenancy (Ariadne step 3a): who owns, who acts, and the
    one boundary that establishes an operator.
 
-   Nothing consumes these yet — 3b threads the identity through the run
-   hierarchy and 3c stamps it onto records. This slice is the vocabulary
-   and its source."
+   3b threads the identity through the run hierarchy; 3c stamps it onto
+   records. This namespace is the vocabulary, its source, and the acting
+   context that carries it."
   (:require
+   [ai.miniforge.tenancy.acting :as acting]
    [ai.miniforge.tenancy.resolver :as resolver]
    [ai.miniforge.tenancy.schema :as schema]
    [malli.core :as m]))
@@ -53,3 +54,26 @@
 (defn ^{:stratum 0} valid-principal? [p] (m/validate schema/Principal p))
 
 (defn ^{:stratum 0} valid-identity? [i] (m/validate schema/Identity i))
+
+(def ^{:stratum 0} ActingContext acting/ActingContext)
+
+(def ^{:stratum 0} establish-acting
+  "Reduce a resolved identity to the acting context a run carries.
+   Called once per boundary; downstream reads rather than re-resolving."
+  acting/establish)
+
+(def ^{:stratum 0} require-acting
+  "Return the acting context held at `key`, or an anomaly. Never
+   substitutes a default and never returns nil."
+  acting/require-acting)
+
+(def ^{:stratum 0} acting-for-agent
+  "The acting context a spawned agent runs under: same tenant, its own
+   `:agent-instance` principal."
+  acting/for-agent)
+
+(def ^{:stratum 0} agent-principal
+  "The principal a spawned agent acts as."
+  acting/agent-principal)
+
+(defn ^{:stratum 0} valid-acting? [a] (acting/valid? a))

--- a/components/tenancy/test/ai/miniforge/tenancy/acting_test.clj
+++ b/components/tenancy/test/ai/miniforge/tenancy/acting_test.clj
@@ -1,0 +1,123 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.tenancy.acting-test
+  "The acting context (Ariadne step 3b)."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.tenancy.interface :as tenancy]
+   [clojure.test :refer [deftest is testing]])
+  (:import
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} now (Instant/parse "2026-08-01T00:00:00Z"))
+
+(def ^{:stratum 0} configured {:tenancy {:operator-name "chris"}})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} an-acting
+  []
+  (tenancy/establish-acting (tenancy/resolve-operator configured now) now))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} acting-carries-ids-not-records-test
+  ;; Ids are the stable half. Whole records would mean a resumed run
+  ;; replays a display name captured months ago.
+  (let [acting (an-acting)
+        identity (tenancy/resolve-operator configured now)]
+    (is (tenancy/valid-acting? acting))
+    (is (= #{:acting/tenant-id :acting/principal-id :acting/established-at}
+           (set (keys acting)))
+        "closed: exactly the two ids and the instant")
+    (is (= (get-in identity [:identity/tenant :tenant/id])
+           (:acting/tenant-id acting)))
+    (is (= (get-in identity [:identity/principal :principal/id])
+           (:acting/principal-id acting)))))
+
+(deftest ^{:stratum 2} both-ids-are-required-test
+  ;; A tenant without a principal cannot say who did it; a principal
+  ;; without a tenant cannot say who owns the result.
+  (let [acting (an-acting)]
+    (doseq [k [:acting/tenant-id :acting/principal-id :acting/established-at]]
+      (is (not (tenancy/valid-acting? (dissoc acting k)))
+          (str "must reject a context missing " k))
+      (is (not (tenancy/valid-acting? (assoc acting k nil)))
+          (str "must reject a nil " k)))
+    (testing "and nothing else may ride along"
+      (is (not (tenancy/valid-acting? (assoc acting :acting/extra :x)))))))
+
+(deftest ^{:stratum 2} absence-is-loud-test
+  ;; The whole point of the slice. An unowned record created during the
+  ;; migration is indistinguishable later from a legitimately anonymous
+  ;; one, and there is no such thing as legitimately anonymous here.
+  (testing "missing"
+    (let [result (tenancy/require-acting {} :execution/acting)]
+      (is (anomaly/anomaly? result))
+      (is (not (tenancy/valid-acting? result))
+          "a refusal must not be mistakable for an acting context")))
+  (testing "explicitly nil"
+    (is (anomaly/anomaly? (tenancy/require-acting {:execution/acting nil}
+                                                  :execution/acting))))
+  (testing "present but malformed — a half-filled context is not a context"
+    (is (anomaly/anomaly?
+         (tenancy/require-acting {:execution/acting {:acting/tenant-id (random-uuid)}}
+                                 :execution/acting))))
+  (testing "present and valid"
+    (let [acting (an-acting)]
+      (is (= acting (tenancy/require-acting {:execution/acting acting}
+                                            :execution/acting))))))
+
+(deftest ^{:stratum 2} a-spawned-agent-inherits-the-tenant-and-gets-its-own-principal-test
+  ;; The asymmetry is what makes a spawned agent containable: revoke the
+  ;; lending tenant's grant and the agent's authority ends with it.
+  (let [acting (an-acting)
+        agent-acting (tenancy/acting-for-agent acting "reviewer")
+        principal (tenancy/agent-principal acting "reviewer")]
+    (is (tenancy/valid-acting? agent-acting))
+    (is (tenancy/valid-principal? principal))
+    (is (= (:acting/tenant-id acting) (:acting/tenant-id agent-acting))
+        "an agent owns nothing, so it acts under the spawning tenant")
+    (is (not= (:acting/principal-id acting) (:acting/principal-id agent-acting))
+        "'an agent did it' and 'the operator did it' stay distinguishable")
+    (is (= :agent-instance (:principal/kind principal)))
+    (is (= (:acting/established-at acting) (:acting/established-at agent-acting))
+        "the agent's authority is the run's authority, not a fresh grant")))
+
+(deftest ^{:stratum 2} agent-principals-are-stable-and-distinct-test
+  (let [acting (an-acting)]
+    (is (= (tenancy/acting-for-agent acting "reviewer")
+           (tenancy/acting-for-agent acting "reviewer"))
+        "same run, same agent name, same principal")
+    (is (not= (:acting/principal-id (tenancy/acting-for-agent acting "reviewer"))
+              (:acting/principal-id (tenancy/acting-for-agent acting "implementer")))
+        "different agents are different principals")
+    (testing "and a different tenant spawning the same agent name differs"
+      (let [other (assoc acting :acting/tenant-id (random-uuid))]
+        (is (not= (:acting/principal-id (tenancy/acting-for-agent acting "reviewer"))
+                  (:acting/principal-id (tenancy/acting-for-agent other "reviewer"))))))))
+
+(deftest ^{:stratum 2} spawning-from-a-bad-context-refuses-test
+  ;; Refuse rather than mint an agent principal under a tenant that was
+  ;; never established.
+  (is (anomaly/anomaly? (tenancy/acting-for-agent {} "reviewer")))
+  (is (anomaly/anomaly? (tenancy/acting-for-agent nil "reviewer")))
+  (testing "a blank agent name is not a name"
+    (is (anomaly/anomaly? (tenancy/acting-for-agent (an-acting) "   ")))))

--- a/components/tenancy/test/ai/miniforge/tenancy/acting_test.clj
+++ b/components/tenancy/test/ai/miniforge/tenancy/acting_test.clj
@@ -47,7 +47,7 @@
         from-date (tenancy/establish-acting identity (java.util.Date/from now))]
     (is (= from-instant from-date)
         "Instant and Date for the same moment produce the same context"))
-  (testing "and an unparseable stamp is refused rather than stored"
+  (testing "and an unparseable stamp yields a context that fails validation"
     (is (not (tenancy/valid-acting?
               (tenancy/establish-acting (tenancy/resolve-operator configured now)
                                         "not-an-instant"))))))

--- a/components/tenancy/test/ai/miniforge/tenancy/acting_test.clj
+++ b/components/tenancy/test/ai/miniforge/tenancy/acting_test.clj
@@ -20,6 +20,7 @@
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.tenancy.interface :as tenancy]
+   [clojure.edn :as edn]
    [clojure.test :refer [deftest is testing]])
   (:import
    [java.time Instant]))
@@ -35,6 +36,21 @@
 (defn ^{:stratum 1} an-acting
   []
   (tenancy/establish-acting (tenancy/resolve-operator configured now) now))
+
+(deftest ^{:stratum 1} both-instant-representations-are-accepted-test
+  ;; `inst?` admits java.util.Date as readily as java.time.Instant, so a
+  ;; caller holding a schema-valid instant may hold either. Assuming
+  ;; Instant and calling `str` on a Date yields "Sat Aug 16 ...", which
+  ;; is not parseable and would fail validation far from its cause.
+  (let [identity (tenancy/resolve-operator configured now)
+        from-instant (tenancy/establish-acting identity now)
+        from-date (tenancy/establish-acting identity (java.util.Date/from now))]
+    (is (= from-instant from-date)
+        "Instant and Date for the same moment produce the same context"))
+  (testing "and an unparseable stamp is refused rather than stored"
+    (is (not (tenancy/valid-acting?
+              (tenancy/establish-acting (tenancy/resolve-operator configured now)
+                                        "not-an-instant"))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 
@@ -121,3 +137,20 @@
   (is (anomaly/anomaly? (tenancy/acting-for-agent nil "reviewer")))
   (testing "a blank agent name is not a name"
     (is (anomaly/anomaly? (tenancy/acting-for-agent (an-acting) "   ")))))
+
+(deftest ^{:stratum 2} established-at-survives-serialization-test
+  ;; The acting context is written into the workflow machine snapshot,
+  ;; which stringifies every instant. A field typed `inst?` would go in
+  ;; an Instant and come back a String, failing its own validation on
+  ;; resume and leaving every resumed run unowned. So the canonical
+  ;; representation IS the string.
+  (let [acting (an-acting)]
+    (is (string? (:acting/established-at acting)))
+    (is (tenancy/valid-acting? acting))
+    (testing "it round-trips through edn unchanged, which is what the snapshot does"
+      (let [round-tripped (edn/read-string (pr-str acting))]
+        (is (= acting round-tripped))
+        (is (tenancy/valid-acting? round-tripped))))
+    (testing "and re-establishing from the stored string is idempotent"
+      (is (= acting (tenancy/establish-acting (tenancy/resolve-operator configured now)
+                                              (:acting/established-at acting)))))))

--- a/components/tenancy/test/ai/miniforge/tenancy/acting_test.clj
+++ b/components/tenancy/test/ai/miniforge/tenancy/acting_test.clj
@@ -154,3 +154,20 @@
     (testing "and re-establishing from the stored string is idempotent"
       (is (= acting (tenancy/establish-acting (tenancy/resolve-operator configured now)
                                               (:acting/established-at acting)))))))
+
+(deftest ^{:stratum 2} agent-principal-refuses-rather-than-shaping-junk-test
+  ;; `agent-principal` is public API. Returning a Principal-shaped map
+  ;; for invalid input would put the burden of validation on every
+  ;; caller, and a caller that must remember to validate eventually
+  ;; forgets — which is the whole failure mode this component exists to
+  ;; prevent.
+  (let [acting (an-acting)]
+    (is (tenancy/valid-principal? (tenancy/agent-principal acting "reviewer")))
+    (testing "a blank name yields no principal, not an unnamed one"
+      (doseq [bad ["" "   " nil]]
+        (is (anomaly/anomaly? (tenancy/agent-principal acting bad))
+            (str "should refuse agent name " (pr-str bad)))))
+    (testing "no tenant to inherit means no principal"
+      (is (anomaly/anomaly? (tenancy/agent-principal {} "reviewer")))
+      (is (anomaly/anomaly?
+           (tenancy/agent-principal (dissoc acting :acting/tenant-id) "reviewer"))))))

--- a/components/tenancy/test/ai/miniforge/tenancy/acting_test.clj
+++ b/components/tenancy/test/ai/miniforge/tenancy/acting_test.clj
@@ -170,4 +170,12 @@
     (testing "no tenant to inherit means no principal"
       (is (anomaly/anomaly? (tenancy/agent-principal {} "reviewer")))
       (is (anomaly/anomaly?
-           (tenancy/agent-principal (dissoc acting :acting/tenant-id) "reviewer"))))))
+           (tenancy/agent-principal (dissoc acting :acting/tenant-id) "reviewer"))))
+    (testing "and the refusal names the actual cause, not a plausible one"
+      ;; A refusal that blames the agent name for a missing tenant sends
+      ;; the reader to the wrong place, which costs more than no message.
+      (is (re-find #"no tenant"
+                   (:anomaly/message (tenancy/agent-principal
+                                      (dissoc acting :acting/tenant-id) "reviewer"))))
+      (is (re-find #"agent name"
+                   (:anomaly/message (tenancy/agent-principal acting "  ")))))))

--- a/components/tenancy/test/ai/miniforge/tenancy/acting_test.clj
+++ b/components/tenancy/test/ai/miniforge/tenancy/acting_test.clj
@@ -130,6 +130,25 @@
         (is (not= (:acting/principal-id (tenancy/acting-for-agent acting "reviewer"))
                   (:acting/principal-id (tenancy/acting-for-agent other "reviewer"))))))))
 
+(deftest ^{:stratum 2} agent-names-are-normalized-before-deriving-an-id-test
+  ;; The principal id is stable-derived from the name and 3c stamps it
+  ;; onto records. An untrimmed name would put the same logical actor in
+  ;; the audit trail twice with no way to tell they were ever the same.
+  (let [acting (an-acting)]
+    (is (= (:principal/id (tenancy/agent-principal acting "reviewer"))
+           (:principal/id (tenancy/agent-principal acting "  reviewer  "))
+           (:principal/id (tenancy/agent-principal acting "reviewer\n")))
+        "equivalent names are one agent, not several")
+    (is (= "reviewer" (:principal/display-name
+                       (tenancy/agent-principal acting "  reviewer  ")))
+        "and the stored name is the trimmed one")
+    (testing "the same holds through the acting context a spawned agent runs under"
+      (is (= (tenancy/acting-for-agent acting "reviewer")
+             (tenancy/acting-for-agent acting " reviewer "))))
+    (testing "but distinct names stay distinct"
+      (is (not= (:principal/id (tenancy/agent-principal acting "reviewer"))
+                (:principal/id (tenancy/agent-principal acting "re viewer")))))))
+
 (deftest ^{:stratum 2} spawning-from-a-bad-context-refuses-test
   ;; Refuse rather than mint an agent principal under a tenant that was
   ;; never established.

--- a/components/tenancy/test/ai/miniforge/tenancy/acting_test.clj
+++ b/components/tenancy/test/ai/miniforge/tenancy/acting_test.clj
@@ -190,6 +190,20 @@
       (is (anomaly/anomaly? (tenancy/agent-principal {} "reviewer")))
       (is (anomaly/anomaly?
            (tenancy/agent-principal (dissoc acting :acting/tenant-id) "reviewer"))))
+    (testing "an unestablished tenant id cannot be laundered into an actor"
+      ;; A bare tenant id yields a schema-valid Principal while the
+      ;; acting context it came from was never established. Validating
+      ;; only the output would let any uuid a caller happens to hold
+      ;; become a well-formed agent identity.
+      (is (anomaly/anomaly?
+           (tenancy/agent-principal {:acting/tenant-id (random-uuid)} "reviewer")))
+      (is (anomaly/anomaly?
+           (tenancy/agent-principal (dissoc acting :acting/principal-id) "reviewer")))
+      (is (anomaly/anomaly?
+           (tenancy/agent-principal (dissoc acting :acting/established-at) "reviewer")))
+      (is (re-find #"never established"
+                   (:anomaly/message
+                    (tenancy/agent-principal {:acting/tenant-id (random-uuid)} "reviewer")))))
     (testing "and the refusal names the actual cause, not a plausible one"
       ;; A refusal that blames the agent name for a missing tenant sends
       ;; the reader to the wrong place, which costs more than no message.

--- a/components/workflow/deps.edn
+++ b/components/workflow/deps.edn
@@ -18,6 +18,7 @@
         ai.miniforge/heuristic {:local/root "../heuristic"} ; Workflow storage
         ai.miniforge/event-stream {:local/root "../event-stream"} ; N3 event emission
         ai.miniforge/supervisory-state {:local/root "../supervisory-state"} ; Supervisory snapshot emission
+        ai.miniforge/tenancy {:local/root "../tenancy"}    ; Acting identity carried through the run
         ai.miniforge/knowledge {:local/root "../knowledge"} ; KB for post-execution learning promotion
         ai.miniforge/self-healing {:local/root "../self-healing"} ; Optional backend failover
         ai.miniforge/phase {:local/root "../phase"}        ; Phase interceptors

--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store_records.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store_records.clj
@@ -44,8 +44,14 @@
   (str (java.time.Instant/now)))
 
 (def ^{:stratum 0} persisted-execution-keys
-  "Serializable execution fields kept in the durable machine snapshot."
+  "Serializable execution fields kept in the durable machine snapshot.
+
+   This is an allowlist: a field absent here is silently dropped at
+   checkpoint and gone on resume. `:execution/acting` is listed
+   deliberately — identity that did not survive a checkpoint would let a
+   resumed run be reattributed to whoever resumed it."
   [:execution/id
+   :execution/acting
    :execution/workflow-id
    :execution/workflow-version
    :execution/input

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -359,7 +359,13 @@
        ;; first-class execution key rather than something read back off
        ;; :execution/opts, because opts is replaced wholesale on resume.
        :execution/acting (:acting opts)
-       :execution/opts opts
+       ;; ...and REMOVED from the opts copy, so the context holds exactly
+       ;; one answer to 'who is this acting for'. Leaving it in both
+       ;; places would put the resuming caller's identity in
+       ;; :execution/opts and the original in :execution/acting, and a
+       ;; future reader picking the wrong one gets a plausible wrong
+       ;; owner rather than an error.
+       :execution/opts (dissoc opts :acting)
        :execution/checkpoint-root checkpoint-root
        :execution/logger (execution-logger opts)}
       (monitoring-runtime-fields workflow)
@@ -395,7 +401,11 @@
        ;; whoever resumed it. Stated explicitly so a later edit cannot
        ;; reintroduce that by treating acting like the other opts below.
        :execution/acting (:execution/acting machine-snapshot)
-       :execution/opts opts
+       ;; The resuming caller's `:acting` is dropped here for the same
+       ;; reason: one answer, not two. Keeping it would leave the
+       ;; resumer's identity sitting in :execution/opts, contradicting
+       ;; :execution/acting, for a later reader to pick up by mistake.
+       :execution/opts (dissoc opts :acting)
        :execution/checkpoint-root checkpoint-root
        :execution/logger (execution-logger opts)}
       (monitoring-runtime-fields workflow)

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -355,6 +355,10 @@
        :execution/output nil
        :execution/metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0}
        :execution/started-at (System/currentTimeMillis)
+       ;; Established once, at the boundary that started this run. A
+       ;; first-class execution key rather than something read back off
+       ;; :execution/opts, because opts is replaced wholesale on resume.
+       :execution/acting (:acting opts)
        :execution/opts opts
        :execution/checkpoint-root checkpoint-root
        :execution/logger (execution-logger opts)}
@@ -385,6 +389,12 @@
        :execution/fsm-state fsm-state
        :execution/input (get machine-snapshot :execution/input input)
        :execution/phase-results phase-results
+       ;; From the SNAPSHOT, never from `opts`. A resumed run is still
+       ;; acting under the authority it was started with; taking this
+       ;; from the resuming invocation would reattribute the run to
+       ;; whoever resumed it. Stated explicitly so a later edit cannot
+       ;; reintroduce that by treating acting like the other opts below.
+       :execution/acting (:execution/acting machine-snapshot)
        :execution/opts opts
        :execution/checkpoint-root checkpoint-root
        :execution/logger (execution-logger opts)}

--- a/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
@@ -263,11 +263,18 @@
                        (:execution/id ctx) {:checkpoint/root checkpoint-root}))]
         (testing "the boundary's identity reaches the context"
           (is (= acting (:execution/acting ctx))))
-        (testing "and survives the durable snapshot"
-          (is (= (:acting/tenant-id acting)
-                 (:acting/tenant-id (:execution/acting snapshot))))
-          (is (= (:acting/principal-id acting)
-                 (:acting/principal-id (:execution/acting snapshot)))))
+        (testing "and survives the durable snapshot INTACT"
+          ;; Not just the ids. The snapshot puts every value through
+          ;; `coerce/stringify-instants`, so a field typed `inst?` would
+          ;; go in an Instant and come back a String, and the context
+          ;; would fail its own validation on resume — leaving every
+          ;; resumed run unowned. Asserting the whole map, and that a
+          ;; consumer can still read it, is what catches that.
+          (is (= acting (:execution/acting snapshot))
+              "the acting context round-trips unchanged, field for field")
+          (is (tenancy/valid-acting? (:execution/acting snapshot)))
+          (is (= acting (tenancy/require-acting snapshot :execution/acting))
+              "a consumer reading the restored snapshot gets the identity, not a refusal"))
         (testing "a resumed run keeps the authority it started with"
           ;; The trap this guards: `restore-context` merges the snapshot
           ;; first and then overrides `:execution/opts` from the CURRENT

--- a/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
@@ -22,7 +22,8 @@
    [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
    [ai.miniforge.workflow.checkpoint-store-paths :as checkpoint-paths]
    [ai.miniforge.workflow.context :as ctx]
-   [ai.miniforge.workflow.interface :as workflow]))
+   [ai.miniforge.workflow.interface :as workflow]
+   [ai.miniforge.tenancy.interface :as tenancy]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -237,3 +238,49 @@
             (is (string? (:execution/started-at snapshot)))
             (is (= (:execution/ended-at snapshot)
                    (:execution/started-at snapshot)))))))))
+
+(deftest ^{:stratum 1} acting-identity-survives-a-checkpoint-test
+  ;; `persisted-execution-keys` is an allowlist: a field absent from it
+  ;; is dropped at checkpoint and gone on resume, silently. Identity is
+  ;; the one field where that failure is unrecoverable after the fact,
+  ;; so it gets a round trip through real disk rather than a unit
+  ;; assertion on the key list.
+  (with-temp-checkpoint-root
+    (fn [checkpoint-root]
+      (let [acting (tenancy/establish-acting
+                    (tenancy/resolve-operator {:tenancy {:operator-name "chris"}}
+                                              instant-stamp)
+                    instant-stamp)
+            workflow {:workflow/id :test
+                      :workflow/version "1.0.0"
+                      :workflow/pipeline [{:phase :done}]}
+            ctx (ctx/create-context workflow {:task "Test"}
+                                    {:checkpoint/root checkpoint-root
+                                     :acting acting})
+            _ (checkpoint-store/persist-execution-state! ctx)
+            snapshot (:machine-snapshot
+                      (checkpoint-store/load-checkpoint-data
+                       (:execution/id ctx) {:checkpoint/root checkpoint-root}))]
+        (testing "the boundary's identity reaches the context"
+          (is (= acting (:execution/acting ctx))))
+        (testing "and survives the durable snapshot"
+          (is (= (:acting/tenant-id acting)
+                 (:acting/tenant-id (:execution/acting snapshot))))
+          (is (= (:acting/principal-id acting)
+                 (:acting/principal-id (:execution/acting snapshot)))))
+        (testing "a resumed run keeps the authority it started with"
+          ;; The trap this guards: `restore-context` merges the snapshot
+          ;; first and then overrides `:execution/opts` from the CURRENT
+          ;; invocation. Acting taken from opts would silently
+          ;; reattribute the run to whoever resumed it.
+          (let [someone-else (assoc acting
+                                    :acting/principal-id (random-uuid)
+                                    :acting/tenant-id (random-uuid))
+                restored (ctx/restore-context workflow {:task "Test"} snapshot {}
+                                              {:checkpoint/root checkpoint-root
+                                               :acting someone-else})]
+            (is (= (:acting/tenant-id acting)
+                   (:acting/tenant-id (:execution/acting restored))))
+            (is (= (:acting/principal-id acting)
+                   (:acting/principal-id (:execution/acting restored)))
+                "resuming must not reattribute the run to the resumer")))))))

--- a/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
@@ -290,4 +290,14 @@
                    (:acting/tenant-id (:execution/acting restored))))
             (is (= (:acting/principal-id acting)
                    (:acting/principal-id (:execution/acting restored)))
-                "resuming must not reattribute the run to the resumer")))))))
+                "resuming must not reattribute the run to the resumer")
+            (testing "and the context holds exactly ONE answer to who is acting"
+              ;; Two sources of truth is the same defect wearing a
+              ;; disguise: the resumer's identity in :execution/opts and
+              ;; the original in :execution/acting, with a later reader
+              ;; free to pick the wrong one and get a plausible wrong
+              ;; owner instead of an error.
+              (is (nil? (:acting (:execution/opts restored)))
+                  "the resuming caller's :acting must not survive in opts")
+              (is (nil? (:acting (:execution/opts ctx)))
+                  "nor the starting caller's, in the fresh context"))))))))

--- a/work/ariadne-identity-boundary.spec.edn
+++ b/work/ariadne-identity-boundary.spec.edn
@@ -74,7 +74,7 @@
   "A missing operator identity is an error at the boundary, never an anonymous fallback"
   "No record-birth site is modified in this slice"
   "Stratified design, max 3 layers per file"
-  "New component MUST be added to all four projects' deps.edn or poly check fails"]
+  "New component MUST be registered in the deps.edn of every project that uses it, or poly check fails"]
 
  :spec/acceptance-criteria
  ["Tenant and Principal schemas validate their documented shape and reject extra keys"


### PR DESCRIPTION
Ariadne step 3b, first half: make the acting identity **available** at the places records are born, and make it survive a checkpoint. Stacked on #1796 (3a); merge that first.

Normative refs: `docs/architecture/rfc-ariadne-adoption.md` (adoption step 3), spec `work/ariadne-run-identity-threading.spec.edn`.

## What this adds

`components/tenancy/acting.clj` — a closed `ActingContext` (`:acting/tenant-id`, `:acting/principal-id`, `:acting/established-at`), plus:

- `establish` — reduce a resolved `Identity` to the context a run carries. Called once per boundary.
- `require-acting` — return it or an anomaly. Never a default, never nil.
- `agent-principal` / `for-agent` — a spawned agent inherits the spawning **tenant** and gets its own `:agent-instance` **principal**, so "an agent did it" and "the operator did it" stay distinguishable.

It carries **ids, not records**: the context is checkpointed and restored, and embedding `Tenant`/`Principal` maps would mean a resumed run replays a display name captured months ago.

`:execution/acting` is then threaded through `create-context` -> checkpoint -> `restore-context`.

## Why this was written against verified shapes

Before writing anything I read the real producers rather than assuming, because two traps sit directly on this path and both fail **silently**:

1. `persisted-execution-keys` (checkpoint_store.clj) is an **allowlist**. A field absent from it is dropped at checkpoint and gone on resume, with no error. Identity is the one field where that loss cannot be repaired after the fact.
2. `restore-context` merges the machine snapshot first and then overrides `:execution/opts` from the **current** invocation. Acting sourced from opts would silently reattribute a resumed run to whoever resumed it.

So acting is a first-class execution key (not carried on opts), listed explicitly in the allowlist, and read in `restore-context` **from the snapshot** — stated explicitly rather than left to merge order, so a later edit cannot reintroduce reattribution by treating it like the other opts.

## Verification

Both failure modes are **mutation-tested** — the test is only worth what it catches:

| mutation | result |
|---|---|
| drop `:execution/acting` from `persisted-execution-keys` | 3 assertions fail |
| `restore-context` sources acting from `opts` | 2 assertions fail |
| `:acting/established-at` back to `inst?` | 5 assertions fail |

The checkpoint test round-trips through **real disk** (`persist-execution-state!` -> `load-checkpoint-data`), and builds its acting context with the real `tenancy/establish-acting` rather than a hand-rolled fixture — hence the new `tenancy` dep in `components/workflow/deps.edn`.

### A defect this PR shipped and then fixed

Copilot caught it, and it was real: with `:acting/established-at` typed `inst?`, the value went into the snapshot an `Instant` and came back a `String`, because the machine snapshot puts everything through `coerce/stringify-instants`. The restored context failed its own validation, so `require-acting` refused a legitimately resumed run — **every resumed run unowned**. Fail-closed, but wrong.

```
ORIGINAL-TYPE   java.time.Instant
RESTORED-TYPE   java.lang.String
RESTORED-VALID? false
```

The reason it got through is the second review comment, which is the more useful one: the test asserted the two ids and skipped the one field that does not survive. It now asserts the whole map round-trips field for field, **and** that `require-acting` still reads it — the thing every 3c consumer will do.

`:acting/established-at` is now a canonical ISO-8601 string. Normalization lives in `ai.miniforge.tenancy.instant` and accepts `Instant` and `Date` both, since `inst?` admits either and `(str date)` is unparseable.

Full `bb test` green.

## Deliberately not here

- Boundary wiring (CLI, MCP, daemon, scheduled trigger) and agent-boundary propagation — second half of 3b.
- Stamping owners onto records — 3c.

## Note on the stratum gate

`checkpoint_store.clj` is **already** over the SL003 layer budget (5 layers) on the base branch. This change adds a docstring and one vector entry, and no layer. Committed with `MINIFORGE_STRATUM_BUDGET_MODE=warn`, which exists for pre-existing over-budget files. The namespace split is real debt but belongs in its own change, not smuggled into an identity PR.

## Sweep that preceded this

Asked to check whether the silent-drop allowlist class had spread, I swept `select-keys` across production src. It has not: only two named key-allowlists exist repo-wide (both above), and only two `select-keys` feed persistence.

One unrelated **live** hazard surfaced and is left for the `deploy-wire` session already in that file: `deploy_provider/render!` returns a raw shell result (`:stdout`, via `kustomize-build!`) while its sibling `apply!` returns a schema'd `KustomizeApplyResult` (`:rendered-yaml`, via `kustomize-apply!`). Same namespace, same docstring style, incompatible shapes, nothing naming the difference — that is what #1794 fell into. The adapter was fixed; the trap was not.

Also noted: `:execution/files-written` is written onto the context and read by nobody (consumers read `:workflow/files-written`). Dead, not dangerous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
