### PR TITLE
refactor(deploy): remove legacy Kustomize apply seam

### DIFF
--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell.clj
@@ -47,18 +47,14 @@
 
 (def ^{:stratum 0} kubectl-get-pods! kubectl/kubectl-get-pods!)
 
-(def ^{:stratum 0} kustomize-build! kustomize/kustomize-build!)
-
 (def ^{:stratum 0} kustomize-render! kustomize/kustomize-render!)
 
 (def ^{:stratum 0} kubectl-apply! kustomize/kubectl-apply!)
-
-(def ^{:stratum 0} kustomize-apply! kustomize/kustomize-apply!)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (sh-with-timeout "echo" ["hello world"])
   (pulumi-preview! "/path/to/project" :stack "dev")
   (kubectl! "get" :extra-args ["pods"] :namespace "default" :output "json")
-  (kustomize-build! "/path/to/overlay")
+  (kustomize-render! "/path/to/overlay")
   :leave-this-here)

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kustomize.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kustomize.clj
@@ -26,32 +26,24 @@
 ;------------------------------------------------------------------------------ Layer 0
 
 ;; Kustomize wrappers
-(def ^{:stratum 0} KustomizeResult
-  "The one result shape for producing a Kustomize manifest, shared by
-   `kustomize-render!` and `kustomize-apply!`.
+(def ^{:stratum 0} KustomizeRenderResult
+  "The result of producing a Kustomize manifest.
 
-   The manifest is always under `:rendered-yaml` and the raw build shell
-   result under `:build-result`. Render and apply differ in exactly one
-   key: `:apply-result` is nil for a render, because nothing was applied.
-
-   They share a shape deliberately. When rendering returned a raw shell
-   result and applying returned this one, a caller reading `:rendered-yaml`
-   off the render got nil and read a healthy render as an empty one."
+   The manifest is under `:rendered-yaml` and the raw build shell result is
+   retained under `:build-result`."
   [:map
    [:success? :boolean]
    [:rendered-yaml [:maybe :string]]
    [:build-result map?]
-   [:apply-result [:maybe map?]]
    [:error {:optional true} any?]
    [:anomaly {:optional true} map?]])
 
-(defn ^{:stratum 0} kustomize-build!
+(defn- ^{:stratum 0} kustomize-build!
   "Run `kustomize build` and return `exec/sh-with-timeout`'s raw
    `CommandResult`, whose manifest is under `:stdout`.
 
-   This is the unwrapped process boundary, NOT a `KustomizeResult` — it has
-   no `:rendered-yaml`. Callers outside this namespace want
-   `kustomize-render!`."
+   This private process boundary is not a `KustomizeRenderResult` — it has no
+   `:rendered-yaml`."
   [kustomize-dir & {:keys [timeout-ms] :or {timeout-ms (get timeouts/timeouts :kustomize-build-ms 60000)}}]
   (exec/sh-with-timeout "kustomize" ["build" kustomize-dir] :timeout-ms timeout-ms))
 
@@ -78,61 +70,22 @@
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} kustomize-render!
-  "Build one Kustomize target and report it as a `KustomizeResult`.
+  "Build one Kustomize target and report it as a `KustomizeRenderResult`.
 
-   `:apply-result` is nil — nothing was applied, and nothing contacted the
-   cluster. `:rendered-yaml` is nil only when the build itself failed, so a
-   nil manifest means no manifest, never a manifest under another key."
+   Nothing contacts the cluster. `:rendered-yaml` is nil only when the build
+   itself failed, so a nil manifest means no manifest, never a manifest under
+   another key."
   [kustomize-dir]
   (let [build-result (kustomize-build! kustomize-dir)]
     (schema/validate-anomaly
-     KustomizeResult
+     KustomizeRenderResult
      (if (schema/failed? build-result)
        (schema/failure :rendered-yaml
                        (msg/t :shell/kustomize-build-failed
                               {:error (failure-detail build-result)})
-                       {:build-result build-result
-                        :apply-result nil})
+                       {:build-result build-result})
        (schema/success :rendered-yaml (:stdout build-result)
-                       {:build-result build-result
-                        :apply-result nil})))))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn ^{:stratum 2} kustomize-apply!
-  "Render one Kustomize target and apply exactly those bytes.
-
-   Returns the same `KustomizeResult` shape as `kustomize-render!`, so a
-   caller reads the manifest from `:rendered-yaml` whichever it called. A
-   build failure is returned unchanged from the render — there is nothing
-   to apply and no kubectl runs."
-  [kustomize-dir & {:keys [namespace context dry-run?]}]
-  (let [rendered (kustomize-render! kustomize-dir)]
-    (if (schema/failed? rendered)
-      rendered
-      (let [rendered-yaml (:rendered-yaml rendered)
-            build-result  (:build-result rendered)
-            apply-args    (cond-> ["apply" "-f" "-"]
-                            namespace (into ["--namespace" namespace])
-                            context   (into ["--context" context])
-                            dry-run?  (conj "--dry-run=client"))
-            apply-result  (exec/sh-with-timeout "kubectl" apply-args
-                                                :in rendered-yaml
-                                                :timeout-ms (get timeouts/timeouts :kustomize-apply-ms 120000))]
-        (schema/validate-anomaly
-         KustomizeResult
-         (if (schema/succeeded? apply-result)
-           (schema/success :rendered-yaml rendered-yaml
-                           {:build-result build-result
-                            :apply-result apply-result})
-           ;; `schema/failure` nils its data key and merges opts last. The
-           ;; manifest is re-set deliberately: the build succeeded, and what
-           ;; kubectl rejected is the evidence worth keeping.
-           (schema/failure :rendered-yaml
-                           (failure-detail apply-result)
-                           {:build-result build-result
-                            :apply-result apply-result
-                            :rendered-yaml rendered-yaml})))))))
+                       {:build-result build-result})))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/shell/kustomize_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/shell/kustomize_test.clj
@@ -30,27 +30,26 @@
   [message]
   (schema/failure :stdout message {:stderr ""}))
 
-(defn ^{:stratum 0} recording-shell
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} recording-shell
   [calls]
   (fn [command args & {:as options}]
     (swap! calls conj {:command command :args args :options options})
-    (schema/success :stdout "accepted")))
+    (schema/success :stdout manifest-bytes)))
 
-;------------------------------------------------------------------------------ Layer 1
+(deftest ^{:stratum 1} a-failed-build-retains-error-and-renders-no-manifest-test
+  (let [result (with-redefs [exec/sh-with-timeout
+                             (fn [& _] (blank-stderr-failure "build broke"))]
+                 (kustomize/kustomize-render! "/deployment"))]
+    (is (schema/failed? result))
+    (is (nil? (:rendered-yaml result))
+        "a nil manifest means no manifest, not a manifest under another key")
+    (is (re-find #"build broke" (:error result)))))
 
-(defn ^{:stratum 1} scripted-shell
-  "Stub the process boundary and nothing above it. `kustomize-build!`,
-   `kustomize-render!`, and `kustomize-apply!` all stay real, so what these
-   tests assert is the producers' own output shape rather than a stub's."
-  [calls & {:keys [apply-result]
-            :or {apply-result (schema/success :stdout "deployment.apps/api configured")}}]
-  (fn [command args & {:as options}]
-    (swap! calls conj {:command command :args args :options options})
-    (if (= "kustomize" command)
-      (schema/success :stdout manifest-bytes)
-      apply-result)))
+;------------------------------------------------------------------------------ Layer 2
 
-(deftest ^{:stratum 1} server-dry-run-and-apply-use-identical-input-test
+(deftest ^{:stratum 2} server-dry-run-and-apply-use-identical-input-test
   (let [calls (atom [])]
     (with-redefs [exec/sh-with-timeout (recording-shell calls)]
       (kustomize/kubectl-apply! manifest-bytes
@@ -71,58 +70,15 @@
                 "--context" "cluster-1"]
                (:args apply-call)))))))
 
-(deftest ^{:stratum 1} a-failed-build-renders-no-manifest-test
-  (let [result (with-redefs [exec/sh-with-timeout
-                             (fn [& _] (blank-stderr-failure "build broke"))]
-                 (kustomize/kustomize-render! "/deployment"))]
-    (is (schema/failed? result))
-    (is (nil? (:rendered-yaml result))
-        "a nil manifest means no manifest, not a manifest under another key")))
-
-(deftest ^{:stratum 1} blank-stderr-retains-command-error-test
-  (testing "build failures retain the structured command error"
-    (let [result (with-redefs [kustomize/kustomize-build!
-                               (fn [& _] (blank-stderr-failure "build broke"))]
-                   (kustomize/kustomize-apply! "/deployment"))]
-      (is (schema/failed? result))
-      (is (re-find #"build broke" (:error result)))))
-  (testing "apply failures retain the structured command error"
-    (let [result (with-redefs [kustomize/kustomize-build!
-                               (fn [& _] (schema/success :stdout manifest-bytes))
-                               exec/sh-with-timeout
-                               (fn [& _] (blank-stderr-failure "apply broke"))]
-                   (kustomize/kustomize-apply! "/deployment"))]
-      (is (schema/failed? result))
-      (is (= "apply broke" (:error result))))))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(deftest ^{:stratum 2} render-and-apply-report-the-manifest-under-one-key-test
+(deftest ^{:stratum 2} render-reports-the-manifest-under-a-stable-key-test
   ;; The trap this closes: a governed caller wired :render! and then read
   ;; :rendered-yaml off the result. Rendering used to return a raw shell
   ;; result, so that key was nil, and a healthy render read as an empty one
   ;; — which denies every deploy.
   (let [render-calls (atom [])
-        rendered (with-redefs [exec/sh-with-timeout (scripted-shell render-calls)]
-                   (kustomize/kustomize-render! "/deployment"))
-        applied (with-redefs [exec/sh-with-timeout (scripted-shell (atom []))]
-                  (kustomize/kustomize-apply! "/deployment"))]
+        rendered (with-redefs [exec/sh-with-timeout
+                               (recording-shell render-calls)]
+                   (kustomize/kustomize-render! "/deployment"))]
     (is (= manifest-bytes (:rendered-yaml rendered)))
-    (is (= (:rendered-yaml rendered) (:rendered-yaml applied))
-        "render and apply must report the manifest under the same key")
     (testing "a render contacts no cluster"
-      (is (= ["kustomize"] (mapv :command @render-calls)))
-      (is (nil? (:apply-result rendered))
-          "nothing was applied, so there is no apply result to report"))))
-
-(deftest ^{:stratum 2} a-refused-apply-keeps-the-manifest-it-built-test
-  ;; The manifest kubectl rejected is the evidence of what was attempted.
-  ;; Nilling it left callers digging it out of [:build-result :stdout] by
-  ;; guesswork, which is the same trap wearing a different key.
-  (let [result (with-redefs [exec/sh-with-timeout
-                             (scripted-shell (atom [])
-                                             :apply-result (blank-stderr-failure "apply broke"))]
-                 (kustomize/kustomize-apply! "/deployment"))]
-    (is (schema/failed? result))
-    (is (= manifest-bytes (:rendered-yaml result))
-        "the build succeeded, so its manifest survives the apply failure")))
+      (is (= ["kustomize"] (mapv :command @render-calls))))))

--- a/docs/pull-requests/2026-08-16-remove-legacy-kustomize-apply.md
+++ b/docs/pull-requests/2026-08-16-remove-legacy-kustomize-apply.md
@@ -1,0 +1,35 @@
+<!--
+  Title: Remove the legacy Kustomize apply shell seam
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(deploy): remove legacy Kustomize apply seam
+
+## Layer
+
+Deployment shell boundary.
+
+## Overview
+
+Remove the lower direct build-and-apply helper after the governed deployment
+path made exact-byte render, server validation, and application the only live
+shell protocol.
+
+## Changes
+
+- Delete `kustomize-apply!`, remove the unused build/apply aliases, and make
+  the raw build helper private.
+- Replace the former combined render/apply result schema with the focused
+  `KustomizeRenderResult` shape.
+- Remove the obsolete `:apply-result` field and direct-apply-only tests.
+- Retain coverage for render failures, stable manifest placement, and exact
+  server-dry-run/application bytes.
+
+## Verification
+
+- Confirm no source or test references `kustomize-apply!` or the former
+  `KustomizeResult` schema.
+- `clojure -M:poly test brick:phase-deployment`
+- `bb pre-commit`
+- `bb review`


### PR DESCRIPTION
<!--
  Title: Remove the legacy Kustomize apply shell seam
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(deploy): remove legacy Kustomize apply seam

## Layer

Deployment shell boundary.

## Overview

Remove the lower direct build-and-apply helper after the governed deployment
path made exact-byte render, server validation, and application the only live
shell protocol.

## Changes

- Delete `kustomize-apply!`, remove the unused build/apply aliases, and make
  the raw build helper private.
- Replace the former combined render/apply result schema with the focused
  `KustomizeRenderResult` shape.
- Remove the obsolete `:apply-result` field and direct-apply-only tests.
- Retain coverage for render failures, stable manifest placement, and exact
  server-dry-run/application bytes.

## Verification

- Confirm no source or test references `kustomize-apply!` or the former
  `KustomizeResult` schema.
- `clojure -M:poly test brick:phase-deployment`
- `bb pre-commit`
- `bb review`
