### PR TITLE
refactor(cli): split app_config.clj (rule 210)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/app_config.clj
+++ b/bases/cli/src/ai/miniforge/cli/app_config.clj
@@ -16,122 +16,85 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.cli.app-config
-  "Project-composed CLI app identity and filesystem layout."
+  "Project-composed CLI app identity and filesystem layout. A stable facade
+   over `ai.miniforge.cli.app-config.profile` (resource-backed identity)
+   and `ai.miniforge.cli.app-config.paths` (home-dir resolution and
+   filesystem layout) — split out (rule 210: the combined namespace
+   measured 6 real layers, max 3). Every symbol here is a plain re-export;
+   the real logic and each sibling's own layer structure live in those two
+   namespaces. Kept as a facade, rather than moving callers over, because
+   this namespace is required directly (fully-qualified) across bases,
+   components, and projects — re-exporting keeps every one of those call
+   sites unchanged."
   (:require
-   [babashka.fs :as fs]
-   [clojure.string :as str]
-   [ai.miniforge.cli.resource-config :as resource-config]))
+   [ai.miniforge.cli.app-config.profile :as profile]
+   [ai.miniforge.cli.app-config.paths :as paths]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Resource loading
+;; Re-exported from ai.miniforge.cli.app-config.profile
 (def ^{:stratum 0} app-config-resource
   "Classpath resource path for CLI app identity."
-  "config/cli/app.edn")
+  profile/app-config-resource)
 
 (def ^{:stratum 0} default-status-config
   "Defaults for workflow status rendering and health classification."
-  {:running-stale-threshold-ms 300000})
+  profile/default-status-config)
 
-(defn- ^{:stratum 0} normalize-profile
-  [profile]
-  (-> profile
-      (update :help-examples #(vec (or % [])))))
-
-(defn ^{:stratum 0} getenv
+(def ^{:stratum 0} getenv
   "Environment-variable lookup seam. Public so tests can rebind it via
    `with-redefs` when validating MINIFORGE_HOME resolution; not part of
    the external API."
-  [var-name]
-  (System/getenv var-name))
+  profile/getenv)
 
-;------------------------------------------------------------------------------ Layer 1
-
-(defn ^{:stratum 1} app-profile
+(def ^{:stratum 0} app-profile
   "Resolve the active CLI app profile from the classpath."
-  []
-  (-> (resource-config/merged-resource-config app-config-resource
-                                              :cli-app/profile
-                                              {})
-      normalize-profile))
+  profile/app-profile)
 
-(defn ^{:stratum 1} pr-monitor-config
+(def ^{:stratum 0} pr-monitor-config
   "Resolve PR monitor CLI config from the classpath."
-  []
-  (resource-config/merged-resource-config app-config-resource
-                                          :cli-app/pr-monitor
-                                          {}))
+  profile/pr-monitor-config)
 
-(defn ^{:stratum 1} status-config
+(def ^{:stratum 0} status-config
   "Resolve workflow status CLI config from the classpath."
-  []
-  (resource-config/merged-resource-config app-config-resource
-                                          :cli-app/status
-                                          default-status-config))
+  profile/status-config)
 
-;------------------------------------------------------------------------------ Layer 2
+(def ^{:stratum 0} binary-name profile/binary-name)
 
-;; Identity helpers
-(defn ^{:stratum 2} binary-name []
-  (:name (app-profile)))
+(def ^{:stratum 0} display-name profile/display-name)
 
-(defn ^{:stratum 2} display-name []
-  (:display-name (app-profile)))
+(def ^{:stratum 0} description profile/description)
 
-(defn ^{:stratum 2} description []
-  (:description (app-profile)))
+(def ^{:stratum 0} system-check-title profile/system-check-title)
 
-(defn ^{:stratum 2} system-check-title []
-  (:system-check-title (app-profile)))
+(def ^{:stratum 0} home-dir-name profile/home-dir-name)
 
-(defn ^{:stratum 2} home-dir-name []
-  (:home-dir-name (app-profile)))
+(def ^{:stratum 0} tui-package profile/tui-package)
 
-(defn ^{:stratum 2} tui-package []
-  (:tui-package (app-profile)))
+(def ^{:stratum 0} help-examples profile/help-examples)
 
-(defn ^{:stratum 2} help-examples []
-  (:help-examples (app-profile)))
-
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} default-home-dir
+;; Re-exported from ai.miniforge.cli.app-config.paths
+(def ^{:stratum 0} default-home-dir
   "Profile-derived default home directory. Public so tests can rebind
    it via `with-redefs`; not part of the external API."
-  []
-  (str (fs/home) "/" (home-dir-name)))
+  paths/default-home-dir)
 
-(defn ^{:stratum 3} command-string
+(def ^{:stratum 0} command-string
   "Build a CLI command string prefixed with the active binary name."
-  [& parts]
-  (str/join " " (cons (binary-name) (remove str/blank? parts))))
+  paths/command-string)
 
-;------------------------------------------------------------------------------ Layer 4
+(def ^{:stratum 0} home-dir paths/home-dir)
 
-(defn ^{:stratum 4} home-dir []
-  (or (getenv "MINIFORGE_HOME")
-      (default-home-dir)))
+(def ^{:stratum 0} config-path paths/config-path)
 
-;------------------------------------------------------------------------------ Layer 5
+(def ^{:stratum 0} artifacts-dir paths/artifacts-dir)
 
-;; Filesystem layout helpers
-(defn ^{:stratum 5} config-path []
-  (str (home-dir) "/config.edn"))
+(def ^{:stratum 0} worktrees-dir paths/worktrees-dir)
 
-(defn ^{:stratum 5} artifacts-dir []
-  (str (home-dir) "/artifacts"))
+(def ^{:stratum 0} events-dir paths/events-dir)
 
-(defn ^{:stratum 5} worktrees-dir []
-  (str (home-dir) "/worktrees"))
+(def ^{:stratum 0} logs-dir paths/logs-dir)
 
-(defn ^{:stratum 5} events-dir []
-  (str (home-dir) "/events"))
+(def ^{:stratum 0} dashboard-port-file paths/dashboard-port-file)
 
-(defn ^{:stratum 5} logs-dir []
-  (str (home-dir) "/logs"))
-
-(defn ^{:stratum 5} dashboard-port-file []
-  (str (home-dir) "/dashboard.port"))
-
-(defn ^{:stratum 5} state-file []
-  (str (home-dir) "/state.edn"))
+(def ^{:stratum 0} state-file paths/state-file)

--- a/bases/cli/src/ai/miniforge/cli/app_config/paths.clj
+++ b/bases/cli/src/ai/miniforge/cli/app_config/paths.clj
@@ -1,0 +1,72 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.app-config.paths
+  "CLI home-directory resolution and the filesystem layout (config file,
+   artifacts/worktrees/events/logs dirs, ...) built on it. Split out of
+   `ai.miniforge.cli.app-config` (rule 210: the combined namespace measured
+   6 real layers, max 3). Builds on the resource-backed identity in the
+   sibling `ai.miniforge.cli.app-config.profile` (binary name, home-dir
+   name, the env-var lookup seam). `ai.miniforge.cli.app-config`
+   re-exports every symbol here as its stable public surface."
+  (:require
+   [babashka.fs :as fs]
+   [clojure.string :as str]
+   [ai.miniforge.cli.app-config.profile :as profile]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} default-home-dir
+  "Profile-derived default home directory. Public so tests can rebind
+   it via `with-redefs`; not part of the external API."
+  []
+  (str (fs/home) "/" (profile/home-dir-name)))
+
+(defn ^{:stratum 0} command-string
+  "Build a CLI command string prefixed with the active binary name."
+  [& parts]
+  (str/join " " (cons (profile/binary-name) (remove str/blank? parts))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} home-dir []
+  (or (profile/getenv "MINIFORGE_HOME")
+      (default-home-dir)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Filesystem layout helpers
+(defn ^{:stratum 2} config-path []
+  (str (home-dir) "/config.edn"))
+
+(defn ^{:stratum 2} artifacts-dir []
+  (str (home-dir) "/artifacts"))
+
+(defn ^{:stratum 2} worktrees-dir []
+  (str (home-dir) "/worktrees"))
+
+(defn ^{:stratum 2} events-dir []
+  (str (home-dir) "/events"))
+
+(defn ^{:stratum 2} logs-dir []
+  (str (home-dir) "/logs"))
+
+(defn ^{:stratum 2} dashboard-port-file []
+  (str (home-dir) "/dashboard.port"))
+
+(defn ^{:stratum 2} state-file []
+  (str (home-dir) "/state.edn"))

--- a/bases/cli/src/ai/miniforge/cli/app_config/profile.clj
+++ b/bases/cli/src/ai/miniforge/cli/app_config/profile.clj
@@ -1,0 +1,99 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.app-config.profile
+  "CLI app identity: the resource-backed profile (name, description,
+   home-dir name, ...) and the PR-monitor / status config blocks that ride
+   the same classpath resource. Split out of `ai.miniforge.cli.app-config`
+   (rule 210: the combined namespace measured 6 real layers, max 3) —
+   identity resolution is layer-coherent on its own, while the home-dir
+   and filesystem-layout logic that builds on it moved to the sibling
+   `ai.miniforge.cli.app-config.paths`. `ai.miniforge.cli.app-config`
+   re-exports every symbol here as its stable public surface."
+  (:require
+   [ai.miniforge.cli.resource-config :as resource-config]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Resource loading
+(def ^{:stratum 0} app-config-resource
+  "Classpath resource path for CLI app identity."
+  "config/cli/app.edn")
+
+(def ^{:stratum 0} default-status-config
+  "Defaults for workflow status rendering and health classification."
+  {:running-stale-threshold-ms 300000})
+
+(defn- ^{:stratum 0} normalize-profile
+  [profile]
+  (-> profile
+      (update :help-examples #(vec (or % [])))))
+
+(defn ^{:stratum 0} getenv
+  "Environment-variable lookup seam. Public so tests can rebind it via
+   `with-redefs` when validating MINIFORGE_HOME resolution; not part of
+   the external API."
+  [var-name]
+  (System/getenv var-name))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} app-profile
+  "Resolve the active CLI app profile from the classpath."
+  []
+  (-> (resource-config/merged-resource-config app-config-resource
+                                              :cli-app/profile
+                                              {})
+      normalize-profile))
+
+(defn ^{:stratum 1} pr-monitor-config
+  "Resolve PR monitor CLI config from the classpath."
+  []
+  (resource-config/merged-resource-config app-config-resource
+                                          :cli-app/pr-monitor
+                                          {}))
+
+(defn ^{:stratum 1} status-config
+  "Resolve workflow status CLI config from the classpath."
+  []
+  (resource-config/merged-resource-config app-config-resource
+                                          :cli-app/status
+                                          default-status-config))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Identity helpers
+(defn ^{:stratum 2} binary-name []
+  (:name (app-profile)))
+
+(defn ^{:stratum 2} display-name []
+  (:display-name (app-profile)))
+
+(defn ^{:stratum 2} description []
+  (:description (app-profile)))
+
+(defn ^{:stratum 2} system-check-title []
+  (:system-check-title (app-profile)))
+
+(defn ^{:stratum 2} home-dir-name []
+  (:home-dir-name (app-profile)))
+
+(defn ^{:stratum 2} tui-package []
+  (:tui-package (app-profile)))
+
+(defn ^{:stratum 2} help-examples []
+  (:help-examples (app-profile)))

--- a/bases/cli/test/ai/miniforge/cli/app_config_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/app_config_test.clj
@@ -19,6 +19,8 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.app-config.paths :as paths]
+   [ai.miniforge.cli.app-config.profile :as profile]
    [ai.miniforge.cli.resource-config :as resource-config]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -48,16 +50,16 @@
 
 (deftest ^{:stratum 0} home-dir-prefers-miniforge-home-env-test
   (testing "MINIFORGE_HOME overrides the default CLI home path"
-    (with-redefs [app-config/getenv (fn [var-name]
-                                      (when (= "MINIFORGE_HOME" var-name)
-                                        "/tmp/mf-home"))
-                  app-config/default-home-dir (constantly "/Users/test/.miniforge")]
+    (with-redefs [profile/getenv (fn [var-name]
+                                   (when (= "MINIFORGE_HOME" var-name)
+                                     "/tmp/mf-home"))
+                  paths/default-home-dir (constantly "/Users/test/.miniforge")]
       (is (= "/tmp/mf-home" (app-config/home-dir)))
       (is (= "/tmp/mf-home/events" (app-config/events-dir))))))
 
 (deftest ^{:stratum 0} home-dir-falls-back-to-profile-based-default-test
   (testing "default CLI home path stays profile-derived when MINIFORGE_HOME is unset"
-    (with-redefs [app-config/getenv (constantly nil)
-                  app-config/default-home-dir (constantly "/Users/test/.miniforge-core")]
+    (with-redefs [profile/getenv (constantly nil)
+                  paths/default-home-dir (constantly "/Users/test/.miniforge-core")]
       (is (= "/Users/test/.miniforge-core" (app-config/home-dir)))
       (is (= "/Users/test/.miniforge-core/config.edn" (app-config/config-path))))))

--- a/docs/pull-requests/2026-08-12-refactor-split-cli-app-config.md
+++ b/docs/pull-requests/2026-08-12-refactor-split-cli-app-config.md
@@ -1,0 +1,113 @@
+<!--
+  Title: Split cli/app_config.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(cli): split app_config.clj (rule 210)
+
+## Overview
+
+Splits `bases/cli/src/ai/miniforge/cli/app_config.clj` (SL003: 6 distinct
+real layers, over the rule-210 budget of 3) into two sibling
+implementation namespaces, and turns the original namespace into a thin
+re-export facade over them.
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program, `bases/cli` batch
+(task #25). `ai.miniforge.cli.app-config` has unusually heavy fan-in for a
+file this size: 34 files require it directly (fully-qualified) across
+`bases/`, `components/pr-lifecycle`, and `projects/miniforge-core`, and
+roughly 111 call sites use one of the ten functions that would move to
+the "paths" concern. Relocating those call sites would touch dozens of
+files for a pure lint fix and — worse — would silently break several
+`with-redefs` mocks in caller test files that redefine `app-config/X` and
+expect production code elsewhere to observe it through that same Var.
+Per the `interface.clj` pattern already codified in
+`standards/miniforge/languages/clojure.mdc` ("Interface.clj pattern
+(CRITICAL)" — pure pass-through files are exempt from the 3-layer budget)
+and the identical precedent in PR #1772
+(`policy-pack/interface/loading.clj` re-exporting from
+`loader.clj`/`loader/io.clj`), the original namespace stays in place as a
+stable facade so no caller needs to change.
+
+## Changes in Detail
+
+- New file `app_config/profile.clj`
+  (`ai.miniforge.cli.app-config.profile`): resource-backed CLI identity —
+  `app-config-resource`, `default-status-config`, `normalize-profile`
+  (private), `getenv` (Layer 0); `app-profile`, `pr-monitor-config`,
+  `status-config` (Layer 1); `binary-name`, `display-name`,
+  `description`, `system-check-title`, `home-dir-name`, `tui-package`,
+  `help-examples` (Layer 2). 3 layers, unchanged behavior.
+- New file `app_config/paths.clj` (`ai.miniforge.cli.app-config.paths`):
+  home-dir resolution and filesystem layout, built on `profile.clj` —
+  `default-home-dir`, `command-string` (Layer 0); `home-dir` (Layer 1);
+  `config-path`, `artifacts-dir`, `worktrees-dir`, `events-dir`,
+  `logs-dir`, `dashboard-port-file`, `state-file` (Layer 2). 3 layers,
+  unchanged behavior.
+- `app_config.clj`: now a pure facade — every symbol is a flat `def`
+  re-exporting the corresponding var from `profile` or `paths`. All
+  re-exports are real Layer 0 (no local interdependency), so the file
+  measures 1 real layer, well within budget. Docstrings preserved
+  verbatim from the originals.
+- `app_config_test.clj`: the two tests that mock the internal composition
+  (`getenv` + `default-home-dir` composing into `home-dir`) now require
+  `app-config.paths` and `app-config.profile` directly and redefine those
+  vars instead of the (now-disconnected) facade copies — `with-redefs` on
+  a re-exported `def` does not affect what the moved implementation calls
+  internally, since it resolves the real `profile`/`paths` Vars, not the
+  facade's. Assertions still call through `app-config/home-dir` etc.,
+  unchanged, since those are the same function values.
+
+This is pure code motion: no logic changed, only relocated and
+re-namespaced. No caller outside `app_config_test.clj` needed any change
+— confirmed by grepping the fully-qualified namespace
+`ai\.miniforge\.cli\.app-config\b` across `bases/`, `components/`, and
+`projects/` (34 hits, all now covered).
+
+## Testing Plan
+
+- `stratum-lint` clean on all three touched/new source files (exit 0, was
+  SL003 exit 1 on `app_config.clj`).
+- `clj-kondo` clean on all four touched files.
+- `clojure -M:dev:test -e '(run-tests ...)'` on
+  `ai.miniforge.cli.app-config-test` directly: 4 tests, 12 assertions, 0
+  failures, 0 errors.
+- Same, on the nine other `bases/cli` namespaces that call the relocated
+  functions (`main-test`, `workflow-runner.display-test`,
+  `main.commands.evidence-test`, `main.commands.policy-test`,
+  `main.commands.monitoring-test`, `main.commands.pr-monitor-test`,
+  `main.commands.workflow-commands-test`, `main.commands.events-test`,
+  `main.commands.artifact-cmds-test`): 94 tests, 198 assertions, 0
+  failures, 0 errors.
+- Same, on the project-level
+  `ai.miniforge.workflow.kernel-loader-integration-test` (in
+  `projects/miniforge-core/test/`, outside `bb test`'s change-scope): 2
+  tests, 16 assertions, 0 failures, 0 errors.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 program, `bases/cli` batch (task
+  #25).
+- Follows the `interface.clj`-facade precedent from PR #1772
+  (`policy-pack/loader.clj` split) and the general namespace-splitting
+  convention from PR #1730 (`builtin_detectors.clj`) and PRs #1662-#1667
+  (`workflow_runner.clj`).
+
+## Checklist
+
+- [x] stratum-lint clean on all resulting files
+- [x] Real-caller test verification (not just `bb test` change-scope):
+      105 tests / 226 assertions across `bases/cli` + project-level, 0
+      failures
+- [x] Adversarial self-review: def set unchanged, only relocated; facade
+      preserves every caller's public API
+- [x] Fan-in confirmed repo-wide before starting (34 files; only the
+      co-located test needed a change)
+- [x] `clj-kondo` clean


### PR DESCRIPTION
## Summary

Splits `bases/cli/src/ai/miniforge/cli/app_config.clj` (SL003: 6 distinct real layers, max 3) into two sibling implementation namespaces — `app_config/profile.clj` (resource-backed CLI identity) and `app_config/paths.clj` (home-dir resolution + filesystem layout, built on profile) — and turns `app_config.clj` into a thin re-export facade over them.

Part of the stratum-lint rule-210 program, `bases/cli` batch (task #25).

## Why a facade instead of moving callers

`ai.miniforge.cli.app-config` has unusually heavy fan-in for a file this size: 34 files require it directly (fully-qualified) across `bases/`, `components/pr-lifecycle`, and `projects/miniforge-core`, with ~111 call sites using one of the ten functions that move to the "paths" concern. Relocating those call sites would touch dozens of files for a pure lint fix, and would silently break several `with-redefs` mocks in caller test files that redefine `app-config/X` and expect production code elsewhere to observe it through that same Var.

The facade follows the `interface.clj` pass-through exemption already codified in `standards/miniforge/languages/clojure.mdc` (pure pass-through files are exempt from the 3-layer budget) and the identical precedent in PR #1772 (`policy-pack/interface/loading.clj` re-exporting from `loader.clj`/`loader/io.clj`). Every re-exported symbol is a flat `def` with no local interdependency, so the facade measures 1 real layer.

Full detail in `docs/pull-requests/2026-08-12-refactor-split-cli-app-config.md`.

## Testing

- `stratum-lint` clean on all three source files (was SL003 exit 1 on `app_config.clj`).
- `clj-kondo` clean on all four touched files.
- Direct `clojure -M:dev:test` `run-tests` (not just `bb test` change-scope) on `app-config-test` (4/12 assertions) plus the 9 other `bases/cli` namespaces that call the relocated functions (94 tests/198 assertions) — all green.
- Project-level `ai.miniforge.workflow.kernel-loader-integration-test` in `projects/miniforge-core/test/` (2 tests/16 assertions) — green.
- Full `bb pre-commit` suite (poly:check, lint, stratum-lint, 345+8 tests) passed on both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)