### PR TITLE
refactor(deploy): require canonical authority inputs

### DIFF
--- a/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
+++ b/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
@@ -14,6 +14,7 @@
   :deploy/render-failed          "Kustomize render failed"
   :deploy/dry-run-failed         "Kubernetes server dry-run failed"
   :deploy/preflight-failed       "Deployment preflight failed"
+  :deploy/authority-input-invalid "Deployment authority requires canonical execution and target inputs"
   :deploy/authority-denied       "Deployment authority denied"
   :deploy/authority-failed       "Deployment authority check failed"
   :deploy/proposal-failed        "Deployment proposal persistence failed"

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
@@ -56,6 +56,17 @@
   {:rule-id :deploy/provision-preview-required
    :message (msg/t :policy/provision-preview-required)})
 
+(defn- ^{:stratum 0} canonical-input-anomaly
+  [context target]
+  (let [missing-fields (cond-> []
+                         (nil? (:execution/id context)) (conj :execution/id)
+                         (nil? (:context target)) (conj :context))]
+    (when (seq missing-fields)
+      (anomaly/anomaly
+       :invalid-input
+       (msg/t :deploy/authority-input-invalid)
+       {:authority/missing-fields missing-fields}))))
+
 (defn- ^{:stratum 0} effect-scope
   [request]
   (dissoc request :workflow-run/status :effect/class :effect/preflight
@@ -131,27 +142,31 @@
 (defn ^{:stratum 2} prepare
   "Evaluate policy, issue exact authority, and derive one deploy decision."
   [context effect-id target preflight ^Instant now]
-  (let [preflight (if (map? preflight) preflight {})
-        request (request context effect-id target)
-        classification (policy-classification context target)
-        policy-envelope (gate/decide classification deployment-policy-pins)
-        policy-allowed? (gate/decision-allowed? policy-envelope)
-        grant-record (when policy-allowed?
-                       (grant/issue-for-effect (breach-dir context) request now))]
-    (cond
-      (not policy-allowed?)
-      (authority-record request classification nil nil policy-envelope preflight)
+  (if-some [invalid-input (canonical-input-anomaly context target)]
+    invalid-input
+    (let [preflight (if (map? preflight) preflight {})
+          request (request context effect-id target)
+          classification (policy-classification context target)
+          policy-envelope (gate/decide classification deployment-policy-pins)
+          policy-allowed? (gate/decision-allowed? policy-envelope)
+          grant-record (when policy-allowed?
+                         (grant/issue-for-effect
+                          (breach-dir context) request now))]
+      (cond
+        (not policy-allowed?)
+        (authority-record request classification nil nil policy-envelope
+                          preflight)
 
-      (anomaly/anomaly? grant-record)
-      grant-record
+        (anomaly/anomaly? grant-record)
+        grant-record
 
-      :else
-      (let [authorization (grant/authorize
-                           grant-record
-                           {:effect/scope (effect-scope request)
-                            :usage/count 1}
-                           now)
-            envelope (gate/decide classification deployment-policy-pins
-                                  authorization)]
-        (authority-record request classification grant-record authorization
-                          envelope preflight)))))
+        :else
+        (let [authorization (grant/authorize
+                             grant-record
+                             {:effect/scope (effect-scope request)
+                              :usage/count 1}
+                             now)
+              envelope (gate/decide classification deployment-policy-pins
+                                    authorization)]
+          (authority-record request classification grant-record authorization
+                            envelope preflight))))))

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
@@ -22,8 +22,7 @@
    [ai.miniforge.execution-grant.interface :as grant]
    [ai.miniforge.gate.interface :as gate]
    [ai.miniforge.phase-deployment.messages :as msg]
-   [ai.miniforge.phase-deployment.policy :as policy]
-   [clojure.string :as str])
+   [ai.miniforge.phase-deployment.policy :as policy])
   (:import
    [java.time Instant]))
 
@@ -77,7 +76,7 @@
 (defn ^{:stratum 0} request
   "Build the closed runtime request for one preflight-approved deployment."
   [context effect-id target]
-  {:workflow-run/id (or (:execution/id context) (:run-id context))
+  {:workflow-run/id (:execution/id context)
    :workflow-run/status :running
    :effect/id effect-id
    :effect/class :effect/deploy
@@ -85,26 +84,9 @@
                       :preflight/result :allow}
    :kustomize-dir (:kustomize-dir target)
    :context (:context target)
-   :default-context (or (:default-context target) (:context target))
+   :default-context (:context target)
    :namespace (:namespace target)
    :deployment-name (:deployment-name target)})
-
-(defn- ^{:stratum 0} exact-target
-  [target]
-  (assoc target :context (or (:context target)
-                             (:context-name target)
-                             (:default-context target))))
-
-(defn ^{:stratum 0} preflight
-  "Reject an absent manifest at the legacy governed-deploy seam."
-  [rendered _policy-context]
-  (if (str/blank? (str rendered))
-    {:preflight/result :deny
-     :preflight/violations [(msg/t :deploy/render-failed)]
-     :preflight/rendered nil}
-    {:preflight/result :allow
-     :preflight/violations []
-     :preflight/rendered rendered}))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -149,8 +131,7 @@
 (defn ^{:stratum 2} prepare
   "Evaluate policy, issue exact authority, and derive one deploy decision."
   [context effect-id target preflight ^Instant now]
-  (let [target (exact-target target)
-        preflight (if (map? preflight) preflight {})
+  (let [preflight (if (map? preflight) preflight {})
         request (request context effect-id target)
         classification (policy-classification context target)
         policy-envelope (gate/decide classification deployment-policy-pins)

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_authority_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_authority_test.clj
@@ -61,11 +61,19 @@
 ;------------------------------------------------------------------------------ Layer 2
 
 (deftest ^{:stratum 2} request-binds-canonical-run-and-exact-target-test
-  (let [request (authority/request (context) (random-uuid)
-                                   (assoc target :default-context "audit"))]
+  (let [request (authority/request (context) (random-uuid) target)
+        legacy-request (authority/request
+                        (-> (context) (dissoc :execution/id)
+                            (assoc :run-id run-id))
+                        (random-uuid)
+                        (-> target (dissoc :context)
+                            (assoc :context-name "legacy")))]
     (is (= run-id (:workflow-run/id request)))
     (is (= "gke-prod" (:context request)))
-    (is (= "audit" (:default-context request)))))
+    (is (= "gke-prod" (:default-context request)))
+    (is (nil? (:workflow-run/id legacy-request)))
+    (is (nil? (:context legacy-request)))
+    (is (nil? (:default-context legacy-request)))))
 
 (deftest ^{:stratum 2} prepare-omits-unrecorded-preflight-evidence-test
   (let [proposal (:effect/proposal

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_authority_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_authority_test.clj
@@ -17,6 +17,7 @@
 ;; limitations under the License.
 (ns ai.miniforge.phase-deployment.deploy-authority-test
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.execution-grant.interface :as grant]
    [ai.miniforge.phase-deployment.deploy-authority :as authority]
    [ai.miniforge.phase-deployment.policy :as policy]
@@ -60,20 +61,23 @@
 
 ;------------------------------------------------------------------------------ Layer 2
 
-(deftest ^{:stratum 2} request-binds-canonical-run-and-exact-target-test
-  (let [request (authority/request (context) (random-uuid) target)
-        legacy-request (authority/request
-                        (-> (context) (dissoc :execution/id)
-                            (assoc :run-id run-id))
-                        (random-uuid)
-                        (-> target (dissoc :context)
-                            (assoc :context-name "legacy")))]
+(deftest ^{:stratum 2} request-binds-canonical-authority-inputs-test
+  (let [request (authority/request (context) (random-uuid) target)]
     (is (= run-id (:workflow-run/id request)))
     (is (= "gke-prod" (:context request)))
-    (is (= "gke-prod" (:default-context request)))
-    (is (nil? (:workflow-run/id legacy-request)))
-    (is (nil? (:context legacy-request)))
-    (is (nil? (:default-context legacy-request)))))
+    (is (= "gke-prod" (:default-context request)))))
+
+(deftest ^{:stratum 2} prepare-rejects-legacy-only-authority-inputs-test
+  (let [legacy-context (-> (context) (dissoc :execution/id)
+                           (assoc :run-id run-id))
+        legacy-target (-> target (dissoc :context)
+                          (assoc :context-name "legacy"))
+        prepared (authority/prepare legacy-context (random-uuid) legacy-target
+                                    preflight now)]
+    (is (anomaly/anomaly? prepared))
+    (is (= :invalid-input (:anomaly/type prepared)))
+    (is (= [:execution/id :context]
+           (get-in prepared [:anomaly/data :authority/missing-fields])))))
 
 (deftest ^{:stratum 2} prepare-omits-unrecorded-preflight-evidence-test
   (let [proposal (:effect/proposal

--- a/docs/pull-requests/2026-08-16-remove-deploy-authority-compat.md
+++ b/docs/pull-requests/2026-08-16-remove-deploy-authority-compat.md
@@ -23,9 +23,12 @@ execution identifier before authority preparation.
   `:default-context` inside the authority boundary.
 - Bind the issuance-required `:default-context` field to that same exact
   context.
+- Reject missing canonical execution or target inputs before policy or grant
+  evaluation.
 - Delete the unused legacy render-only `preflight` function and its string
   dependency.
-- Assert that legacy-only run and target inputs remain unbound.
+- Assert that legacy-only run and target inputs are rejected before grant
+  issuance.
 
 ## Verification
 

--- a/docs/pull-requests/2026-08-16-remove-deploy-authority-compat.md
+++ b/docs/pull-requests/2026-08-16-remove-deploy-authority-compat.md
@@ -1,0 +1,34 @@
+<!--
+  Title: Remove temporary deployment-authority compatibility
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(deploy): require canonical authority inputs
+
+## Layer
+
+Deployment domain authority.
+
+## Overview
+
+Remove migration fallbacks retained while the governed deploy caller was not
+yet live. PR 1794 now resolves one exact target and supplies the canonical
+execution identifier before authority preparation.
+
+## Changes
+
+- Require `:execution/id`; do not fall back to legacy `:run-id`.
+- Require the caller-resolved `:context`; do not normalize `:context-name` or
+  `:default-context` inside the authority boundary.
+- Bind the issuance-required `:default-context` field to that same exact
+  context.
+- Delete the unused legacy render-only `preflight` function and its string
+  dependency.
+- Assert that legacy-only run and target inputs remain unbound.
+
+## Verification
+
+- `clojure -M:poly test brick:phase-deployment`
+- `bb pre-commit`
+- `bb review`


### PR DESCRIPTION
<!--
  Title: Remove temporary deployment-authority compatibility
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(deploy): require canonical authority inputs

## Layer

Deployment domain authority.

## Overview

Remove migration fallbacks retained while the governed deploy caller was not
yet live. PR 1794 now resolves one exact target and supplies the canonical
execution identifier before authority preparation.

## Changes

- Require `:execution/id`; do not fall back to legacy `:run-id`.
- Require the caller-resolved `:context`; do not normalize `:context-name` or
  `:default-context` inside the authority boundary.
- Bind the issuance-required `:default-context` field to that same exact
  context.
- Delete the unused legacy render-only `preflight` function and its string
  dependency.
- Assert that legacy-only run and target inputs remain unbound.

## Verification

- `clojure -M:poly test brick:phase-deployment`
- `bb pre-commit`
- `bb review`
