### PR TITLE
fix(deploy): one result shape for rendering and applying a manifest

### DIFF
--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_flow.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_flow.clj
@@ -35,8 +35,7 @@
 (defn- ^{:stratum 1} apply-outcome!
   [deploy-config rollback-info]
   (let [applied (provider/apply! deploy-config)
-        rendered-yaml (or (:rendered-yaml applied)
-                          (get-in applied [:build-result :stdout]))]
+        rendered-yaml (:rendered-yaml applied)]
     (if (schema/failed? applied)
       (outcome :failed :apply rollback-info
                {:deploy/rendered-yaml rendered-yaml

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_governed.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_governed.clj
@@ -98,10 +98,23 @@
 (defn ^{:stratum 2} transact!
   "Dry-run, check, authorize, record, and only then mutate.
 
-   `provider` supplies `:dry-run!`, `:apply!`, `:observe!`, and
-   `:rollback-info!`. Returns the deploy outcome map the flow already
-   speaks, so the refusal paths look like every other failure to the
-   caller — except that no kubectl mutation ran."
+   `provider` is an adapter, not `deploy-provider` itself. Each slot takes
+   `deploy-config` and must return what this seam reads:
+
+   - `:dry-run!` -> the rendered manifest as a STRING. `preflight` denies a
+     blank one, so returning a result map instead denies every deploy.
+     Bridge it with `(:rendered-yaml (provider/render! config))`.
+   - `:apply!` -> a map in the flow's own vocabulary: `:deploy/failed?`,
+     `:deploy/failure`, `:deploy/rollback-info`. `deploy-provider/apply!`
+     speaks `:success?` instead, so wiring it raw makes a failed apply read
+     as not-failed and fall through to observation.
+   - `:observe!` -> `:provider/matched?` and `:provider/observed`, which
+     `deploy-provider/observe!` already returns.
+   - `:rollback-info!` -> the pre-mutation state, or an anomaly.
+
+   Returns the deploy outcome map the flow already speaks, so the refusal
+   paths look like every other failure to the caller — except that no
+   kubectl mutation ran."
   [context deploy-config provider ^Instant now]
   (let [rendered ((:dry-run! provider) deploy-config)
         pre (authority/preflight rendered (:policy-context context {}))]

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_provider.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_provider.clj
@@ -33,24 +33,41 @@
    [:replicas {:optional true} [:maybe int?]]])
 
 (defn ^{:stratum 0} apply!
-  "Build and apply one Kustomize target through the shell adapter."
+  "Build and apply one Kustomize target through the shell adapter.
+
+   Returns a `kustomize/KustomizeResult`: the manifest is under
+   `:rendered-yaml`. Same shape as [[render!]]."
   [{:keys [kustomize-dir namespace context]}]
   (shell/kustomize-apply! kustomize-dir
                           :namespace namespace :context context))
 
 (defn ^{:stratum 0} render!
-  "Render one Kustomize target without contacting Kubernetes."
+  "Render one Kustomize target without contacting Kubernetes.
+
+   Returns a `kustomize/KustomizeResult`: the manifest is under
+   `:rendered-yaml`, exactly as in [[apply!]], and `:apply-result` is nil
+   because nothing was applied. Reading the manifest is the same expression
+   whichever of the two you called."
   [{:keys [kustomize-dir]}]
-  (shell/kustomize-build! kustomize-dir))
+  (shell/kustomize-render! kustomize-dir))
 
 (defn ^{:stratum 0} apply-rendered!
-  "Apply exactly the manifest bytes recorded by the caller."
+  "Apply exactly the manifest bytes recorded by the caller.
+
+   Takes the manifest and returns a raw `exec/CommandResult` — kubectl's
+   own output under `:stdout`. This is NOT the `KustomizeResult` that
+   [[apply!]] and [[render!]] return; it has no `:rendered-yaml`, because
+   the caller already holds the bytes it passed in."
   [{:keys [namespace context]} rendered-yaml]
   (shell/kubectl-apply! rendered-yaml
                         :namespace namespace :context context))
 
 (defn ^{:stratum 0} dry-run!
-  "Ask the API server to validate exactly the manifest bytes to be applied."
+  "Ask the API server to validate exactly the manifest bytes to be applied.
+
+   Like [[apply-rendered!]], takes the manifest and returns a raw
+   `exec/CommandResult`, not a `KustomizeResult`. The server's echo of the
+   validated objects is under `:stdout`."
   [{:keys [namespace context]} rendered-yaml]
   (shell/kubectl-apply! rendered-yaml :namespace namespace :context context
                         :server-dry-run? true))

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell.clj
@@ -49,6 +49,8 @@
 
 (def ^{:stratum 0} kustomize-build! kustomize/kustomize-build!)
 
+(def ^{:stratum 0} kustomize-render! kustomize/kustomize-render!)
+
 (def ^{:stratum 0} kubectl-apply! kustomize/kubectl-apply!)
 
 (def ^{:stratum 0} kustomize-apply! kustomize/kustomize-apply!)

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kustomize.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kustomize.clj
@@ -26,7 +26,17 @@
 ;------------------------------------------------------------------------------ Layer 0
 
 ;; Kustomize wrappers
-(def ^{:stratum 0} KustomizeApplyResult
+(def ^{:stratum 0} KustomizeResult
+  "The one result shape for producing a Kustomize manifest, shared by
+   `kustomize-render!` and `kustomize-apply!`.
+
+   The manifest is always under `:rendered-yaml` and the raw build shell
+   result under `:build-result`. Render and apply differ in exactly one
+   key: `:apply-result` is nil for a render, because nothing was applied.
+
+   They share a shape deliberately. When rendering returned a raw shell
+   result and applying returned this one, a caller reading `:rendered-yaml`
+   off the render got nil and read a healthy render as an empty one."
   [:map
    [:success? :boolean]
    [:rendered-yaml [:maybe :string]]
@@ -36,6 +46,12 @@
    [:anomaly {:optional true} map?]])
 
 (defn ^{:stratum 0} kustomize-build!
+  "Run `kustomize build` and return `exec/sh-with-timeout`'s raw
+   `CommandResult`, whose manifest is under `:stdout`.
+
+   This is the unwrapped process boundary, NOT a `KustomizeResult` — it has
+   no `:rendered-yaml`. Callers outside this namespace want
+   `kustomize-render!`."
   [kustomize-dir & {:keys [timeout-ms] :or {timeout-ms (get timeouts/timeouts :kustomize-build-ms 60000)}}]
   (exec/sh-with-timeout "kustomize" ["build" kustomize-dir] :timeout-ms timeout-ms))
 
@@ -61,18 +77,41 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} kustomize-apply!
-  [kustomize-dir & {:keys [namespace context dry-run?]}]
+(defn ^{:stratum 1} kustomize-render!
+  "Build one Kustomize target and report it as a `KustomizeResult`.
+
+   `:apply-result` is nil — nothing was applied, and nothing contacted the
+   cluster. `:rendered-yaml` is nil only when the build itself failed, so a
+   nil manifest means no manifest, never a manifest under another key."
+  [kustomize-dir]
   (let [build-result (kustomize-build! kustomize-dir)]
-    (if (schema/failed? build-result)
-      (schema/validate-anomaly
-       KustomizeApplyResult
+    (schema/validate-anomaly
+     KustomizeResult
+     (if (schema/failed? build-result)
        (schema/failure :rendered-yaml
                        (msg/t :shell/kustomize-build-failed
                               {:error (failure-detail build-result)})
                        {:build-result build-result
-                        :apply-result nil}))
-      (let [rendered-yaml (:stdout build-result)
+                        :apply-result nil})
+       (schema/success :rendered-yaml (:stdout build-result)
+                       {:build-result build-result
+                        :apply-result nil})))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} kustomize-apply!
+  "Render one Kustomize target and apply exactly those bytes.
+
+   Returns the same `KustomizeResult` shape as `kustomize-render!`, so a
+   caller reads the manifest from `:rendered-yaml` whichever it called. A
+   build failure is returned unchanged from the render — there is nothing
+   to apply and no kubectl runs."
+  [kustomize-dir & {:keys [namespace context dry-run?]}]
+  (let [rendered (kustomize-render! kustomize-dir)]
+    (if (schema/failed? rendered)
+      rendered
+      (let [rendered-yaml (:rendered-yaml rendered)
+            build-result  (:build-result rendered)
             apply-args    (cond-> ["apply" "-f" "-"]
                             namespace (into ["--namespace" namespace])
                             context   (into ["--context" context])
@@ -80,20 +119,23 @@
             apply-result  (exec/sh-with-timeout "kubectl" apply-args
                                                 :in rendered-yaml
                                                 :timeout-ms (get timeouts/timeouts :kustomize-apply-ms 120000))]
-        (if (schema/succeeded? apply-result)
-          (schema/validate-anomaly
-           KustomizeApplyResult
+        (schema/validate-anomaly
+         KustomizeResult
+         (if (schema/succeeded? apply-result)
            (schema/success :rendered-yaml rendered-yaml
                            {:build-result build-result
-                            :apply-result apply-result}))
-          (schema/validate-anomaly
-           KustomizeApplyResult
+                            :apply-result apply-result})
+           ;; `schema/failure` nils its data key and merges opts last. The
+           ;; manifest is re-set deliberately: the build succeeded, and what
+           ;; kubectl rejected is the evidence worth keeping.
            (schema/failure :rendered-yaml
                            (failure-detail apply-result)
                            {:build-result build-result
-                            :apply-result apply-result})))))))
+                            :apply-result apply-result
+                            :rendered-yaml rendered-yaml})))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (kustomize-build! "/path/to/overlay")
+  (kustomize-render! "/path/to/overlay")
   :leave-this-here)

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_flow_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_flow_test.clj
@@ -22,6 +22,7 @@
    [ai.miniforge.phase-deployment.deploy-flow :as flow]
    [ai.miniforge.phase-deployment.deploy-provider :as provider]
    [ai.miniforge.phase-deployment.shell :as shell]
+   [ai.miniforge.phase-deployment.shell.exec :as exec]
    [ai.miniforge.schema.interface :as schema]
    [clojure.test :refer [deftest is]]))
 
@@ -38,8 +39,19 @@
 
 (def ^{:stratum 0} rollback-info {:revision "7" :image "api:v7" :replicas 3})
 
-(def ^{:stratum 0} apply-failure
-  (schema/failure :rendered-yaml "apply refused" {:build-result {:stdout "image: api:v8"}}))
+(defn ^{:stratum 0} apply-failure
+  "A refused apply in the shape `kustomize-apply!` actually produces, taken
+   from that producer with only the process boundary stubbed. Hand-writing
+   this map is how a fixture drifts from what deploys really return — the
+   previous one had no `:rendered-yaml` at all, and passed only because the
+   flow guessed at `[:build-result :stdout]`."
+  []
+  (with-redefs [exec/sh-with-timeout
+                (fn [command _args & _]
+                  (if (= "kustomize" command)
+                    (schema/success :stdout "image: api:v8")
+                    (schema/failure :stdout "apply refused" {:stderr "apply refused"})))]
+    (shell/kustomize-apply! "/deploy")))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -53,11 +65,12 @@
 
 (deftest ^{:stratum 1} apply-failure-preserves-rollback-test
   (with-redefs [provider/rollback-info! (constantly rollback-info)
-                provider/apply! (constantly apply-failure)]
+                provider/apply! (constantly (apply-failure))]
     (let [deployment (flow/execute! (deployment-config))]
       (is (= :failed (:deploy/status deployment)))
       (is (= :apply (:deploy/stage deployment)))
-      (is (= "image: api:v8" (:deploy/rendered-yaml deployment)))
+      (is (= "image: api:v8" (:deploy/rendered-yaml deployment))
+          "the manifest reaches the flow from :rendered-yaml, not a guessed key")
       (is (= rollback-info (:deploy/rollback-info deployment))))))
 
 (deftest ^{:stratum 1} invalid-rollback-stops-apply-test

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/shell/kustomize_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/shell/kustomize_test.clj
@@ -38,6 +38,18 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
+(defn ^{:stratum 1} scripted-shell
+  "Stub the process boundary and nothing above it. `kustomize-build!`,
+   `kustomize-render!`, and `kustomize-apply!` all stay real, so what these
+   tests assert is the producers' own output shape rather than a stub's."
+  [calls & {:keys [apply-result]
+            :or {apply-result (schema/success :stdout "deployment.apps/api configured")}}]
+  (fn [command args & {:as options}]
+    (swap! calls conj {:command command :args args :options options})
+    (if (= "kustomize" command)
+      (schema/success :stdout manifest-bytes)
+      apply-result)))
+
 (deftest ^{:stratum 1} server-dry-run-and-apply-use-identical-input-test
   (let [calls (atom [])]
     (with-redefs [exec/sh-with-timeout (recording-shell calls)]
@@ -59,6 +71,14 @@
                 "--context" "cluster-1"]
                (:args apply-call)))))))
 
+(deftest ^{:stratum 1} a-failed-build-renders-no-manifest-test
+  (let [result (with-redefs [exec/sh-with-timeout
+                             (fn [& _] (blank-stderr-failure "build broke"))]
+                 (kustomize/kustomize-render! "/deployment"))]
+    (is (schema/failed? result))
+    (is (nil? (:rendered-yaml result))
+        "a nil manifest means no manifest, not a manifest under another key")))
+
 (deftest ^{:stratum 1} blank-stderr-retains-command-error-test
   (testing "build failures retain the structured command error"
     (let [result (with-redefs [kustomize/kustomize-build!
@@ -74,3 +94,35 @@
                    (kustomize/kustomize-apply! "/deployment"))]
       (is (schema/failed? result))
       (is (= "apply broke" (:error result))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} render-and-apply-report-the-manifest-under-one-key-test
+  ;; The trap this closes: a governed caller wired :render! and then read
+  ;; :rendered-yaml off the result. Rendering used to return a raw shell
+  ;; result, so that key was nil, and a healthy render read as an empty one
+  ;; — which denies every deploy.
+  (let [render-calls (atom [])
+        rendered (with-redefs [exec/sh-with-timeout (scripted-shell render-calls)]
+                   (kustomize/kustomize-render! "/deployment"))
+        applied (with-redefs [exec/sh-with-timeout (scripted-shell (atom []))]
+                  (kustomize/kustomize-apply! "/deployment"))]
+    (is (= manifest-bytes (:rendered-yaml rendered)))
+    (is (= (:rendered-yaml rendered) (:rendered-yaml applied))
+        "render and apply must report the manifest under the same key")
+    (testing "a render contacts no cluster"
+      (is (= ["kustomize"] (mapv :command @render-calls)))
+      (is (nil? (:apply-result rendered))
+          "nothing was applied, so there is no apply result to report"))))
+
+(deftest ^{:stratum 2} a-refused-apply-keeps-the-manifest-it-built-test
+  ;; The manifest kubectl rejected is the evidence of what was attempted.
+  ;; Nilling it left callers digging it out of [:build-result :stdout] by
+  ;; guesswork, which is the same trap wearing a different key.
+  (let [result (with-redefs [exec/sh-with-timeout
+                             (scripted-shell (atom [])
+                                             :apply-result (blank-stderr-failure "apply broke"))]
+                 (kustomize/kustomize-apply! "/deployment"))]
+    (is (schema/failed? result))
+    (is (= manifest-bytes (:rendered-yaml result))
+        "the build succeeded, so its manifest survives the apply failure")))


### PR DESCRIPTION
## The trap

`deploy-provider/render!` returned `kustomize-build!`'s raw shell result — manifest under `:stdout`. Its sibling `apply!` returned a schema'd `KustomizeApplyResult` — manifest under `:rendered-yaml`. Same namespace, same docstring style, no schema on `render!`, and nothing in either docstring said the shapes differed.

[PR #1794](https://github.com/miniforge-ai/miniforge/pull/1794) fell into it: the governed deploy adapter wired `:render! provider/render!`, read `:rendered-yaml` off the result, got `nil`, and `authority/preflight` denies a blank render. Every deploy would have been denied. That adapter was fixed in its own worktree; the trap that produced it was not.

## What changed

1. `KustomizeApplyResult` → `KustomizeResult`, now the one shape for producing a manifest, with a docstring saying so. No external references to the old name.
2. New `kustomize-render!`: build, reported as a `KustomizeResult` with `:apply-result nil`. `kustomize-apply!` is now render-then-apply, so the two shapes cannot drift and a build failure returns identically from both.
3. **A refused apply keeps the manifest it built.** `schema/failure` nils its data key, so the apply-failure branch was discarding the very bytes kubectl rejected. That is why `deploy-flow` had to guess at `[:build-result :stdout]` — the fallback was load-bearing, not merely defensive. Both are fixed: the manifest survives, the fallback is gone.
4. `dry-run!` and `apply-rendered!` docstrings now name their shape: raw `CommandResult`, deliberately **not** `KustomizeResult`. Nothing in the namespace returns an unnamed shape any more.
5. `governed/transact!`'s provider-map contract is documented. Two more slots had unnamed shapes, verified by running them:
   - `:dry-run!` must return the manifest as a **string**; a result map denies every deploy.
   - `:apply!` must speak `:deploy/failed?`. `deploy-provider/apply!` speaks `:success?`, so wiring it raw makes a genuinely failed apply read as not-failed and fall through to observation.

   Docstring only — no behavior change. The governed seam's tests use stubs that happen to satisfy the implied contract, which is why neither mismatch was visible.

## Verification

Against the real producers, not stubs. `exec/sh-with-timeout` returns an `exec/CommandResult` (manifest under `:stdout`); `schema/failure` sets its data key to `nil` and merges opts last. Both confirmed by reading the source and by running the producers.

- `render!` had no other callers; the only other `render!` in the repo is `tui-engine`'s, unrelated.
- New tests stub only the process boundary, so `kustomize-build!`/`render!`/`apply!` all stay real.
- The `deploy-flow` fixture for a refused apply now comes from `kustomize-apply!` itself. The hand-written one had no `:rendered-yaml` at all and passed only via the fallback.
- Mutation-checked: reverting the manifest-retention change fails the two new assertions; restoring it passes them.
- 69 tests / 188 assertions green in `phase-deployment`; 345 tests / 1301 assertions in the pre-commit smoke; clj-kondo and stratum-lint clean.

## Not fixed here

`deploy_authority.clj:67` uses `clojure.string/blank?` without requiring `clojure.string` — a pre-existing clj-kondo warning in this component, untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)