### PR TITLE
refactor(deploy): expose normalized provider operations

### DIFF
--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_flow.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_flow.clj
@@ -18,7 +18,6 @@
 (ns ai.miniforge.phase-deployment.deploy-flow
   "Application flow for deployment provider operations."
   (:require
-   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.phase-deployment.deploy-provider :as provider]
    [ai.miniforge.schema.interface :as schema]))
 
@@ -56,7 +55,7 @@
 (defn ^{:stratum 2} execute!
   "Capture rollback state, apply, and translate provider observation."
   [deploy-config]
-  (let [rollback-info (provider/rollback-info! deploy-config)]
-    (if (anomaly/anomaly? rollback-info)
-      (outcome :failed :capture nil {:deploy/failure (:anomaly/message rollback-info)})
-      (apply-outcome! deploy-config rollback-info))))
+  (let [result (provider/rollback-info! deploy-config)]
+    (if (schema/failed? result)
+      (outcome :failed :capture nil {:deploy/failure (:error result)})
+      (apply-outcome! deploy-config (:rollback-info result)))))

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_operations.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_operations.clj
@@ -30,7 +30,7 @@
   []
   {:target! provider/target!
    :render! provider/render!
-   :dry-run! provider/dry-run!
+   :server-dry-run! provider/dry-run!
    :rollback-info! provider/rollback-info!
-   :apply! provider/apply-rendered!
+   :apply-rendered! provider/apply-rendered!
    :observe! provider/observe!})

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_operations.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_operations.clj
@@ -1,0 +1,36 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-deployment.deploy-operations
+  "Injectable Kubernetes operations for the governed deploy transaction."
+  (:require
+   [ai.miniforge.phase-deployment.deploy-provider :as provider]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} operations
+  "Return the provider boundary used by the governed transaction.
+
+   Rendered bytes remain ordinary transaction data. The durable proposal,
+   rather than adapter state, is the source used by commit and reconciliation."
+  []
+  {:target! provider/target!
+   :render! provider/render!
+   :dry-run! provider/dry-run!
+   :rollback-info! provider/rollback-info!
+   :apply! provider/apply-rendered!
+   :observe! provider/observe!})

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_provider.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_provider.clj
@@ -93,6 +93,22 @@
        (msg/t :deploy/context-unavailable))
    {:kubectl-result kubectl-result}))
 
+(defn- ^{:stratum 0} rollback-failure
+  [kubectl-result]
+  (schema/failure
+   :rollback-info
+   (or (not-empty (:stderr kubectl-result))
+       (:error kubectl-result)
+       (msg/t :deploy/rollback-capture-failed))
+   {:kubectl-result kubectl-result}))
+
+(defn- ^{:stratum 0} rollback-result
+  [rollback-info]
+  (if (anomaly/anomaly? rollback-info)
+    (schema/failure :rollback-info (:anomaly/message rollback-info)
+                    {:validation rollback-info})
+    (schema/success :rollback-info rollback-info)))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} target!
@@ -116,14 +132,16 @@
                                :context context
                                :output "json"
                                :extra-args ["deployment" deployment-name])]
-    (when (schema/succeeded? result)
-      (schema/validate-anomaly
-       RollbackInfo
-       {:revision (get-in result [:parsed :metadata :annotations
-                                  "deployment.kubernetes.io/revision"])
-        :image (get-in result [:parsed :spec :template :spec
-                               :containers 0 :image])
-        :replicas (get-in result [:parsed :status :readyReplicas])}))))
+    (if (schema/failed? result)
+      (rollback-failure result)
+      (rollback-result
+       (schema/validate-anomaly
+        RollbackInfo
+        {:revision (get-in result [:parsed :metadata :annotations
+                                   "deployment.kubernetes.io/revision"])
+         :image (get-in result [:parsed :spec :template :spec
+                                :containers 0 :image])
+         :replicas (get-in result [:parsed :status :readyReplicas])})))))
 
 (defn ^{:stratum 1} pod-state
   [pods]

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_flow_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_flow_test.clj
@@ -38,6 +38,8 @@
 
 (def ^{:stratum 0} rollback-info {:revision "7" :image "api:v7" :replicas 3})
 
+(def ^{:stratum 0} rollback-error "invalid rollback")
+
 (def ^{:stratum 0} apply-failure
   (schema/failure :rendered-yaml "apply refused" {:build-result {:stdout "image: api:v8"}}))
 
@@ -52,7 +54,8 @@
    :deploy/failure "rollout timed out"})
 
 (deftest ^{:stratum 1} apply-failure-preserves-rollback-test
-  (with-redefs [provider/rollback-info! (constantly rollback-info)
+  (with-redefs [provider/rollback-info!
+                (constantly (schema/success :rollback-info rollback-info))
                 provider/apply! (constantly apply-failure)]
     (let [deployment (flow/execute! (deployment-config))]
       (is (= :failed (:deploy/status deployment)))
@@ -61,7 +64,8 @@
       (is (= rollback-info (:deploy/rollback-info deployment))))))
 
 (deftest ^{:stratum 1} invalid-rollback-stops-apply-test
-  (with-redefs [provider/rollback-info! (constantly (schema/validate-anomaly [:map [:valid? true?]] {}))
+  (with-redefs [provider/rollback-info!
+                (constantly (schema/failure :rollback-info rollback-error))
                 provider/apply! #(throw (ex-info "apply must not run" %))]
     (is (= :capture (:deploy/stage (flow/execute! (deployment-config)))))))
 

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_operations_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_operations_test.clj
@@ -1,0 +1,56 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-deployment.deploy-operations-test
+  "Provider functions exposed to the governed deployment flow."
+  (:require
+   [ai.miniforge.phase-deployment.deploy-operations :as operations]
+   [ai.miniforge.phase-deployment.deploy-provider :as provider]
+   [ai.miniforge.schema.interface :as schema]
+   [clojure.test :refer [deftest is]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} target
+  {:kustomize-dir "/k8s" :namespace "prod" :context "gke"})
+
+(def ^{:stratum 0} rendered-yaml "manifest")
+
+(def ^{:stratum 0} dry-run-output "validated")
+
+(def ^{:stratum 0} apply-output "applied")
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} operations-preserve-provider-results-test
+  (let [render-result (schema/success :stdout rendered-yaml)
+        dry-run-result (schema/success :stdout dry-run-output)]
+    (with-redefs [provider/render! (constantly render-result)
+                  provider/dry-run! (fn [_ _] dry-run-result)]
+      (let [ops (operations/operations)]
+        (is (= render-result ((:render! ops) target)))
+        (is (= dry-run-result ((:dry-run! ops) target rendered-yaml)))))))
+
+(deftest ^{:stratum 1} operations-pass-explicit-bytes-to-provider-test
+  (let [applied (atom nil)]
+    (with-redefs [provider/apply-rendered!
+                  (fn [actual-target rendered]
+                    (reset! applied [actual-target rendered])
+                    (schema/success :stdout apply-output))]
+      ((:apply! (operations/operations)) target rendered-yaml)
+      (is (= [target rendered-yaml] @applied)
+          "the adapter must neither cache nor re-render the artifact"))))

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_operations_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_operations_test.clj
@@ -16,7 +16,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.phase-deployment.deploy-operations-test
-  "Provider functions exposed to the governed deployment flow."
+  "Normalized Kubernetes operations available to application flows."
   (:require
    [ai.miniforge.phase-deployment.deploy-operations :as operations]
    [ai.miniforge.phase-deployment.deploy-provider :as provider]
@@ -40,7 +40,8 @@
                 provider/dry-run! (fn [_ _] dry-run-result)]
     (let [ops (operations/operations)]
       (is (= render-result ((:render! ops) target)))
-      (is (= dry-run-result ((:dry-run! ops) target rendered-yaml))))))
+      (is (= dry-run-result
+             ((:server-dry-run! ops) target rendered-yaml))))))
 
 (deftest ^{:stratum 1} operations-pass-explicit-bytes-to-provider-test
   (let [applied (atom nil)]
@@ -48,6 +49,6 @@
                   (fn [actual-target rendered]
                     (reset! applied [actual-target rendered])
                     nil)]
-      ((:apply! (operations/operations)) target rendered-yaml)
+      ((:apply-rendered! (operations/operations)) target rendered-yaml)
       (is (= [target rendered-yaml] @applied)
           "the adapter must neither cache nor re-render the artifact"))))

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_test.clj
@@ -24,6 +24,13 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
+(def ^{:stratum 0} rollback-target
+  {:deployment-name "api"
+   :namespace "production"
+   :context "cluster-1"})
+
+(def ^{:stratum 0} rollback-error "kubectl unavailable")
+
 (deftest ^{:stratum 0} resolve-deploy-config-test
   (testing "deploy config normalizes workflow inputs and provision outputs once"
     (let [resolved (config/resolve-config
@@ -86,3 +93,24 @@
         (is (schema/failed? result))
         (is (contains? result :target))
         (is (= kubectl-result (:kubectl-result result)))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} rollback-shell-failure-keeps-provider-result-test
+  (let [kubectl-result (schema/failure :parsed rollback-error)]
+    (with-redefs [shell/kubectl! (fn [& _] kubectl-result)]
+      (let [result (provider/rollback-info! rollback-target)]
+        (is (schema/failed? result))
+        (is (= kubectl-result (:kubectl-result result)))))))
+
+(deftest ^{:stratum 1} invalid-rollback-shape-returns-failure-test
+  (let [kubectl-result
+        (schema/success
+         :parsed
+         {:metadata {:annotations {"deployment.kubernetes.io/revision" "4"}}
+          :spec {:template {:spec {:containers [{:image "api:v4"}]}}}
+          :status {:readyReplicas "three"}})]
+    (with-redefs [shell/kubectl! (fn [& _] kubectl-result)]
+      (let [result (provider/rollback-info! rollback-target)]
+        (is (schema/failed? result))
+        (is (some? (:validation result)))))))

--- a/docs/pull-requests/2026-08-16-refactor-deploy-provider-contract.md
+++ b/docs/pull-requests/2026-08-16-refactor-deploy-provider-contract.md
@@ -16,9 +16,9 @@ None.
 
 ## Overview
 
-Defines the injectable Kubernetes operation map used by the governed deployment
-flow and makes rollback capture obey the same canonical success/failure result
-contract as render, dry-run, and apply operations.
+Defines the injectable Kubernetes operation map available to the next governed
+deployment flow and makes rollback capture obey the same canonical
+success/failure result contract as render, dry-run, and apply operations.
 
 ## Changes
 

--- a/docs/pull-requests/2026-08-16-refactor-deploy-provider-contract.md
+++ b/docs/pull-requests/2026-08-16-refactor-deploy-provider-contract.md
@@ -1,0 +1,47 @@
+<!--
+  Title: Normalize deployment provider operations
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(deploy): expose normalized provider operations
+
+## Layer
+
+Adapter.
+
+## Depends on
+
+None.
+
+## Overview
+
+Defines the injectable Kubernetes operation map used by the governed deployment
+flow and makes rollback capture obey the same canonical success/failure result
+contract as render, dry-run, and apply operations.
+
+## Changes
+
+- Expose target resolution, render, server dry-run, rollback capture, exact-byte
+  apply, and observation as one immutable operation map.
+- Return a schema success or failure from rollback capture, including shell and
+  rollback-shape failures.
+- Keep the existing deployment flow compatible with the normalized result.
+- Test result preservation, exact rendered-byte forwarding, and both rollback
+  failure boundaries.
+
+## Design
+
+- Simple: the operation map is plain data and carries no cached manifest or
+  mutable provider state.
+- Separated: provider mechanics stay in the adapter; the later application flow
+  receives replaceable functions.
+- Canonical: callers use `schema/succeeded?` and `schema/failed?` rather than
+  inspecting result-map structure.
+
+## Verification
+
+- `bb pre-commit`
+- `clojure -M:poly test brick:phase-deployment`
+- Adversarial review against Clojure, result-handling, testing, component, and
+  stratified-design standards.


### PR DESCRIPTION
<!--
  Title: Normalize deployment provider operations
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(deploy): expose normalized provider operations

## Layer

Adapter.

## Depends on

None.

## Overview

Defines the injectable Kubernetes operation map used by the governed deployment
flow and makes rollback capture obey the same canonical success/failure result
contract as render, dry-run, and apply operations.

## Changes

- Expose target resolution, render, server dry-run, rollback capture, exact-byte
  apply, and observation as one immutable operation map.
- Return a schema success or failure from rollback capture, including shell and
  rollback-shape failures.
- Keep the existing deployment flow compatible with the normalized result.
- Test result preservation, exact rendered-byte forwarding, and both rollback
  failure boundaries.

## Design

- Simple: the operation map is plain data and carries no cached manifest or
  mutable provider state.
- Separated: provider mechanics stay in the adapter; the later application flow
  receives replaceable functions.
- Canonical: callers use `schema/succeeded?` and `schema/failed?` rather than
  inspecting result-map structure.

## Verification

- `bb pre-commit`
- `clojure -M:poly test brick:phase-deployment`
- Adversarial review against Clojure, result-handling, testing, component, and
  stratified-design standards.
