### PR TITLE
refactor(cli): split web/components/status.clj (rule 210)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/web/components/status.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/components/status.clj
@@ -16,16 +16,17 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.cli.web.components.status
-  "Status-oriented dashboard fragments."
+  "Status-oriented dashboard fragments. The per-run workflow list rendering
+   lives in `ai.miniforge.cli.web.components.status.workflow-runs` (rule 210:
+   this namespace measured 4 real layers, max 3; the icon -> run -> runs
+   composition chain is layer-coherent on its own)."
   (:require
    [hiccup2.core :as h]
    [ai.miniforge.cli.messages :as messages]
-   [ai.miniforge.cli.web.fleet :as fleet]))
+   [ai.miniforge.cli.web.fleet :as fleet]
+   [ai.miniforge.cli.web.components.status.workflow-runs :as workflow-runs]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-(def ^{:stratum 0} ^:const no-workflows-style
-  "color: var(--text-muted); font-size: 12px; text-align: center;")
 
 (defn- ^{:stratum 0} t
   ([message-key]
@@ -47,15 +48,10 @@
   [:span {:class class-name}
    [:span value]])
 
-(defn ^{:stratum 0} workflow-status-icon
-  [run]
-  (let [status (get run :status)
-        conclusion (get run :conclusion)]
-    (cond
-      (= status "in_progress") "⏳"
-      (= conclusion "success") "✓"
-      (#{"failure" "timed_out" "startup_failure"} conclusion) "✗"
-      :else "○")))
+(def ^{:stratum 0} workflow-status-icon
+  "Re-exported from `status.workflow-runs`: callers outside this component
+   tree (e.g. `web.components`) reach it via this namespace."
+  workflow-runs/workflow-status-icon)
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -72,31 +68,13 @@
       [:span.status-dot]
       [:span status-text]])))
 
-(defn- ^{:stratum 1} workflow-run
-  [{:keys [workflowName createdAt] :as run}]
-  [:div.workflow-run
-   [:span.workflow-run-status (workflow-status-icon run)]
-   [:span.workflow-run-name workflowName]
-   [:span.workflow-run-time (fleet/format-time-ago createdAt)]])
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn- ^{:stratum 2} workflow-runs
-  [runs]
-  (if (seq runs)
-    (map workflow-run runs)
-    [[:div {:style no-workflows-style}
-      (t :web-ui/workflow-status-none)]]))
-
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} workflow-status
+(defn ^{:stratum 1} workflow-status
   [repos]
   (let [{:keys [running failed succeeded runs]} (fleet/get-workflow-status repos)
         running-value (str running " ⏳")
         failed-value (str failed " ✗")
         succeeded-value (str succeeded " ✓")
-        rendered-runs (workflow-runs runs)]
+        rendered-runs (workflow-runs/workflow-runs runs)]
     (h/html
      [:div.workflow-status
       {:hx-get "/api/workflows"

--- a/bases/cli/src/ai/miniforge/cli/web/components/status/workflow_runs.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/components/status/workflow_runs.clj
@@ -1,0 +1,65 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.web.components.status.workflow-runs
+  "Per-run workflow list rendering: the run status icon, a single rendered
+   run row, and the run list (or its \"none\" placeholder). Split out of
+   `ai.miniforge.cli.web.components.status` (rule 210: the parent namespace
+   measured 4 real layers, max 3; this icon -> run -> runs composition chain
+   is layer-coherent on its own)."
+  (:require
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.web.fleet :as fleet]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:const no-workflows-style
+  "color: var(--text-muted); font-size: 12px; text-align: center;")
+
+(defn- ^{:stratum 0} t
+  ([message-key]
+   (messages/t message-key))
+  ([message-key params]
+   (messages/t message-key params)))
+
+(defn ^{:stratum 0} workflow-status-icon
+  [run]
+  (let [status (get run :status)
+        conclusion (get run :conclusion)]
+    (cond
+      (= status "in_progress") "⏳"
+      (= conclusion "success") "✓"
+      (#{"failure" "timed_out" "startup_failure"} conclusion) "✗"
+      :else "○")))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} workflow-run
+  [{:keys [workflowName createdAt] :as run}]
+  [:div.workflow-run
+   [:span.workflow-run-status (workflow-status-icon run)]
+   [:span.workflow-run-name workflowName]
+   [:span.workflow-run-time (fleet/format-time-ago createdAt)]])
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} workflow-runs
+  [runs]
+  (if (seq runs)
+    (map workflow-run runs)
+    [[:div {:style no-workflows-style}
+      (t :web-ui/workflow-status-none)]]))

--- a/docs/pull-requests/2026-08-09-refactor-split-cli-web-status.md
+++ b/docs/pull-requests/2026-08-09-refactor-split-cli-web-status.md
@@ -1,0 +1,98 @@
+<!--
+  Title: Split cli/web/components/status.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(cli): split web/components/status.clj (rule 210)
+
+## Overview
+
+Splits the per-run workflow list rendering out of
+`ai.miniforge.cli.web.components.status` into a new sibling namespace,
+`ai.miniforge.cli.web.components.status.workflow-runs`, resolving a
+stratum-lint SL003 finding (the combined namespace measured 4 real
+layers, over the rule 210 budget of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program, `bases/cli`
+batch. `status.clj`'s call graph has a genuine 4-deep chain:
+`workflow-status-icon` (leaf) -> `workflow-run` (renders one row,
+calls the icon fn) -> `workflow-runs` (renders the list, calls
+`workflow-run`) -> `workflow-status` (the widget, calls `workflow-runs`).
+No amount of relabeling collapses that to 3 layers in one file; the
+chain has to be split across a namespace boundary.
+
+`ai.miniforge.cli.web.components.status/workflow-status-icon` is the
+only symbol from this namespace consumed outside it (re-exported by
+`web/components.clj`, itself the sole fan-in point for this
+namespace repo-wide — confirmed via a fully-qualified-namespace grep
+across `components/`, `bases/`, and `projects/`), so the split had to
+preserve that name resolving from the original namespace without
+introducing a require cycle between the two files.
+
+## Changes in Detail
+
+- New file `status/workflow_runs.clj`
+  (`ai.miniforge.cli.web.components.status.workflow-runs`): the
+  icon -> run -> runs composition chain (`no-workflows-style`,
+  `workflow-status-icon`, `workflow-run`, `workflow-runs`) — 3 layers.
+  `workflow-runs` changes from `defn-` to `defn` (now consumed across
+  the namespace boundary by `status.clj`'s `workflow-status`); no
+  other visibility or behavior changes.
+- `status.clj`: keeps `status-indicator` and `workflow-status` (the
+  two externally-relevant widgets) plus their shared leaf helpers
+  (`t`, `overall-status-key`, `workflow-stat`) — 2 layers. Requires
+  the new `workflow-runs` namespace for `workflow-run`s' rendering and
+  re-exports `workflow-status-icon` as a passthrough `def` so
+  `ai.miniforge.cli.web.components.status/workflow-status-icon` still
+  resolves for `web/components.clj` unchanged.
+
+This is pure code motion plus one necessary `defn-` -> `defn`
+visibility change and one passthrough re-export `def`: no logic
+changed.
+
+Note: `bases/cli/src/ai/miniforge/cli/web/components.clj` (task #24)
+is being split concurrently by a separate agent and is not touched by
+this PR.
+
+## Testing Plan
+
+- `stratum-lint` clean on both files (exit 0, was SL003 exit 1 on the
+  original).
+- Namespaces compile clean from the full workspace
+  (`projects/miniforge`), including the unmodified `web/components.clj`
+  facade that re-exports the moved symbols.
+- `ai.miniforge.cli.web.components-test` and
+  `ai.miniforge.cli.web.handlers-test` (the tests exercising
+  `status-indicator`, `workflow-status`, and `workflow-status-icon`
+  through the `web/components.clj` facade and the HTTP handlers) run
+  directly via `clojure.test/run-tests`: 9 tests, 23 assertions, 0
+  failures, 0 errors.
+- No `projects/miniforge/test/` file references this namespace
+  directly (checked by grep) — no project-level test gap to cover.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 program, `bases/cli` batch (task
+  #29). See PR #1730 (`policy-pack/builtin_detectors.clj`) for the
+  established single-sibling split convention this follows, and the
+  `workflow_runner/preflight_probe.clj` + `preflight_support.clj` pair
+  for precedent on breaking a multi-file dependency chain across a
+  namespace boundary without introducing a require cycle.
+
+## Checklist
+
+- [x] stratum-lint clean on both resulting files
+- [x] Full-workspace compile check green, including the dependent
+      `web/components.clj` facade
+- [x] Direct `clojure.test/run-tests` green (9 tests / 23 assertions)
+- [x] Adversarial self-review: def set unchanged except one
+      `defn-` -> `defn` visibility change and one re-export `def`
+- [x] Fan-in confirmed repo-wide before starting (single caller:
+      `web/components.clj`, itself untouched)


### PR DESCRIPTION
## Overview

Splits the per-run workflow list rendering out of
`ai.miniforge.cli.web.components.status` into a new sibling namespace,
`ai.miniforge.cli.web.components.status.workflow-runs`, resolving a
stratum-lint SL003 finding (the combined namespace measured 4 real
layers, over the rule 210 budget of 3).

## Motivation

Part of the stratum-lint rule-210 remediation program, `bases/cli`
batch (task #29). `status.clj`'s call graph has a genuine 4-deep
chain: `workflow-status-icon` (leaf) -> `workflow-run` (renders one
row, calls the icon fn) -> `workflow-runs` (renders the list, calls
`workflow-run`) -> `workflow-status` (the widget, calls
`workflow-runs`). No relabeling collapses that to 3 layers in one
file; the chain has to be split across a namespace boundary.

`ai.miniforge.cli.web.components.status/workflow-status-icon` is the
only symbol from this namespace consumed outside it (re-exported by
`web/components.clj`, itself the sole fan-in point for this
namespace repo-wide — confirmed via a fully-qualified-namespace grep
across `components/`, `bases/`, and `projects/`), so the split had to
preserve that name resolving from the original namespace without
introducing a require cycle between the two files.

## Changes in Detail

- New file `status/workflow_runs.clj`
  (`ai.miniforge.cli.web.components.status.workflow-runs`): the
  icon -> run -> runs composition chain (`no-workflows-style`,
  `workflow-status-icon`, `workflow-run`, `workflow-runs`) — 3 layers.
  `workflow-runs` changes from `defn-` to `defn` (now consumed across
  the namespace boundary by `status.clj`'s `workflow-status`); no
  other visibility or behavior changes.
- `status.clj`: keeps `status-indicator` and `workflow-status` (the
  two externally-relevant widgets) plus their shared leaf helpers
  (`t`, `overall-status-key`, `workflow-stat`) — 2 layers. Requires
  the new `workflow-runs` namespace and re-exports
  `workflow-status-icon` as a passthrough `def` so
  `ai.miniforge.cli.web.components.status/workflow-status-icon` still
  resolves for `web/components.clj` unchanged.

Pure code motion plus one necessary `defn-` -> `defn` visibility
change and one passthrough re-export `def`: no logic changed.

Note: `bases/cli/src/ai/miniforge/cli/web/components.clj` (task #24)
is being split concurrently by a separate agent and is not touched by
this PR.

## Testing Plan

- `stratum-lint` clean on both files (exit 0, was SL003 exit 1 on the
  original).
- `clj-kondo` clean on both files.
- Namespaces compile clean from the full workspace
  (`projects/miniforge`), including the unmodified `web/components.clj`
  facade that re-exports the moved symbols.
- `ai.miniforge.cli.web.components-test` and
  `ai.miniforge.cli.web.handlers-test` run directly via
  `clojure.test/run-tests`: 9 tests, 23 assertions, 0 failures, 0
  errors.
- No `projects/miniforge/test/` file references this namespace
  directly (checked by grep) — no project-level test gap to cover.
- Full `bb pre-commit` (commit-budget, poly:check, lint:clj,
  lint:stratum, fmt:md, test:precommit, test:graalvm) green: 345 + 8
  tests, 0 failures, 0 errors.

## Deployment Plan

Merges to `main` immediately; no follow-up needed for this file.

## Related Issues/PRs

- Part of the stratum-lint rule-210 program, `bases/cli` batch (task
  #29). See PR #1730 (`policy-pack/builtin_detectors.clj`) for the
  established single-sibling split convention this follows, and the
  `workflow_runner/preflight_probe.clj` + `preflight_support.clj` pair
  for precedent on breaking a multi-file dependency chain across a
  namespace boundary without introducing a require cycle.

PR doc: `docs/pull-requests/2026-08-09-refactor-split-cli-web-status.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)