### PR TITLE
refactor(cli): split main/display.clj (rule 210)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
@@ -22,6 +22,7 @@
    [clojure.edn :as edn]
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.main.display.classified-error :as classified-error]
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.spec-parser :as spec-parser]
    [ai.miniforge.cli.workflow-runner :as workflow-runner]
@@ -99,7 +100,7 @@
   [e]
   (let [classification (classify-error e)]
     (if classification
-      (display/print-classified-error classification)
+      (classified-error/print-classified-error classification)
       (do
         (display/print-error (messages/t :run/failed {:error (ex-message e)}))
         (when-let [data (ex-data e)]

--- a/bases/cli/src/ai/miniforge/cli/main/display.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/display.clj
@@ -16,7 +16,16 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.cli.main.display
-  "Terminal styling and error display for CLI output."
+  "Terminal styling and generic entity/detail rendering for CLI output.
+
+   Layer 0: ANSI color table and data-driven field/section renderers
+   Layer 1: ANSI styling primitive
+   Layer 2: Styled print helpers and the composite detail-view renderer
+
+   Classified-error display (headers, context, retry recommendation, and
+   the `print-classified-error` composite) lives in
+   `ai.miniforge.cli.main.display.classified-error` (rule 210: the
+   combined namespace measured 5 real layers, max 3)."
   (:require
    [clojure.string :as str]
    [ai.miniforge.cli.messages :as messages]))
@@ -58,29 +67,6 @@
       (doseq [item (cond->> items max (take max))]
         (println (messages/t entry (if entry-fn (entry-fn item) {:value (str item)})))))))
 
-(defn ^{:stratum 0} print-agent-backend-error-context
-  [completed-work]
-  (if (seq completed-work)
-    (println (messages/t :classified-error/agent-backend-context-success))
-    (println (messages/t :classified-error/agent-backend-context))))
-
-(defn ^{:stratum 0} print-task-code-error-context
-  [completed-work]
-  (println (messages/t :classified-error/task-code-context))
-  (when (seq completed-work)
-    (println)
-    (println (messages/t :classified-error/partial-work))
-    (doseq [work completed-work]
-      (println (str "  ⏸️  " work)))))
-
-(defn ^{:stratum 0} get-retry-recommendation
-  [error-type]
-  (case error-type
-    :task-code (messages/t :classified-error/retry-task-code)
-    :external (messages/t :classified-error/retry-external)
-    :agent-backend (messages/t :classified-error/retry-agent-backend)
-    (messages/t :classified-error/retry-generic)))
-
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} style
@@ -116,95 +102,3 @@
   (doseq [section sections]
     (render-section entity section))
   (println))
-
-;; Error classification display
-(defn ^{:stratum 2} print-agent-backend-error-header
-  [completed-work]
-  (println (style (messages/t :classified-error/agent-backend-header)
-                  :foreground :yellow :bold true))
-  (when (seq completed-work)
-    (println)
-    (println (style (messages/t :classified-error/task-completed)
-                    :foreground :green))
-    (doseq [work completed-work]
-      (println (str "  " (style "✅" :foreground :green) " " work)))))
-
-(defn ^{:stratum 2} print-task-code-error-header
-  []
-  (println (style (messages/t :classified-error/task-code-header)
-                  :foreground :red :bold true)))
-
-(defn ^{:stratum 2} print-external-error-header
-  []
-  (println (style (messages/t :classified-error/external-header)
-                  :foreground :yellow :bold true)))
-
-(defn ^{:stratum 2} print-generic-error-header
-  []
-  (println (style (messages/t :classified-error/generic-header)
-                  :foreground :red :bold true)))
-
-(defn ^{:stratum 2} print-external-error-context
-  [completed-work]
-  (println (messages/t :classified-error/external-context))
-  (when (seq completed-work)
-    (println)
-    (println (messages/t :classified-error/partial-work))
-    (doseq [work completed-work]
-      (println (str "  " (style "✅" :foreground :green) " " work)))))
-
-(defn ^{:stratum 2} print-error-report-url
-  [report-url vendor]
-  (when report-url
-    (println)
-    (println (str (style (messages/t :classified-error/report-prefix)
-                         :foreground :cyan)
-                  vendor ":"))
-    (println (str "   " report-url))))
-
-(defn ^{:stratum 2} print-retry-recommendation
-  [should-retry error-type completed-work]
-  (println)
-  (if should-retry
-    (println (str (style (messages/t :classified-error/recommendation-prefix)
-                         :foreground :cyan)
-                 (get-retry-recommendation error-type)))
-    (println (str (style (messages/t :classified-error/no-retry-prefix)
-                         :foreground :cyan)
-                 (if (seq completed-work)
-                   (messages/t :classified-error/no-retry-success)
-                   (messages/t :classified-error/no-retry-failure))))))
-
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} print-error-header-by-type
-  [error-type completed-work]
-  (case error-type
-    :agent-backend (print-agent-backend-error-header completed-work)
-    :task-code (print-task-code-error-header)
-    :external (print-external-error-header)
-    (print-generic-error-header)))
-
-(defn ^{:stratum 3} print-error-context
-  [error-type completed-work]
-  (case error-type
-    :agent-backend (print-agent-backend-error-context completed-work)
-    :task-code (print-task-code-error-context completed-work)
-    :external (print-external-error-context completed-work)
-    nil))
-
-;------------------------------------------------------------------------------ Layer 4
-
-;; Composite error display
-(defn ^{:stratum 4} print-classified-error
-  "Display a classified error with rich formatting."
-  [error-classification]
-  (when error-classification
-    (let [{:keys [type message completed-work report-url should-retry vendor]} error-classification]
-      (print-error-header-by-type type completed-work)
-      (println)
-      (println (str "  " message))
-      (println)
-      (print-error-context type completed-work)
-      (print-error-report-url report-url vendor)
-      (print-retry-recommendation should-retry type completed-work))))

--- a/bases/cli/src/ai/miniforge/cli/main/display/classified_error.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/display/classified_error.clj
@@ -1,0 +1,151 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.main.display.classified-error
+  "Classified-error display for CLI output: per-type headers, per-type
+   context (including partial-work listings), the retry recommendation,
+   and the composite `print-classified-error` view.
+
+   Layer 0: Per-type header/context printers and the retry-recommendation
+            message lookup
+   Layer 1: Error-type dispatch (header-by-type, context-by-type) and the
+            styled retry-recommendation printer
+   Layer 2: `print-classified-error` — the composite view
+
+   Extracted from `ai.miniforge.cli.main.display` (rule 210: the combined
+   namespace measured 5 real layers, max 3). Generic ANSI styling
+   (`style`) still lives there and is required here."
+  (:require
+   [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.messages :as messages]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} print-agent-backend-error-context
+  [completed-work]
+  (if (seq completed-work)
+    (println (messages/t :classified-error/agent-backend-context-success))
+    (println (messages/t :classified-error/agent-backend-context))))
+
+(defn ^{:stratum 0} print-task-code-error-context
+  [completed-work]
+  (println (messages/t :classified-error/task-code-context))
+  (when (seq completed-work)
+    (println)
+    (println (messages/t :classified-error/partial-work))
+    (doseq [work completed-work]
+      (println (str "  ⏸️  " work)))))
+
+(defn ^{:stratum 0} get-retry-recommendation
+  [error-type]
+  (case error-type
+    :task-code (messages/t :classified-error/retry-task-code)
+    :external (messages/t :classified-error/retry-external)
+    :agent-backend (messages/t :classified-error/retry-agent-backend)
+    (messages/t :classified-error/retry-generic)))
+
+;; Error classification display
+(defn ^{:stratum 0} print-agent-backend-error-header
+  [completed-work]
+  (println (display/style (messages/t :classified-error/agent-backend-header)
+                          :foreground :yellow :bold true))
+  (when (seq completed-work)
+    (println)
+    (println (display/style (messages/t :classified-error/task-completed)
+                            :foreground :green))
+    (doseq [work completed-work]
+      (println (str "  " (display/style "✅" :foreground :green) " " work)))))
+
+(defn ^{:stratum 0} print-task-code-error-header
+  []
+  (println (display/style (messages/t :classified-error/task-code-header)
+                          :foreground :red :bold true)))
+
+(defn ^{:stratum 0} print-external-error-header
+  []
+  (println (display/style (messages/t :classified-error/external-header)
+                          :foreground :yellow :bold true)))
+
+(defn ^{:stratum 0} print-generic-error-header
+  []
+  (println (display/style (messages/t :classified-error/generic-header)
+                          :foreground :red :bold true)))
+
+(defn ^{:stratum 0} print-external-error-context
+  [completed-work]
+  (println (messages/t :classified-error/external-context))
+  (when (seq completed-work)
+    (println)
+    (println (messages/t :classified-error/partial-work))
+    (doseq [work completed-work]
+      (println (str "  " (display/style "✅" :foreground :green) " " work)))))
+
+(defn ^{:stratum 0} print-error-report-url
+  [report-url vendor]
+  (when report-url
+    (println)
+    (println (str (display/style (messages/t :classified-error/report-prefix)
+                                 :foreground :cyan)
+                  vendor ":"))
+    (println (str "   " report-url))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} print-error-header-by-type
+  [error-type completed-work]
+  (case error-type
+    :agent-backend (print-agent-backend-error-header completed-work)
+    :task-code (print-task-code-error-header)
+    :external (print-external-error-header)
+    (print-generic-error-header)))
+
+(defn ^{:stratum 1} print-error-context
+  [error-type completed-work]
+  (case error-type
+    :agent-backend (print-agent-backend-error-context completed-work)
+    :task-code (print-task-code-error-context completed-work)
+    :external (print-external-error-context completed-work)
+    nil))
+
+(defn ^{:stratum 1} print-retry-recommendation
+  [should-retry error-type completed-work]
+  (println)
+  (if should-retry
+    (println (str (display/style (messages/t :classified-error/recommendation-prefix)
+                                 :foreground :cyan)
+                 (get-retry-recommendation error-type)))
+    (println (str (display/style (messages/t :classified-error/no-retry-prefix)
+                                 :foreground :cyan)
+                 (if (seq completed-work)
+                   (messages/t :classified-error/no-retry-success)
+                   (messages/t :classified-error/no-retry-failure))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Composite error display
+(defn ^{:stratum 2} print-classified-error
+  "Display a classified error with rich formatting."
+  [error-classification]
+  (when error-classification
+    (let [{:keys [type message completed-work report-url should-retry vendor]} error-classification]
+      (print-error-header-by-type type completed-work)
+      (println)
+      (println (str "  " message))
+      (println)
+      (print-error-context type completed-work)
+      (print-error-report-url report-url vendor)
+      (print-retry-recommendation should-retry type completed-work))))

--- a/docs/pull-requests/2026-08-09-refactor-split-cli-main-display.md
+++ b/docs/pull-requests/2026-08-09-refactor-split-cli-main-display.md
@@ -1,0 +1,111 @@
+<!--
+  Title: Split cli/main/display.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(cli): split main/display.clj (rule 210)
+
+## Overview
+
+Splits the classified-error display group out of
+`ai.miniforge.cli.main.display` into a new sibling namespace,
+`ai.miniforge.cli.main.display.classified-error`, resolving a
+stratum-lint SL003 finding (the combined namespace measured 5 real
+layers, over the rule 210 budget of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program, `bases/cli`
+batch. `bases/cli/src/ai/miniforge/cli/main/display.clj` (196 lines)
+was flagged over budget.
+
+## Changes in Detail
+
+- New file `main/display/classified_error.clj`
+  (`ai.miniforge.cli.main.display.classified-error`): the per-type
+  header printers (`print-agent-backend-error-header`,
+  `print-task-code-error-header`, `print-external-error-header`,
+  `print-generic-error-header`), the per-type context printers
+  (`print-agent-backend-error-context`, `print-task-code-error-context`,
+  `print-external-error-context`), `get-retry-recommendation`,
+  `print-error-report-url`, the dispatch functions
+  (`print-error-header-by-type`, `print-error-context`), the styled
+  `print-retry-recommendation`, and the composite
+  `print-classified-error` — 3 layers. Requires
+  `ai.miniforge.cli.main.display` for the shared `style` primitive.
+- `main/display.clj`: keeps the ANSI-styling primitives
+  (`ansi-colors`, `style`), the data-driven renderers (`render-fields`,
+  `render-section`, `render-detail`), and the generic styled print
+  helpers (`print-error`, `print-success`, `print-info`) — now 3
+  layers (down from 5).
+- Layer numbers (`^{:stratum N}` metadata) recomputed per file: strata
+  are a same-namespace call-depth measure, so a function whose only
+  local-file callee moved out drops to stratum 0 in its new file even
+  though `display.clj` still called it at a higher stratum. No
+  function's behavior changed, only its `:stratum` tag and which file
+  it lives in.
+- `main/commands/run.clj`, the one real caller of
+  `print-classified-error` repo-wide (confirmed by grepping the fully
+  qualified namespace `ai\.miniforge\.cli\.main\.display\b` across
+  components, bases, and projects, not a symbol-prefix guess): added a
+  `[ai.miniforge.cli.main.display.classified-error :as
+  classified-error]` require and changed the one call site from
+  `display/print-classified-error` to
+  `classified-error/print-classified-error`. Its other `display/*`
+  calls (`print-info`, `print-error`) are untouched — those symbols
+  stayed in `display.clj`.
+
+No test file called any of the moved functions directly (`display_test.clj`
+only exercises `print-error`, which did not move), and no
+`projects/miniforge/test/` caller referenced the display namespace at
+all, so no test call sites needed updating.
+
+This is pure code motion — no detection/formatting logic changed.
+
+## Testing Plan
+
+- `stratum-lint` clean on `display.clj`, `display/classified_error.clj`,
+  and `commands/run.clj` (exit 0, was SL003 exit 1 on the original
+  `display.clj`).
+- `clj-kondo` clean on all three touched/added files.
+- `bb pre-commit` green on both commits (commit-budget, poly check,
+  lint, stratum-lint, the 18-namespace smoke suite, and the GraalVM
+  compatibility suite).
+- Direct namespace verification (not relying on `bb test`
+  change-scope alone): `clojure -M:dev:test -e "..."` run per affected
+  namespace —
+  `ai.miniforge.cli.main.display-test` (1 test / 1 assertion),
+  `ai.miniforge.cli.main.commands.run-test` (2 tests / 8 assertions),
+  `ai.miniforge.cli.workflow-runner.runner-control-wiring-test`,
+  `ai.miniforge.cli.main.commands.monitoring-test`,
+  `ai.miniforge.cli.main.commands.resume-test`, and
+  `ai.miniforge.cli.main.commands.pr-monitor-test` (26 tests / 91
+  assertions combined) — 0 failures, 0 errors. All pass.
+- Repo-wide grep for the fully-qualified namespace
+  (`ai\.miniforge\.cli\.main\.display\b`) across components, bases,
+  and projects, and separately for the moved symbol name
+  (`print-classified-error`), confirmed exactly one real caller
+  (`main/commands/run.clj`), now updated.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file. Other
+`bases/cli/main/commands/*.clj` splits in the same batch are tracked
+as separate concurrent PRs.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 program, `bases/cli` batch. See
+  `loader.clj` (miniforge#1772) and `knowledge_safety.clj`
+  (miniforge#1731) for the established split convention this follows.
+
+## Checklist
+
+- [x] stratum-lint clean on all resulting files
+- [x] `bb pre-commit` green (both commits)
+- [x] Direct namespace verification per affected test namespace
+- [x] Adversarial self-review: no def added/removed beyond the split,
+      no behavior change, `:stratum` metadata recomputed per file
+- [x] Zero-fan-in-missed confirmed via fully-qualified namespace grep
+      (not symbol-prefix) across components, bases, and projects


### PR DESCRIPTION
## Summary

Splits `bases/cli/src/ai/miniforge/cli/main/display.clj` (stratum-lint SL003: 5 real layers, max 3) into:

- `main/display.clj` — generic ANSI styling + entity/detail rendering (3 layers, down from 5)
- `main/display/classified_error.clj` (new, `ai.miniforge.cli.main.display.classified-error`) — the classified-error display group: per-type headers/context, retry recommendation, and the composite `print-classified-error` (3 layers)

Pure code motion — no behavior changes, only `:stratum` metadata recomputed per file.

## Fan-in

Grepped the fully-qualified namespace `ai\.miniforge\.cli\.main\.display\b` across components, bases, and projects (not a symbol-prefix guess). One real caller of the moved symbol `print-classified-error`: `main/commands/run.clj`, updated to require `ai.miniforge.cli.main.display.classified-error` and call `classified-error/print-classified-error`. No `projects/miniforge/test/` caller referenced this namespace at all.

## Testing

- `stratum-lint` clean on all three touched/added files (was SL003 exit 1 on the original `display.clj`).
- `clj-kondo` clean.
- `bb pre-commit` green on all three commits.
- Direct namespace verification via `clojure -M:dev:test`, not `bb test` change-scope alone: `ai.miniforge.cli.main.display-test`, `ai.miniforge.cli.main.commands.run-test`, `ai.miniforge.cli.workflow-runner.runner-control-wiring-test`, `ai.miniforge.cli.main.commands.monitoring-test`, `ai.miniforge.cli.main.commands.resume-test`, `ai.miniforge.cli.main.commands.pr-monitor-test` — all green, 0 failures/errors.

See `docs/pull-requests/2026-08-09-refactor-split-cli-main-display.md` for full detail.

Part of the stratum-lint rule-210 program, `bases/cli` batch. Several sibling `main/commands/*.clj` splits are in flight concurrently in this batch and may also touch `display.clj`'s fan-in — rebase expected if so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)