### PR TITLE
fix(poly): declare packaged tenancy necessary

### DIFF
--- a/docs/pull-requests/2026-08-16-fix-tenancy-poly-warning.md
+++ b/docs/pull-requests/2026-08-16-fix-tenancy-poly-warning.md
@@ -1,0 +1,32 @@
+<!--
+  Title: Declare packaged tenancy component necessary
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix(poly): declare packaged tenancy component necessary
+
+## Layer
+
+Workspace configuration.
+
+## Depends on
+
+None.
+
+## Overview
+
+The Ariadne 3a tenancy component is deliberately packaged in the Miniforge
+runtime projects before its application wiring lands. Declare that intent in
+the Polylith workspace instead of reporting the component as unnecessary.
+
+## Changes
+
+- Mark `tenancy` necessary in `miniforge-core`, `miniforge`, and
+  `miniforge-tui`.
+- Retain the component in each packaged artifact while clearing Warning 207.
+
+## Verification
+
+- `clojure -M:poly check`
+- `bb pre-commit`

--- a/workspace.edn
+++ b/workspace.edn
@@ -33,6 +33,9 @@
                                           "repo-dag"
                                           "reporting"
                                           "task-executor"
+                                          ;; Packaged ownership boundary; application wiring
+                                          ;; lands in a later Ariadne 3a change.
+                                          "tenancy"
                                           "tool-registry"
                                           "workflow-compliance-scanner"]}
             "miniforge"      {:alias "cli"
@@ -59,6 +62,9 @@
                                           "repo-dag"
                                           "reporting"
                                           "task-executor"
+                                          ;; Packaged ownership boundary; application wiring
+                                          ;; lands in a later Ariadne 3a change.
+                                          "tenancy"
                                           "tool-registry"
                                           "training-capture"
                                           "tui-views"
@@ -89,6 +95,9 @@
                                           "repo-dag"
                                           "reporting"
                                           "task-executor"
+                                          ;; Packaged ownership boundary; application wiring
+                                          ;; lands in a later Ariadne 3a change.
+                                          "tenancy"
                                           "tool-registry"
                                           "tui-views"
                                           "workflow-chain-software-factory"


### PR DESCRIPTION
<!--
  Title: Declare packaged tenancy component necessary
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix(poly): declare packaged tenancy component necessary

## Layer

Workspace configuration.

## Depends on

None.

## Overview

The Ariadne 3a tenancy component is deliberately packaged in the Miniforge
runtime projects before its application wiring lands. Declare that intent in
the Polylith workspace instead of reporting the component as unnecessary.

## Changes

- Mark `tenancy` necessary in `miniforge-core`, `miniforge`, and
  `miniforge-tui`.
- Retain the component in each packaged artifact while clearing Warning 207.

## Verification

- `clojure -M:poly check`
- `bb pre-commit`
