### PR TITLE
refactor(workflow): split checkpoint_store.clj (rule 210)

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
@@ -16,89 +16,35 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.workflow.checkpoint-store
-  "Durable execution-machine snapshots and phase checkpoints.
+  "Durable execution-machine snapshots and phase checkpoints: the two
+   operations that move a checkpoint between memory and disk.
 
-   Strata, bottom-up: filenames, key lists and path normalization (0);
-   the per-run paths, the atomic write, and the snapshot/phase-record
-   builders (1); `resolve-checkpoint-root` and `phase-checkpoint-path`
-   (2); `build-manifest` and `load-checkpoint-data` (3);
-   `persist-execution-state!`, which drives all of it (4).
+   `persist-execution-state!` writes a run's snapshot, manifest and
+   current phase checkpoint; `load-checkpoint-data` reads them back.
+   Both go through the same EDN read/write pair below, so the instant
+   normalization a restore depends on is a property of the store rather
+   than of whichever version wrote the file.
 
-   Five, two over the budget — SL003 fires here and fired identically
-   before this file carried any stratum metadata. The chain is real
-   (persist → manifest → per-phase path → atomic write → path
-   normalization), so closing it means splitting the namespace along
-   the path-resolution / record-building / persistence seam, not
-   renumbering what is here."
+   Two siblings carry what used to be the lower half of this chain,
+   which stood at five strata against rule 210's cap of three:
+   `checkpoint-store-paths` resolves the checkpoint root and every
+   per-run path; `checkpoint-store-records` builds the snapshot,
+   per-phase and manifest records — including
+   `persisted-execution-keys`, the allowlist deciding what survives a
+   checkpoint."
   (:require
    [ai.miniforge.coerce.interface :as coerce]
-   [ai.miniforge.config.interface :as config]
+   [ai.miniforge.workflow.checkpoint-store-paths :as checkpoint-paths]
+   [ai.miniforge.workflow.checkpoint-store-records :as checkpoint-records]
    [ai.miniforge.workflow.schemas :as schemas]
    [babashka.fs :as fs]
    [clojure.edn :as edn]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Constants and path resolution
-(def ^{:stratum 0} checkpoint-root-option-key
-  "Execution option key for overriding the checkpoint root."
-  :checkpoint/root)
-
-(def ^{:stratum 0} machine-snapshot-filename
-  "Filename for the authoritative execution-machine snapshot."
-  "machine-snapshot.edn")
-
-(def ^{:stratum 0} manifest-filename
-  "Filename for the durable workflow checkpoint manifest."
-  "manifest.edn")
-
-(def ^{:stratum 0} phase-checkpoints-directory-name
-  "Directory name for per-phase checkpoint files."
-  "phases")
-
 (def ^{:stratum 0} temp-file-suffix
   "Temporary suffix used for atomic checkpoint writes."
   ".tmp")
-
-(defn- ^{:stratum 0} current-checkpoint-timestamp
-  []
-  (str (java.time.Instant/now)))
-
-(def ^{:stratum 0} persisted-execution-keys
-  "Serializable execution fields kept in the durable machine snapshot."
-  [:execution/id
-   :execution/workflow-id
-   :execution/workflow-version
-   :execution/input
-   :execution/status
-   :execution/current-phase
-   :execution/phase-index
-   :execution/redirect-count
-   :execution/fsm-state
-   :execution/response-chain
-   :execution/errors
-   :execution/phase-handoffs
-   :execution/artifacts
-   :execution/dag-result
-   :execution/dag-pr-infos
-   :execution/metrics
-   :execution/output
-   :execution/started-at
-   :execution/ended-at
-   :execution/environment-id
-   :execution/environment-metadata
-   :execution/worktree-path
-   :execution/mode
-   :execution/completed-with-warnings?])
-
-(defn- ^{:stratum 0} normalize-checkpoint-root
-  [checkpoint-root]
-  (some-> checkpoint-root fs/expand-home str))
-
-(defn ^{:stratum 0} workflow-checkpoint-dir
-  "Directory for one workflow run's durable checkpoint state."
-  [checkpoint-root workflow-run-id]
-  (str (fs/path checkpoint-root (str workflow-run-id))))
 
 (defn- ^{:stratum 0} read-edn-file
   "Read a checkpoint EDN file, normalizing instants the same way the
@@ -114,41 +60,7 @@
   (when (fs/exists? path)
     (coerce/stringify-instants (edn/read-string (slurp path)))))
 
-(defn ^{:stratum 0} ordered-phase-ids
-  "Phase ids in workflow pipeline order, filtered to checkpointed phases."
-  [ctx]
-  (let [phase-results (:execution/phase-results ctx)
-        pipeline-phase-ids (map :phase (get-in ctx [:execution/workflow :workflow/pipeline]))
-        ordered-phase-ids (filter #(contains? phase-results %) pipeline-phase-ids)
-        remaining-phase-ids (remove (set ordered-phase-ids) (keys phase-results))]
-    (vec (concat ordered-phase-ids remaining-phase-ids))))
-
 ;------------------------------------------------------------------------------ Layer 1
-
-(defn ^{:stratum 1} default-checkpoint-root
-  "Default durable checkpoint root from merged config."
-  []
-  (normalize-checkpoint-root
-   (or (get-in (config/load-merged-config) [:workflow :checkpoint-root])
-       (str (config/miniforge-home) "/checkpoints"))))
-
-(defn ^{:stratum 1} machine-snapshot-path
-  "Path to the authoritative machine snapshot for a workflow run."
-  [checkpoint-root workflow-run-id]
-  (str (fs/path (workflow-checkpoint-dir checkpoint-root workflow-run-id)
-                machine-snapshot-filename)))
-
-(defn ^{:stratum 1} manifest-path
-  "Path to the manifest for a workflow run."
-  [checkpoint-root workflow-run-id]
-  (str (fs/path (workflow-checkpoint-dir checkpoint-root workflow-run-id)
-                manifest-filename)))
-
-(defn ^{:stratum 1} phase-checkpoints-dir
-  "Directory that stores per-phase checkpoint files."
-  [checkpoint-root workflow-run-id]
-  (str (fs/path (workflow-checkpoint-dir checkpoint-root workflow-run-id)
-                phase-checkpoints-directory-name)))
 
 (defn- ^{:stratum 1} write-edn-atomically!
   [target-path data]
@@ -161,101 +73,19 @@
     (fs/move temp-path target-path)
     target-path))
 
-(defn ^{:stratum 1} active-or-last-phase
-  "Current phase when present, otherwise the last checkpointed phase."
-  [ctx]
-  (or (:execution/current-phase ctx)
-      (last (ordered-phase-ids ctx))))
-
-(defn ^{:stratum 1} build-machine-snapshot
-  "Build the durable machine snapshot for an execution context.
-
-   Timestamps are normalized by type on the way out. Writers of
-   :execution/started-at / :execution/ended-at disagree today
-   (context.clj writes epoch millis, runner.clj an Instant), and
-   `inst?` admits a Date as readily as an Instant — so without
-   normalization a restore hands its reader an Instant-derived string
-   from one writer and a live Date from another for the same key."
-  [ctx]
-  (-> (select-keys ctx persisted-execution-keys)
-      coerce/stringify-instants))
-
-(defn ^{:stratum 1} build-phase-checkpoint
-  "Build a durable per-phase checkpoint record."
-  [ctx phase-name phase-result]
-  (let [checkpointed-at (current-checkpoint-timestamp)]
-    (coerce/stringify-instants
-     {:workflow/id (:execution/id ctx)
-      :workflow/workflow-id (:execution/workflow-id ctx)
-      :workflow/workflow-version (:execution/workflow-version ctx)
-      :workflow/phase phase-name
-      :workflow/checkpointed-at checkpointed-at
-      :phase/result phase-result})))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn ^{:stratum 2} resolve-checkpoint-root
-  "Resolve checkpoint root from context/opts/config."
-  ([]
-   (default-checkpoint-root))
-  ([m]
-   (normalize-checkpoint-root
-    (or (:execution/checkpoint-root m)
-        (get m checkpoint-root-option-key)
-        (get-in m [:execution/opts checkpoint-root-option-key])
-        (default-checkpoint-root)))))
-
-(defn ^{:stratum 2} phase-checkpoint-path
-  "Path to a persisted phase checkpoint."
-  [checkpoint-root workflow-run-id phase-name]
-  (str (fs/path (phase-checkpoints-dir checkpoint-root workflow-run-id)
-                (str (name phase-name) ".edn"))))
-
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} build-manifest
-  "Build the durable checkpoint manifest for an execution context."
-  ([ctx checkpoint-root]
-   (build-manifest ctx checkpoint-root nil))
-  ([ctx checkpoint-root existing-manifest]
-   (let [workflow-run-id (:execution/id ctx)
-         current-phase-ids (ordered-phase-ids ctx)
-         existing-phase-paths (or (:workflow/phase-checkpoints existing-manifest) {})
-         existing-phase-ids (or (not-empty (:workflow/phases-completed existing-manifest))
-                                (sort-by name (keys existing-phase-paths)))
-         phase-ids (vec (concat existing-phase-ids
-                                (remove (set existing-phase-ids)
-                                        current-phase-ids)))
-         current-phase-paths (into {}
-                                   (map (fn [phase-id]
-                                          [phase-id
-                                           (phase-checkpoint-path checkpoint-root
-                                                                  workflow-run-id
-                                                                  phase-id)]))
-                                   current-phase-ids)
-         phase-paths (merge existing-phase-paths current-phase-paths)]
-     (coerce/stringify-instants
-      {:workflow/id workflow-run-id
-       :workflow/workflow-id (:execution/workflow-id ctx)
-       :workflow/workflow-version (:execution/workflow-version ctx)
-       :workflow/phases-completed phase-ids
-       :workflow/machine-snapshot-path
-       (machine-snapshot-path checkpoint-root workflow-run-id)
-       :workflow/phase-checkpoints phase-paths
-       :workflow/last-checkpoint-at (current-checkpoint-timestamp)}))))
-
-(defn ^{:stratum 3} load-checkpoint-data
+(defn ^{:stratum 1} load-checkpoint-data
   "Load durable checkpoint data for a workflow run, if present."
   ([workflow-run-id]
    (load-checkpoint-data workflow-run-id {}))
   ([workflow-run-id opts]
    (try
-     (let [checkpoint-root (resolve-checkpoint-root opts)
-           manifest-path' (manifest-path checkpoint-root workflow-run-id)
-           manifest (read-edn-file manifest-path')
-           snapshot-path' (or (:workflow/machine-snapshot-path manifest)
-                              (machine-snapshot-path checkpoint-root workflow-run-id))
-           machine-snapshot (read-edn-file snapshot-path')
+     (let [checkpoint-root (checkpoint-paths/resolve-checkpoint-root opts)
+           manifest-path (checkpoint-paths/manifest-path checkpoint-root workflow-run-id)
+           manifest (read-edn-file manifest-path)
+           snapshot-path (or (:workflow/machine-snapshot-path manifest)
+                             (checkpoint-paths/machine-snapshot-path checkpoint-root
+                                                                     workflow-run-id))
+           machine-snapshot (read-edn-file snapshot-path)
            phase-paths (or (:workflow/phase-checkpoints manifest) {})
            phase-results (into {}
                                (keep (fn [[phase-id path]]
@@ -270,21 +100,21 @@
      (catch Exception _
        nil))))
 
-;------------------------------------------------------------------------------ Layer 4
+;------------------------------------------------------------------------------ Layer 2
 
-;; Persistence and restore inputs
-(defn ^{:stratum 4} persist-execution-state!
+(defn ^{:stratum 2} persist-execution-state!
   "Persist a machine snapshot, manifest, and current phase checkpoint."
   [ctx]
   (when-let [workflow-run-id (:execution/id ctx)]
-    (let [checkpoint-root (resolve-checkpoint-root ctx)
-          phase-name (active-or-last-phase ctx)
+    (let [checkpoint-root (checkpoint-paths/resolve-checkpoint-root ctx)
+          phase-name (checkpoint-records/active-or-last-phase ctx)
           phase-result (get-in ctx [:execution/phase-results phase-name])
-          snapshot-path' (machine-snapshot-path checkpoint-root workflow-run-id)
-          manifest-path' (manifest-path checkpoint-root workflow-run-id)
-          existing-manifest (read-edn-file manifest-path')
-          snapshot (build-machine-snapshot ctx)
-          manifest (build-manifest ctx checkpoint-root existing-manifest)
+          snapshot-path (checkpoint-paths/machine-snapshot-path checkpoint-root
+                                                                workflow-run-id)
+          manifest-path (checkpoint-paths/manifest-path checkpoint-root workflow-run-id)
+          existing-manifest (read-edn-file manifest-path)
+          snapshot (checkpoint-records/build-machine-snapshot ctx)
+          manifest (checkpoint-records/build-manifest ctx checkpoint-root existing-manifest)
           checkpoint-data {:checkpoint/root checkpoint-root
                            :manifest manifest
                            :machine-snapshot snapshot
@@ -293,12 +123,14 @@
       (try
         (when (and phase-name phase-result)
           (write-edn-atomically!
-           (phase-checkpoint-path checkpoint-root workflow-run-id phase-name)
-           (build-phase-checkpoint ctx phase-name phase-result)))
-        (write-edn-atomically! snapshot-path' snapshot)
-        (write-edn-atomically! manifest-path' manifest)
+           (checkpoint-paths/phase-checkpoint-path checkpoint-root
+                                                   workflow-run-id
+                                                   phase-name)
+           (checkpoint-records/build-phase-checkpoint ctx phase-name phase-result)))
+        (write-edn-atomically! snapshot-path snapshot)
+        (write-edn-atomically! manifest-path manifest)
         {:checkpoint/root checkpoint-root
-         :checkpoint/machine-snapshot-path snapshot-path'
-         :checkpoint/manifest-path manifest-path'}
+         :checkpoint/machine-snapshot-path snapshot-path
+         :checkpoint/manifest-path manifest-path}
         (catch Exception _
           nil)))))

--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store_paths.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store_paths.clj
@@ -1,0 +1,107 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.workflow.checkpoint-store-paths
+  "Where one workflow run's durable checkpoint state lives on disk.
+
+   Filenames, the per-run directory layout, and root resolution from
+   context / opts / config. Nothing here opens a file: callers get a
+   path string back and decide what to do with it.
+
+   Split out of `checkpoint-store`, which held path resolution, record
+   building and persistence as one five-stratum chain in a single file
+   (rule 210 caps a file at three). `checkpoint-store-records` builds
+   what gets written; this namespace answers where it goes;
+   `checkpoint-store` does the writing."
+  (:require
+   [ai.miniforge.config.interface :as config]
+   [babashka.fs :as fs]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Constants and single-segment path pieces
+(def ^{:stratum 0} checkpoint-root-option-key
+  "Execution option key for overriding the checkpoint root."
+  :checkpoint/root)
+
+(def ^{:stratum 0} machine-snapshot-filename
+  "Filename for the authoritative execution-machine snapshot."
+  "machine-snapshot.edn")
+
+(def ^{:stratum 0} manifest-filename
+  "Filename for the durable workflow checkpoint manifest."
+  "manifest.edn")
+
+(def ^{:stratum 0} phase-checkpoints-directory-name
+  "Directory name for per-phase checkpoint files."
+  "phases")
+
+(defn- ^{:stratum 0} normalize-checkpoint-root
+  [checkpoint-root]
+  (some-> checkpoint-root fs/expand-home str))
+
+(defn ^{:stratum 0} workflow-checkpoint-dir
+  "Directory for one workflow run's durable checkpoint state."
+  [checkpoint-root workflow-run-id]
+  (str (fs/path checkpoint-root (str workflow-run-id))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Per-run paths and the configured default root
+(defn ^{:stratum 1} default-checkpoint-root
+  "Default durable checkpoint root from merged config."
+  []
+  (normalize-checkpoint-root
+   (or (get-in (config/load-merged-config) [:workflow :checkpoint-root])
+       (str (config/miniforge-home) "/checkpoints"))))
+
+(defn ^{:stratum 1} machine-snapshot-path
+  "Path to the authoritative machine snapshot for a workflow run."
+  [checkpoint-root workflow-run-id]
+  (str (fs/path (workflow-checkpoint-dir checkpoint-root workflow-run-id)
+                machine-snapshot-filename)))
+
+(defn ^{:stratum 1} manifest-path
+  "Path to the manifest for a workflow run."
+  [checkpoint-root workflow-run-id]
+  (str (fs/path (workflow-checkpoint-dir checkpoint-root workflow-run-id)
+                manifest-filename)))
+
+(defn ^{:stratum 1} phase-checkpoints-dir
+  "Directory that stores per-phase checkpoint files."
+  [checkpoint-root workflow-run-id]
+  (str (fs/path (workflow-checkpoint-dir checkpoint-root workflow-run-id)
+                phase-checkpoints-directory-name)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} resolve-checkpoint-root
+  "Resolve checkpoint root from context/opts/config."
+  ([]
+   (default-checkpoint-root))
+  ([m]
+   (normalize-checkpoint-root
+    (or (:execution/checkpoint-root m)
+        (get m checkpoint-root-option-key)
+        (get-in m [:execution/opts checkpoint-root-option-key])
+        (default-checkpoint-root)))))
+
+(defn ^{:stratum 2} phase-checkpoint-path
+  "Path to a persisted phase checkpoint."
+  [checkpoint-root workflow-run-id phase-name]
+  (str (fs/path (phase-checkpoints-dir checkpoint-root workflow-run-id)
+                (str (name phase-name) ".edn"))))

--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store_records.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store_records.clj
@@ -1,0 +1,141 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.workflow.checkpoint-store-records
+  "What a checkpoint contains: the machine snapshot, the per-phase
+   record, and the manifest that indexes them.
+
+   Every builder here is a pure projection of an execution context —
+   given the same context it returns the same map, and none of them
+   touch the filesystem. `persisted-execution-keys`, the allowlist
+   deciding what survives a checkpoint at all, lives here with
+   `build-machine-snapshot`, the one function that applies it.
+
+   Split out of `checkpoint-store`, which held path resolution, record
+   building and persistence as one five-stratum chain in a single file
+   (rule 210 caps a file at three). `checkpoint-store-paths` answers
+   where a record goes; `checkpoint-store` writes it."
+  (:require
+   [ai.miniforge.coerce.interface :as coerce]
+   [ai.miniforge.workflow.checkpoint-store-paths :as checkpoint-paths]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} current-checkpoint-timestamp
+  []
+  (str (java.time.Instant/now)))
+
+(def ^{:stratum 0} persisted-execution-keys
+  "Serializable execution fields kept in the durable machine snapshot."
+  [:execution/id
+   :execution/workflow-id
+   :execution/workflow-version
+   :execution/input
+   :execution/status
+   :execution/current-phase
+   :execution/phase-index
+   :execution/redirect-count
+   :execution/fsm-state
+   :execution/response-chain
+   :execution/errors
+   :execution/phase-handoffs
+   :execution/artifacts
+   :execution/dag-result
+   :execution/dag-pr-infos
+   :execution/metrics
+   :execution/output
+   :execution/started-at
+   :execution/ended-at
+   :execution/environment-id
+   :execution/environment-metadata
+   :execution/worktree-path
+   :execution/mode
+   :execution/completed-with-warnings?])
+
+(defn ^{:stratum 0} ordered-phase-ids
+  "Phase ids in workflow pipeline order, filtered to checkpointed phases."
+  [ctx]
+  (let [phase-results (:execution/phase-results ctx)
+        pipeline-phase-ids (map :phase (get-in ctx [:execution/workflow :workflow/pipeline]))
+        ordered-phase-ids (filter #(contains? phase-results %) pipeline-phase-ids)
+        remaining-phase-ids (remove (set ordered-phase-ids) (keys phase-results))]
+    (vec (concat ordered-phase-ids remaining-phase-ids))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} active-or-last-phase
+  "Current phase when present, otherwise the last checkpointed phase."
+  [ctx]
+  (or (:execution/current-phase ctx)
+      (last (ordered-phase-ids ctx))))
+
+(defn ^{:stratum 1} build-machine-snapshot
+  "Build the durable machine snapshot for an execution context.
+
+   Timestamps are normalized by type on the way out. Writers of
+   :execution/started-at / :execution/ended-at disagree today
+   (context.clj writes epoch millis, runner.clj an Instant), and
+   `inst?` admits a Date as readily as an Instant — so without
+   normalization a restore hands its reader an Instant-derived string
+   from one writer and a live Date from another for the same key."
+  [ctx]
+  (-> (select-keys ctx persisted-execution-keys)
+      coerce/stringify-instants))
+
+(defn ^{:stratum 1} build-phase-checkpoint
+  "Build a durable per-phase checkpoint record."
+  [ctx phase-name phase-result]
+  (let [checkpointed-at (current-checkpoint-timestamp)]
+    (coerce/stringify-instants
+     {:workflow/id (:execution/id ctx)
+      :workflow/workflow-id (:execution/workflow-id ctx)
+      :workflow/workflow-version (:execution/workflow-version ctx)
+      :workflow/phase phase-name
+      :workflow/checkpointed-at checkpointed-at
+      :phase/result phase-result})))
+
+(defn ^{:stratum 1} build-manifest
+  "Build the durable checkpoint manifest for an execution context."
+  ([ctx checkpoint-root]
+   (build-manifest ctx checkpoint-root nil))
+  ([ctx checkpoint-root existing-manifest]
+   (let [workflow-run-id (:execution/id ctx)
+         current-phase-ids (ordered-phase-ids ctx)
+         existing-phase-paths (or (:workflow/phase-checkpoints existing-manifest) {})
+         existing-phase-ids (or (not-empty (:workflow/phases-completed existing-manifest))
+                                (sort-by name (keys existing-phase-paths)))
+         phase-ids (vec (concat existing-phase-ids
+                                (remove (set existing-phase-ids)
+                                        current-phase-ids)))
+         current-phase-paths (into {}
+                                   (map (fn [phase-id]
+                                          [phase-id
+                                           (checkpoint-paths/phase-checkpoint-path
+                                            checkpoint-root
+                                            workflow-run-id
+                                            phase-id)]))
+                                   current-phase-ids)
+         phase-paths (merge existing-phase-paths current-phase-paths)]
+     (coerce/stringify-instants
+      {:workflow/id workflow-run-id
+       :workflow/workflow-id (:execution/workflow-id ctx)
+       :workflow/workflow-version (:execution/workflow-version ctx)
+       :workflow/phases-completed phase-ids
+       :workflow/machine-snapshot-path
+       (checkpoint-paths/machine-snapshot-path checkpoint-root workflow-run-id)
+       :workflow/phase-checkpoints phase-paths
+       :workflow/last-checkpoint-at (current-checkpoint-timestamp)}))))

--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store_records.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store_records.clj
@@ -19,11 +19,15 @@
   "What a checkpoint contains: the machine snapshot, the per-phase
    record, and the manifest that indexes them.
 
-   Every builder here is a pure projection of an execution context —
-   given the same context it returns the same map, and none of them
-   touch the filesystem. `persisted-execution-keys`, the allowlist
-   deciding what survives a checkpoint at all, lives here with
-   `build-machine-snapshot`, the one function that applies it.
+   No builder here touches the filesystem, and all of the run's own
+   data comes from the context handed in. Two of them are still not
+   pure: `build-phase-checkpoint` and `build-manifest` stamp the
+   moment they were called, so the same context builds two records
+   that differ in `:workflow/checkpointed-at` /
+   `:workflow/last-checkpoint-at`. `build-machine-snapshot` is the
+   deterministic one, and `persisted-execution-keys` — the allowlist
+   deciding what survives a checkpoint at all — lives here with it,
+   since it is the only function that applies it.
 
    Split out of `checkpoint-store`, which held path resolution, record
    building and persistence as one five-stratum chain in a single file

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -108,7 +108,7 @@
                                  writer) — consumers guard on this key
                                  for best-effort warning paths and must
                                  never mint their own. Never persisted
-                                 (checkpoint-store whitelists keys).
+                                 (checkpoint-store-records whitelists keys).
 
    ### Supervision Support
    :execution/supervision-runtime — Runtime for workflow health supervision
@@ -124,7 +124,7 @@
   (:require [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.logging.interface :as log]
             [ai.miniforge.response.interface :as response]
-            [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
+            [ai.miniforge.workflow.checkpoint-store-paths :as checkpoint-paths]
             [ai.miniforge.workflow.fsm :as fsm]
             [ai.miniforge.workflow.monitoring :as monitoring]
             [ai.miniforge.agent.interface :as agent]))
@@ -338,7 +338,7 @@
   (let [execution-machine (fsm/compile-execution-machine workflow)
         fsm-state (let [initial-state (fsm/initialize-execution execution-machine)]
                     (fsm/start-execution execution-machine initial-state))
-        checkpoint-root (checkpoint-store/resolve-checkpoint-root opts)]
+        checkpoint-root (checkpoint-paths/resolve-checkpoint-root opts)]
     (sync-machine-projections
      (merge
       {:execution/id (or (opts-run-id opts) (random-uuid))
@@ -373,7 +373,7 @@
                     (->> (fsm/initialize-execution execution-machine)
                          (fsm/start-execution execution-machine))
                     (:execution/fsm-state machine-snapshot))
-        checkpoint-root (checkpoint-store/resolve-checkpoint-root
+        checkpoint-root (checkpoint-paths/resolve-checkpoint-root
                          (merge opts machine-snapshot))]
     (sync-machine-projections
      (merge

--- a/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
@@ -20,6 +20,7 @@
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
+   [ai.miniforge.workflow.checkpoint-store-paths :as checkpoint-paths]
    [ai.miniforge.workflow.context :as ctx]
    [ai.miniforge.workflow.interface :as workflow]))
 
@@ -221,7 +222,7 @@
     (with-temp-checkpoint-root
       (fn [checkpoint-root]
         (let [run-id (random-uuid)
-              snapshot-path (checkpoint-store/machine-snapshot-path
+              snapshot-path (checkpoint-paths/machine-snapshot-path
                              checkpoint-root run-id)]
           (io/make-parents snapshot-path)
           ;; :started-at as the old writer left it (#inst), :ended-at as the

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -28,6 +28,7 @@
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.supervisory-state.interface :as supervisory]
    [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
+   [ai.miniforge.workflow.checkpoint-store-records :as checkpoint-records]
    [ai.miniforge.workflow.fsm :as workflow-fsm]
    [ai.miniforge.workflow.phase-test-support :as phase-test-support]
    [ai.miniforge.workflow.runner :as runner]
@@ -358,7 +359,7 @@
           result (runner/run-pipeline workflow
                                       {:task "Ignored"}
                                       {:resume-machine-snapshot
-                                       (checkpoint-store/build-machine-snapshot resume-ctx)
+                                       (checkpoint-records/build-machine-snapshot resume-ctx)
                                        :resume-phase-results {}})]
       (is (= :completed (:execution/status result)))
       (is (= (:execution/id resume-ctx) (:execution/id result))))))
@@ -580,7 +581,7 @@
           (let [result (runner/run-pipeline workflow
                                             {:task "Ignored"}
                                             {:resume-machine-snapshot
-                                             (checkpoint-store/build-machine-snapshot resume-ctx)
+                                             (checkpoint-records/build-machine-snapshot resume-ctx)
                                              :resume-phase-results {}})]
             (is (= metadata (:execution/environment-metadata result)))))))))
 

--- a/docs/pull-requests/2026-08-16-refactor-split-workflow-checkpoint-store.md
+++ b/docs/pull-requests/2026-08-16-refactor-split-workflow-checkpoint-store.md
@@ -1,0 +1,116 @@
+<!--
+  Title: Split workflow/checkpoint_store.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(workflow): split checkpoint_store.clj (rule 210)
+
+## Overview
+
+Splits path resolution and record building out of
+`ai.miniforge.workflow.checkpoint-store` into two new sibling
+namespaces, `checkpoint-store-paths` and `checkpoint-store-records`,
+clearing a pre-existing stratum-lint SL003 finding: the combined
+namespace measured 5 real layers against rule 210's budget of 3.
+
+Pure code motion. No behavior change — every moved function keeps its
+body byte-for-byte, and the only edits to moved code are the
+namespace-qualified call sites the move requires.
+
+## Motivation
+
+`bb lint:stratum` lints changed files only, so the violation was
+dormant until someone touched the file — at which point a one-line
+edit inherited the whole finding. PR #1800 hit exactly this: adding
+`:execution/acting` to `persisted-execution-keys` had to be committed
+with `MINIFORGE_STRATUM_BUDGET_MODE=warn`.
+
+The file's own docstring already named the seam and stated that
+renumbering banners would not close it: the chain (persist → manifest
+→ per-phase path → atomic write → path normalization) is real, so the
+fix is decomposition.
+
+## Changes in Detail
+
+Three namespaces, each a distinct question about a checkpoint:
+
+- **`checkpoint_store_paths.clj` (new, 3 layers) — where it goes.**
+  The filename/option-key constants, `normalize-checkpoint-root`,
+  `workflow-checkpoint-dir`, `default-checkpoint-root`,
+  `machine-snapshot-path`, `manifest-path`, `phase-checkpoints-dir`,
+  `resolve-checkpoint-root`, `phase-checkpoint-path`. No file is
+  opened here; callers get a path string back.
+- **`checkpoint_store_records.clj` (new, 2 layers) — what it
+  contains.** `persisted-execution-keys`, `ordered-phase-ids`,
+  `active-or-last-phase`, `build-machine-snapshot`,
+  `build-phase-checkpoint`, `build-manifest`, and the private
+  `current-checkpoint-timestamp`. Pure projections of an execution
+  context. The allowlist sits with `build-machine-snapshot`, the one
+  function that applies it.
+- **`checkpoint_store.clj` (3 layers) — moving it between memory and
+  disk.** `temp-file-suffix`, the private `read-edn-file` and
+  `write-edn-atomically!`, and the two public operations
+  `load-checkpoint-data` and `persist-execution-state!`.
+
+Dependency direction is one-way: `checkpoint-store` →
+`checkpoint-store-records` → `checkpoint-store-paths`.
+
+`load-checkpoint-data` and `persist-execution-state!` stay defined
+(as `defn`, not re-export `def`) in `checkpoint-store`, so every
+existing caller — `workflow.interface.checkpoints`, `runner`,
+`dag-resilience` — and every `with-redefs` in the test suite still
+targets a real var in the namespace it already named. No re-export
+aliases were introduced anywhere in this split; the three call sites
+that used a moved var were repointed instead:
+
+- `context.clj`: `resolve-checkpoint-root` ×2, now via
+  `checkpoint-store-paths` (its only use of the store — the
+  `checkpoint-store` require is gone).
+- `checkpoint_store_test.clj`: `machine-snapshot-path` ×1.
+- `runner_test.clj`: `build-machine-snapshot` ×2.
+
+Deliberately **not** in scope, to keep the move behavior-preserving:
+the `(or (:k m) {})` map-access forms in `build-manifest` and
+`persist-execution-state!` that rule 106 would rewrite to
+`(get m :k {})`. Those two forms differ when a key is present with an
+explicit `nil` (EDN read back off disk can produce that), so the
+rewrite is a semantic change and belongs in its own PR.
+
+## Testing Plan
+
+- `stratum-lint` clean (exit 0, no findings) on all six touched files,
+  which is the finding this PR exists to clear.
+- `clj-kondo` clean: 0 errors, 0 warnings.
+- `bb poly:check`: OK.
+- Direct namespace verification — `checkpoint-store-test` and
+  `dag-resilience-resume-test`, with `runner-test` loaded to prove it
+  compiles: 7 tests, 27 assertions, 0 failures, 0 errors.
+- `bb test:all` (full brick + integration suite, not
+  `check:affected-tests`): store namespace, so dependent bricks are
+  out of the affected-tests scope.
+
+## Deployment Plan
+
+No deployment step. Library-internal refactor; no schema, config, or
+on-disk checkpoint format change. Checkpoints written before this
+change are read by the same code path afterwards.
+
+## Related Issues/PRs
+
+- Blocks/conflicts with #1800 (Ariadne 3b, open): it adds
+  `:execution/acting` plus a docstring to `persisted-execution-keys`.
+  That allowlist now lives in
+  `components/workflow/src/ai/miniforge/workflow/checkpoint_store_records.clj`;
+  the 7-line hunk moves there verbatim on rebase. Its context.clj and
+  test changes are untouched by this PR.
+- Part of the stratum-lint rule-210 remediation program.
+
+## Checklist
+
+- [x] SL003 cleared without `MINIFORGE_STRATUM_BUDGET_MODE=warn`
+- [x] `persisted-execution-keys` contents unchanged
+- [x] Public entry points (`load-checkpoint-data`,
+      `persist-execution-state!`) still `defn` in `checkpoint-store`
+- [x] No re-export `def` aliases introduced
+- [x] Full test suite run, not affected-tests

--- a/docs/pull-requests/2026-08-16-refactor-split-workflow-checkpoint-store.md
+++ b/docs/pull-requests/2026-08-16-refactor-split-workflow-checkpoint-store.md
@@ -45,9 +45,10 @@ Three namespaces, each a distinct question about a checkpoint:
   contains.** `persisted-execution-keys`, `ordered-phase-ids`,
   `active-or-last-phase`, `build-machine-snapshot`,
   `build-phase-checkpoint`, `build-manifest`, and the private
-  `current-checkpoint-timestamp`. Pure projections of an execution
-  context. The allowlist sits with `build-machine-snapshot`, the one
-  function that applies it.
+  `current-checkpoint-timestamp`. Nothing here opens a file;
+  `build-phase-checkpoint` and `build-manifest` do read the clock, so
+  only `build-machine-snapshot` is deterministic. The allowlist sits
+  with it, being the one function that applies it.
 - **`checkpoint_store.clj` (3 layers) — moving it between memory and
   disk.** `temp-file-suffix`, the private `read-edn-file` and
   `write-edn-atomically!`, and the two public operations

--- a/docs/pull-requests/2026-08-16-refactor-split-workflow-checkpoint-store.md
+++ b/docs/pull-requests/2026-08-16-refactor-split-workflow-checkpoint-store.md
@@ -53,8 +53,10 @@ Three namespaces, each a distinct question about a checkpoint:
   `write-edn-atomically!`, and the two public operations
   `load-checkpoint-data` and `persist-execution-state!`.
 
-Dependency direction is one-way: `checkpoint-store` →
-`checkpoint-store-records` → `checkpoint-store-paths`.
+Dependencies point one way, with no cycles. `checkpoint-store`
+requires both new namespaces; `checkpoint-store-records` requires
+`checkpoint-store-paths` (`build-manifest` records the paths it
+indexes); `checkpoint-store-paths` requires neither of the other two.
 
 `load-checkpoint-data` and `persist-execution-state!` stay defined
 (as `defn`, not re-export `def`) in `checkpoint-store`, so every


### PR DESCRIPTION
<!--
  Title: Split workflow/checkpoint_store.clj (rule 210)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(workflow): split checkpoint_store.clj (rule 210)

## Overview

Splits path resolution and record building out of
`ai.miniforge.workflow.checkpoint-store` into two new sibling
namespaces, `checkpoint-store-paths` and `checkpoint-store-records`,
clearing a pre-existing stratum-lint SL003 finding: the combined
namespace measured 5 real layers against rule 210's budget of 3.

Pure code motion. No behavior change — every moved function keeps its
body byte-for-byte, and the only edits to moved code are the
namespace-qualified call sites the move requires.

## Motivation

`bb lint:stratum` lints changed files only, so the violation was
dormant until someone touched the file — at which point a one-line
edit inherited the whole finding. PR #1800 hit exactly this: adding
`:execution/acting` to `persisted-execution-keys` had to be committed
with `MINIFORGE_STRATUM_BUDGET_MODE=warn`.

The file's own docstring already named the seam and stated that
renumbering banners would not close it: the chain (persist → manifest
→ per-phase path → atomic write → path normalization) is real, so the
fix is decomposition.

## Changes in Detail

Three namespaces, each a distinct question about a checkpoint:

- **`checkpoint_store_paths.clj` (new, 3 layers) — where it goes.**
  The filename/option-key constants, `normalize-checkpoint-root`,
  `workflow-checkpoint-dir`, `default-checkpoint-root`,
  `machine-snapshot-path`, `manifest-path`, `phase-checkpoints-dir`,
  `resolve-checkpoint-root`, `phase-checkpoint-path`. No file is
  opened here; callers get a path string back.
- **`checkpoint_store_records.clj` (new, 2 layers) — what it
  contains.** `persisted-execution-keys`, `ordered-phase-ids`,
  `active-or-last-phase`, `build-machine-snapshot`,
  `build-phase-checkpoint`, `build-manifest`, and the private
  `current-checkpoint-timestamp`. Pure projections of an execution
  context. The allowlist sits with `build-machine-snapshot`, the one
  function that applies it.
- **`checkpoint_store.clj` (3 layers) — moving it between memory and
  disk.** `temp-file-suffix`, the private `read-edn-file` and
  `write-edn-atomically!`, and the two public operations
  `load-checkpoint-data` and `persist-execution-state!`.

Dependency direction is one-way: `checkpoint-store` →
`checkpoint-store-records` → `checkpoint-store-paths`.

`load-checkpoint-data` and `persist-execution-state!` stay defined
(as `defn`, not re-export `def`) in `checkpoint-store`, so every
existing caller — `workflow.interface.checkpoints`, `runner`,
`dag-resilience` — and every `with-redefs` in the test suite still
targets a real var in the namespace it already named. No re-export
aliases were introduced anywhere in this split; the three call sites
that used a moved var were repointed instead:

- `context.clj`: `resolve-checkpoint-root` ×2, now via
  `checkpoint-store-paths` (its only use of the store — the
  `checkpoint-store` require is gone).
- `checkpoint_store_test.clj`: `machine-snapshot-path` ×1.
- `runner_test.clj`: `build-machine-snapshot` ×2.

Deliberately **not** in scope, to keep the move behavior-preserving:
the `(or (:k m) {})` map-access forms in `build-manifest` and
`persist-execution-state!` that rule 106 would rewrite to
`(get m :k {})`. Those two forms differ when a key is present with an
explicit `nil` (EDN read back off disk can produce that), so the
rewrite is a semantic change and belongs in its own PR.

## Testing Plan

- `stratum-lint` clean (exit 0, no findings) on all six touched files,
  which is the finding this PR exists to clear.
- `clj-kondo` clean: 0 errors, 0 warnings.
- `bb poly:check`: OK.
- Direct namespace verification — `checkpoint-store-test` and
  `dag-resilience-resume-test`, with `runner-test` loaded to prove it
  compiles: 7 tests, 27 assertions, 0 failures, 0 errors.
- `bb test:all` (full brick + integration suite, not
  `check:affected-tests`): store namespace, so dependent bricks are
  out of the affected-tests scope.

## Deployment Plan

No deployment step. Library-internal refactor; no schema, config, or
on-disk checkpoint format change. Checkpoints written before this
change are read by the same code path afterwards.

## Related Issues/PRs

- Blocks/conflicts with #1800 (Ariadne 3b, open): it adds
  `:execution/acting` plus a docstring to `persisted-execution-keys`.
  That allowlist now lives in
  `components/workflow/src/ai/miniforge/workflow/checkpoint_store_records.clj`;
  the 7-line hunk moves there verbatim on rebase. Its context.clj and
  test changes are untouched by this PR.
- Part of the stratum-lint rule-210 remediation program.

## Checklist

- [x] SL003 cleared without `MINIFORGE_STRATUM_BUDGET_MODE=warn`
- [x] `persisted-execution-keys` contents unchanged
- [x] Public entry points (`load-checkpoint-data`,
      `persist-execution-state!`) still `defn` in `checkpoint-store`
- [x] No re-export `def` aliases introduced
- [x] Full test suite run, not affected-tests
