### PR TITLE
refactor(cli): split messages.clj (rule 210)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/messages.clj
+++ b/bases/cli/src/ai/miniforge/cli/messages.clj
@@ -16,71 +16,42 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.cli.messages
-  "Resource-backed message catalog for shared CLI user-facing copy."
+  "Resource-backed message catalog for shared CLI user-facing copy. Locale
+   resolution primitives live in `ai.miniforge.cli.messages.locale` and
+   template-value rendering lives in `ai.miniforge.cli.messages.rendering`
+   (rule 210 split); this namespace composes them into the public
+   `catalog`/`t` API."
   (:require
    [clojure.string :as str]
+   [ai.miniforge.cli.messages.locale :as locale]
+   [ai.miniforge.cli.messages.rendering :as rendering]
    [ai.miniforge.cli.resource-config :as resource-config]
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Catalog loading
-(def ^{:stratum 0} default-locale "en-US")
-
-(defn- ^{:stratum 0} locale-resource
-  [locale]
-  (str "config/cli/messages/" locale ".edn"))
-
-(defn- ^{:stratum 0} lang->locale
-  "Convert POSIX LANG (e.g. 'en_US.UTF-8') to BCP 47 tag (e.g. 'en-US')."
-  [lang]
-  (when-let [base (some-> lang (str/split #"\.") first not-empty)]
-    (str/replace base "_" "-")))
-
-;; Template rendering
-(defn- ^{:stratum 0} render-string
-  [template params]
-  (reduce-kv (fn [rendered key value]
-               (str/replace rendered
-                            (str "{" (name key) "}")
-                            (str value)))
-             template
-             params))
+(defn ^{:stratum 0} active-locale
+  []
+  (or (some-> (System/getenv "MINIFORGE_LOCALE") str/trim not-empty)
+      (locale/lang->locale (System/getenv "LANG"))
+      locale/default-locale))
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} active-locale
-  []
-  (or (some-> (System/getenv "MINIFORGE_LOCALE") str/trim not-empty)
-      (lang->locale (System/getenv "LANG"))
-      default-locale))
-
-(defn- ^{:stratum 1} render-value
-  [value params]
-  (cond
-    (string? value) (render-string value params)
-    (vector? value) (mapv #(render-value % params) value)
-    (map? value) (into {} (map (fn [[key entry]]
-                                 [key (render-value entry params)]))
-                     value)
-    :else value))
+(defn ^{:stratum 1} catalog
+  "Load the active message catalog, falling back to English."
+  ([] (catalog (active-locale)))
+  ([locale-tag]
+   (let [catalog-data (resource-config/merged-resource-config (locale/locale-resource locale-tag)
+                                                               :cli/messages
+                                                               {})]
+     (if (or (= locale-tag locale/default-locale) (seq catalog-data))
+       catalog-data
+       (catalog locale/default-locale)))))
 
 ;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 2} catalog
-  "Load the active message catalog, falling back to English."
-  ([] (catalog (active-locale)))
-  ([locale]
-   (let [catalog-data (resource-config/merged-resource-config (locale-resource locale)
-                                                              :cli/messages
-                                                              {})]
-     (if (or (= locale default-locale) (seq catalog-data))
-       catalog-data
-       (catalog default-locale)))))
-
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} t
+(defn ^{:stratum 2} t
   "Return a rendered message value for `message-key`.
 
    Supports strings, vectors, and maps loaded from EDN resources."
@@ -88,7 +59,7 @@
    (t message-key {}))
   ([message-key params]
    (if-let [value (get (catalog) message-key)]
-     (render-value value params)
+     (rendering/render-value value params)
      (response/throw-anomaly! :anomalies/not-found
                              "Missing CLI message key"
                              {:message-key message-key

--- a/bases/cli/src/ai/miniforge/cli/messages/locale.clj
+++ b/bases/cli/src/ai/miniforge/cli/messages/locale.clj
@@ -1,0 +1,38 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.messages.locale
+  "Locale-resolution primitives for the CLI message catalog. Split out of
+   `ai.miniforge.cli.messages` (rule 210: the combined namespace measured 4
+   real layers, max 3) — these are the independent building blocks the
+   parent namespace's `active-locale` and `catalog` compose."
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} default-locale "en-US")
+
+(defn ^{:stratum 0} locale-resource
+  [locale]
+  (str "config/cli/messages/" locale ".edn"))
+
+(defn ^{:stratum 0} lang->locale
+  "Convert POSIX LANG (e.g. 'en_US.UTF-8') to BCP 47 tag (e.g. 'en-US')."
+  [lang]
+  (when-let [base (some-> lang (str/split #"\.") first not-empty)]
+    (str/replace base "_" "-")))

--- a/bases/cli/src/ai/miniforge/cli/messages/rendering.clj
+++ b/bases/cli/src/ai/miniforge/cli/messages/rendering.clj
@@ -1,0 +1,48 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.messages.rendering
+  "Template-value rendering for CLI catalog messages. Split out of
+   `ai.miniforge.cli.messages` (rule 210: the combined namespace measured 4
+   real layers, max 3). `render-value` recursively walks strings, vectors,
+   and maps loaded from EDN resources, interpolating `{param}` placeholders
+   via `render-string`."
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} render-string
+  [template params]
+  (reduce-kv (fn [rendered key value]
+               (str/replace rendered
+                            (str "{" (name key) "}")
+                            (str value)))
+             template
+             params))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} render-value
+  [value params]
+  (cond
+    (string? value) (render-string value params)
+    (vector? value) (mapv #(render-value % params) value)
+    (map? value) (into {} (map (fn [[key entry]]
+                                 [key (render-value entry params)]))
+                     value)
+    :else value))

--- a/docs/pull-requests/2026-08-12-refactor-split-cli-messages.md
+++ b/docs/pull-requests/2026-08-12-refactor-split-cli-messages.md
@@ -1,0 +1,90 @@
+<!--
+  Title: Split cli/messages.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(cli): split messages.clj (rule 210)
+
+## Overview
+
+Splits `ai.miniforge.cli.messages` (measured 4 real layers, over the
+rule 210 budget of 3) into three namespaces:
+
+- `ai.miniforge.cli.messages.locale` — locale-resolution primitives
+  (`default-locale`, `locale-resource`, `lang->locale`).
+- `ai.miniforge.cli.messages.rendering` — template-value rendering
+  (`render-string`, `render-value`).
+- `ai.miniforge.cli.messages` — unchanged public API (`active-locale`,
+  `catalog`, `t`), now composing the two sibling namespaces.
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program, `bases/cli`
+batch. `messages.clj` was 81 lines with two unrelated concerns
+(locale resolution and template rendering) stacked into one 4-layer
+namespace.
+
+`ai.miniforge.cli.messages` has the largest fan-in of any file
+touched so far in this program (40+ requiring namespaces across
+`bases/cli` and one project-level test), so the split keeps the
+public surface (`active-locale`, `catalog`, `t`) unchanged and in
+place — no caller needed a code change. Two previously-private helpers
+(`locale-resource`, `lang->locale`) became public (`defn` instead of
+`defn-`) since the parent namespace now calls them across a namespace
+boundary; their behavior is unchanged.
+
+## Changes in Detail
+
+- New file `messages/locale.clj`: `default-locale`, `locale-resource`,
+  `lang->locale` — 1 layer, unchanged behavior.
+- New file `messages/rendering.clj`: `render-string`, `render-value`
+  — 2 layers, unchanged behavior.
+- `messages.clj`: `active-locale`, `catalog`, `t` stay together (3
+  layers) — this preserves the existing `messages_test.clj` test,
+  which does `(with-redefs [messages/active-locale ...])` and expects
+  `catalog`'s internal call to `active-locale` to observe the redef;
+  keeping both functions in the same namespace as before means the
+  test needed no change.
+
+This is pure code motion: no logic changed, only relocated,
+re-namespaced, and (for the two helpers above) made public.
+
+## Testing Plan
+
+- `stratum-lint` clean on all three files (exit 0, was SL003 exit 1
+  on the original).
+- `clj-kondo` clean on all three files (0 errors, 0 warnings).
+- Direct namespace test runs (not just `bb test`, which is unreliable
+  under load in this batch):
+  - `ai.miniforge.cli.messages-test` — 3 tests, 6 assertions, 0
+    failures.
+  - 8 sampled `bases/cli` caller test namespaces (`main-test`,
+    `workflow-selector-test`, `workflow-runner.display-test`,
+    `main.display-test`, and four `main.commands.*-test` files) — 70
+    tests, 217 assertions, 0 failures.
+  - Project-level `ai.miniforge.workflow.kernel-loader-integration-test`
+    (under `projects/miniforge-core`, outside `bb test`'s change-scope)
+    — 2 tests, 16 assertions, 0 failures.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 program's `bases/cli` batch (see
+  `builtin_detectors.clj` split, miniforge#1730, for the established
+  convention this follows).
+
+## Checklist
+
+- [x] stratum-lint clean on all three resulting files
+- [x] clj-kondo clean on all three resulting files
+- [x] Direct namespace tests green (messages, 8 sampled callers,
+      1 project-level integration test)
+- [x] Adversarial self-review: def set unchanged except two
+      necessary defn- → defn visibility flips; public API of
+      `ai.miniforge.cli.messages` unchanged
+- [x] Fan-in confirmed repo-wide before starting (40+ callers, all
+      `:as messages`, none needed a change)


### PR DESCRIPTION
## Overview

Splits `ai.miniforge.cli.messages` (measured 4 real layers, over the rule 210 budget of 3) into three namespaces:

- `ai.miniforge.cli.messages.locale` — locale-resolution primitives (`default-locale`, `locale-resource`, `lang->locale`).
- `ai.miniforge.cli.messages.rendering` — template-value rendering (`render-string`, `render-value`).
- `ai.miniforge.cli.messages` — unchanged public API (`active-locale`, `catalog`, `t`), now composing the two sibling namespaces.

Part of the stratum-lint rule-210 remediation program, `bases/cli` batch. Full PR doc: `docs/pull-requests/2026-08-12-refactor-split-cli-messages.md`.

## Why the split is shaped this way

`ai.miniforge.cli.messages` has the largest fan-in of any file touched so far in this program (40+ requiring namespaces across `bases/cli` and one project-level test), so the split keeps the public surface (`active-locale`, `catalog`, `t`) unchanged and in place — no caller needed a code change.

`active-locale` and `catalog` stay together in the parent namespace rather than moving out: `messages_test.clj` does `(with-redefs [messages/active-locale ...])` and expects `catalog`'s internal call to observe the redef. Keeping both in the same namespace preserves that without touching the test.

Two previously-private helpers (`locale-resource`, `lang->locale`) became public (`defn` instead of `defn-`) since the parent namespace now calls them across a namespace boundary. No other behavior change — pure code motion.

## Testing

- `stratum-lint` clean on all three files (exit 0, was SL003 exit 1 on the original).
- `clj-kondo` clean on all three files.
- `bb pre-commit` green: commit-budget, Polylith check, lint, stratum-lint, 345-test/1301-assertion smoke suite, GraalVM/Babashka compatibility.
- Direct namespace test runs (not relying on `bb test` alone):
  - `ai.miniforge.cli.messages-test` — 3 tests, 6 assertions, 0 failures.
  - 8 sampled `bases/cli` caller test namespaces — 70 tests, 217 assertions, 0 failures.
  - Project-level `ai.miniforge.workflow.kernel-loader-integration-test` (under `projects/miniforge-core`, outside `bb test`'s change-scope) — 2 tests, 16 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
