### PR TITLE
refactor(deploy): remove legacy provider apply seam

### DIFF
--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_provider.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_provider.clj
@@ -35,8 +35,7 @@
 (defn ^{:stratum 0} render!
   "Render one Kustomize target without contacting Kubernetes.
 
-   Returns a `kustomize/KustomizeResult`: the manifest is under
-   `:rendered-yaml`, and `:apply-result` is nil because nothing was applied."
+   Returns the rendered manifest under `:rendered-yaml`."
   [{:keys [kustomize-dir]}]
   (shell/kustomize-render! kustomize-dir))
 
@@ -53,9 +52,8 @@
 (defn ^{:stratum 0} dry-run!
   "Ask the API server to validate exactly the manifest bytes to be applied.
 
-   Like [[apply-rendered!]], takes the manifest and returns a raw
-   `exec/CommandResult`, not a `KustomizeResult`. The server's echo of the
-   validated objects is under `:stdout`."
+   Like [[apply-rendered!]], takes the manifest and returns kubectl's raw
+   result. The server's echo of the validated objects is under `:stdout`."
   [{:keys [namespace context]} rendered-yaml]
   (shell/kubectl-apply! rendered-yaml :namespace namespace :context context
                         :server-dry-run? true))

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_provider.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_provider.clj
@@ -32,22 +32,11 @@
    [:image {:optional true} [:maybe :string]]
    [:replicas {:optional true} [:maybe int?]]])
 
-(defn ^{:stratum 0} apply!
-  "Build and apply one Kustomize target through the shell adapter.
-
-   Returns a `kustomize/KustomizeResult`: the manifest is under
-   `:rendered-yaml`. Same shape as [[render!]]."
-  [{:keys [kustomize-dir namespace context]}]
-  (shell/kustomize-apply! kustomize-dir
-                          :namespace namespace :context context))
-
 (defn ^{:stratum 0} render!
   "Render one Kustomize target without contacting Kubernetes.
 
    Returns a `kustomize/KustomizeResult`: the manifest is under
-   `:rendered-yaml`, exactly as in [[apply!]], and `:apply-result` is nil
-   because nothing was applied. Reading the manifest is the same expression
-   whichever of the two you called."
+   `:rendered-yaml`, and `:apply-result` is nil because nothing was applied."
   [{:keys [kustomize-dir]}]
   (shell/kustomize-render! kustomize-dir))
 
@@ -55,9 +44,8 @@
   "Apply exactly the manifest bytes recorded by the caller.
 
    Takes the manifest and returns a raw `exec/CommandResult` — kubectl's
-   own output under `:stdout`. This is NOT the `KustomizeResult` that
-   [[apply!]] and [[render!]] return; it has no `:rendered-yaml`, because
-   the caller already holds the bytes it passed in."
+   own output under `:stdout`. Unlike [[render!]], it has no
+   `:rendered-yaml`, because the caller already holds the bytes it passed in."
   [{:keys [namespace context]} rendered-yaml]
   (shell/kubectl-apply! rendered-yaml
                         :namespace namespace :context context))

--- a/docs/pull-requests/2026-08-16-remove-legacy-provider-apply.md
+++ b/docs/pull-requests/2026-08-16-remove-legacy-provider-apply.md
@@ -1,0 +1,32 @@
+<!--
+  Title: Remove the legacy deployment provider apply seam
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(deploy): remove legacy provider apply seam
+
+## Layer
+
+Deployment provider boundary.
+
+## Overview
+
+Remove the direct Kustomize build-and-apply provider operation left unused
+after the governed deployment transaction replaced the legacy application
+flow. Governed deployment renders once, validates those exact bytes, and
+applies those same bytes through `apply-rendered!`.
+
+## Changes
+
+- Delete the unreferenced `deploy-provider/apply!` operation.
+- Update provider documentation to describe only the live render and
+  exact-byte apply seams.
+- Retain the lower shell implementation for separate boundary cleanup.
+
+## Verification
+
+- Confirm no source or test references `deploy-provider/apply!`.
+- `clojure -M:poly test brick:phase-deployment`
+- `bb pre-commit`
+- `bb review`


### PR DESCRIPTION
<!--
  Title: Remove the legacy deployment provider apply seam
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(deploy): remove legacy provider apply seam

## Layer

Deployment provider boundary.

## Overview

Remove the direct Kustomize build-and-apply provider operation left unused
after the governed deployment transaction replaced the legacy application
flow. Governed deployment renders once, validates those exact bytes, and
applies those same bytes through `apply-rendered!`.

## Changes

- Delete the unreferenced `deploy-provider/apply!` operation.
- Update provider documentation to describe only the live render and
  exact-byte apply seams.
- Retain the lower shell implementation for separate boundary cleanup.

## Verification

- Confirm no source or test references `deploy-provider/apply!`.
- `clojure -M:poly test brick:phase-deployment`
- `bb pre-commit`
- `bb review`
