### PR TITLE
refactor(cli): split etl.clj (rule 210)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/etl.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/etl.clj
@@ -30,185 +30,27 @@
 
    The `etl repo` command clones the repository and runs the direct
    repo-analyzer interface. The `etl run|list|validate` commands shell
-   out to `ai.miniforge.etl.main` on the JVM."
+   out to `ai.miniforge.etl.main` on the JVM.
+
+   Git-URL validation/cloning, JVM shell-out, and pack-path resolution
+   live in sibling `ai.miniforge.cli.main.commands.etl.*` namespaces
+   (rule 210: the combined namespace measured 4 real layers, max 3).
+   With those hops no longer counted toward this namespace's own local
+   layer depth, the five command entry points below don't call each
+   other — each calls straight into a sibling namespace — so they all
+   measure a single layer."
   (:require
-   [babashka.fs :as fs]
-   [babashka.process :as process]
-   [clojure.string :as str]
-   [ai.miniforge.response.interface :as response]
+   [ai.miniforge.cli.main.commands.etl.paths :as etl-paths]
+   [ai.miniforge.cli.main.commands.etl.repo :as etl-repo]
+   [ai.miniforge.cli.main.commands.etl.shell :as etl-shell]
    [ai.miniforge.cli.main.commands.shared :as shared]
    [ai.miniforge.cli.main.display :as display]
-   [ai.miniforge.cli.messages :as messages]
-   [ai.miniforge.repo-analyzer.interface :as repo-analyzer]
-   [ai.miniforge.schema.interface :as schema]))
+   [ai.miniforge.cli.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Helpers — shared by etl repo
-(defn ^{:stratum 0} validate-git-url
-  "Return true when url begins with a recognised git transport prefix."
-  [url]
-  (boolean
-   (or (str/starts-with? url "https://")
-       (str/starts-with? url "git@")
-       (str/starts-with? url "ssh://")
-       (str/starts-with? url "http://"))))
-
-(defn- ^{:stratum 0} git-clone-temp
-  "Shallow-clone `url` into a temporary directory.
-   Returns a schema/success or schema/failure result."
-  [url]
-  (try
-    (let [tmp-dir (str (System/getProperty "java.io.tmpdir") "/miniforge-etl-"
-                       (System/currentTimeMillis))
-          result  (process/sh "git" "clone" "--depth" "1" url tmp-dir)]
-      (if (zero? (:exit result))
-        (schema/success :path tmp-dir)
-        (schema/failure :path (str/trim (:err result)))))
-    (catch Exception e
-      (schema/failure :path (ex-message e)))))
-
-;; Pack-path resolution (shared by run + validate)
-(defn- ^{:stratum 0} single-file-under
-  "If exactly one .edn file lives under `dir/subdir`, return its abs path;
-   otherwise nil (caller decides whether to error)."
-  [dir subdir]
-  (let [sub (fs/file dir subdir)]
-    (when (fs/directory? sub)
-      (let [ednfiles (->> (fs/glob sub "*.edn") (map fs/file))]
-        (when (= 1 (count ednfiles))
-          (str (first ednfiles)))))))
-
-(defn- ^{:stratum 0} resolve-env-path
-  "Resolve `--env`, which may be a `.edn` path or a bare env name that
-   maps to `<pack-dir>/envs/<name>.edn`. Returns an absolute path or
-   throws on an unresolvable input."
-  [env pack-dir]
-  (cond
-    (nil? env)
-    (response/throw-anomaly! :anomalies/incorrect
-                             "missing --env <env.edn|name>"
-                             {})
-
-    (str/ends-with? env ".edn")
-    (str (fs/absolutize env))
-
-    pack-dir
-    (let [candidate (fs/file pack-dir "envs" (str env ".edn"))]
-      (if (fs/regular-file? candidate)
-        (str (fs/absolutize candidate))
-        (response/throw-anomaly! :anomalies/not-found
-                                 (str "env not found: " candidate)
-                                 {:env env :candidate (str candidate)})))
-
-    :else
-    (response/throw-anomaly! :anomalies/incorrect
-                             (str "--env was a name but pipeline was given directly; pass a .edn path instead: " env)
-                             {:env env})))
-
-;; JVM shell-out (run / list / validate)
-(defn- ^{:stratum 0} find-miniforge-root
-  "Walk up from `start` until a directory containing both `workspace.edn`
-   and `bases/etl/deps.edn` is found. Returns the absolute path or nil
-   if no such ancestor exists (i.e., not inside a miniforge checkout
-   that ships the etl base)."
-  ([] (find-miniforge-root (fs/file (System/getProperty "user.dir"))))
-  ([start]
-   (loop [dir (fs/absolutize start)]
-     (cond
-       (nil? dir)
-       nil
-
-       (and (fs/exists? (fs/file dir "workspace.edn"))
-            (fs/exists? (fs/file dir "bases/etl/deps.edn")))
-       (str dir)
-
-       :else
-       (recur (fs/parent dir))))))
-
-;------------------------------------------------------------------------------ Layer 1
-
-(defn- ^{:stratum 1} resolve-pipeline-path
-  "Resolve `pack-or-pipeline` into `[pack-dir pipeline-path]` as absolute
-   paths. `pack-dir` is nil when the caller passed a pipeline EDN
-   directly (no envs/ lookup possible)."
-  [pack-or-pipeline]
-  (let [f (fs/file pack-or-pipeline)]
-    (cond
-      (fs/directory? f)
-      (if-let [p (single-file-under f "pipelines")]
-        [(str (fs/absolutize f)) (str (fs/absolutize p))]
-        (response/throw-anomaly! :anomalies/not-found
-                                 (str "Could not find a single pipelines/*.edn under " f)
-                                 {:pack-dir (str (fs/absolutize f))}))
-
-      (and (fs/regular-file? f) (str/ends-with? (str f) ".edn"))
-      [nil (str (fs/absolutize f))]
-
-      :else
-      (response/throw-anomaly! :anomalies/incorrect
-                               (str "Not a pack directory or pipeline EDN: " pack-or-pipeline)
-                               {:input pack-or-pipeline}))))
-
-(defn- ^{:stratum 1} shell-etl!
-  "Shell out to the JVM etl entry point from the miniforge root. `args`
-   are the post-`-m` args: the subcommand name and its flags. Streams
-   stdout/stderr to the user's terminal. Returns the subprocess exit
-   code."
-  [args]
-  (if-let [root (find-miniforge-root)]
-    (let [argv (into ["clojure" "-M:dev" "-m" "ai.miniforge.etl.main"] args)
-          {:keys [exit]} (deref (process/process argv {:dir  root
-                                                       :out  :inherit
-                                                       :err  :inherit}))]
-      exit)
-    (do (display/print-error (messages/t :etl/run-requires-checkout))
-        1)))
-
-;; Repository analysis (etl repo)
-(defn- ^{:stratum 1} analyze-repo-url!
-  "Clone repo and run repo-analyzer against the temporary checkout."
-  [url]
-  (let [clone-result (git-clone-temp url)]
-    (if (schema/failed? clone-result)
-      (do
-        (display/print-error (messages/t :etl/clone-failed {:error (:error clone-result)}))
-        1)
-      (let [repo-path (:path clone-result)]
-        (try
-          (let [analysis (repo-analyzer/analyze-repo repo-path)]
-            (display/print-success (messages/t :etl/analysis-complete))
-            (println (messages/t :etl/technologies {:value (pr-str (:technologies analysis))}))
-            (println (messages/t :etl/git-host {:value (get analysis :git-host "unknown")}))
-            (println (messages/t :etl/packs {:value (pr-str (:packs analysis))}))
-            (println)
-            (println (display/style (messages/t :etl/install-note) :foreground :yellow))
-            0)
-          (catch Exception e
-            (display/print-error (messages/t :etl/analysis-failed {:error (ex-message e)}))
-            1)
-          (finally
-            (try (fs/delete-tree repo-path)
-                 (catch Exception _ nil))))))))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn- ^{:stratum 2} resolve-pack-paths
-  "Given the positional arg to `etl run` / `etl validate` and the `--env`
-   flag, return `[pipeline-path env-path]` as absolute file paths, or
-   throw ex-info on an unresolvable input.
-
-   - If `pack-or-pipeline` is a directory, look for one `pipelines/*.edn`.
-   - If it's an .edn file, use it as the pipeline.
-   - `env` may be a path or a bare env name that resolves to
-     `<pack>/envs/<name>.edn` when pack-or-pipeline is a directory."
-  [pack-or-pipeline env]
-  (let [[pack-dir pipeline-path] (resolve-pipeline-path pack-or-pipeline)
-        env-path                 (resolve-env-path env pack-dir)]
-    [pipeline-path env-path]))
-
 ;; Command implementations
-(defn ^{:stratum 2} etl-repo-cmd
+(defn ^{:stratum 0} etl-repo-cmd
   "Run the ETL pipeline against a git repository URL.
 
    Clones the repository, extracts structured metadata (languages, packs,
@@ -220,35 +62,33 @@
   (let [{:keys [url]} opts]
     (if-not url
       (shared/usage-error! :etl/repo-usage "etl repo <url>")
-      (if-not (validate-git-url url)
+      (if-not (etl-repo/validate-git-url url)
         (do (display/print-error (messages/t :etl/invalid-url {:url url}))
             (shared/exit! 1))
         (do
           (display/print-info (messages/t :etl/running {:url url}))
-          (let [exit-code (analyze-repo-url! url)]
+          (let [exit-code (etl-repo/analyze-repo-url! url)]
             (when (pos? exit-code)
               (shared/exit! exit-code))))))))
 
-(defn ^{:stratum 2} etl-list-cmd
+(defn ^{:stratum 0} etl-list-cmd
   "List pipeline EDN files discovered under a search path.
 
    Usage: miniforge etl list [<search-path>]
           (defaults to `.`)"
   [opts]
   (let [path (get opts :paths ".")]
-    (shared/exit! (shell-etl! ["list" path]))))
+    (shared/exit! (etl-shell/shell-etl! ["list" path]))))
 
-(defn ^{:stratum 2} etl-registry-cmd
+(defn ^{:stratum 0} etl-registry-cmd
   "Export the product-owned ETL state-variable registry as EDN or JSON."
   [opts]
   (if-let [out (:out opts)]
-    (shared/exit! (shell-etl! ["registry" "--out" out]))
+    (shared/exit! (etl-shell/shell-etl! ["registry" "--out" out]))
     (shared/usage-error! :etl/registry-usage
                          "etl registry --out <registry.edn|.json>")))
 
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} etl-run-cmd
+(defn ^{:stratum 0} etl-run-cmd
   "Execute a Data Foundry ETL pack.
 
    Usage:
@@ -270,7 +110,7 @@
                                 " [--workbench-out <snapshot.json> --experiment-id <id> --label <label>"
                                 " --source-hash <sha256:...> [--baseline <snapshot.json>]]"))
       (try
-        (let [[pipeline-path env-path] (resolve-pack-paths pack env)
+        (let [[pipeline-path env-path] (etl-paths/resolve-pack-paths pack env)
               args (cond-> ["run" pipeline-path "--env" env-path]
                      out            (into ["--out" out])
                      workbench-out  (into ["--workbench-out" workbench-out])
@@ -280,12 +120,12 @@
                      baseline       (into ["--baseline" baseline])
                      snapshot-id    (into ["--snapshot-id" snapshot-id])
                      run-id         (into ["--run-id" run-id]))]
-          (shared/exit! (shell-etl! args)))
+          (shared/exit! (etl-shell/shell-etl! args)))
         (catch clojure.lang.ExceptionInfo e
           (display/print-error (ex-message e))
           (shared/exit! 1))))))
 
-(defn ^{:stratum 3} etl-validate-cmd
+(defn ^{:stratum 0} etl-validate-cmd
   "Load + resolve a pack without executing. Surfaces loader, env, or
    resolver errors.
 
@@ -296,8 +136,8 @@
       (shared/usage-error! :etl/validate-usage
                            "etl validate <pack-dir-or-pipeline.edn> --env <env.edn|name>")
       (try
-        (let [[pipeline-path env-path] (resolve-pack-paths pack env)]
-          (shared/exit! (shell-etl! ["validate" pipeline-path "--env" env-path])))
+        (let [[pipeline-path env-path] (etl-paths/resolve-pack-paths pack env)]
+          (shared/exit! (etl-shell/shell-etl! ["validate" pipeline-path "--env" env-path])))
         (catch clojure.lang.ExceptionInfo e
           (display/print-error (ex-message e))
           (shared/exit! 1))))))

--- a/bases/cli/src/ai/miniforge/cli/main/commands/etl/paths.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/etl/paths.clj
@@ -1,0 +1,112 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.main.commands.etl.paths
+  "Pack-path resolution shared by `etl run` and `etl validate`: turns the
+   positional `pack-or-pipeline` argument and `--env` flag into absolute
+   `pipeline-path` / `env-path` file paths. Extracted from
+   `ai.miniforge.cli.main.commands.etl` (rule 210: the combined namespace
+   measured 4 real layers, max 3)."
+  (:require
+   [babashka.fs :as fs]
+   [clojure.string :as str]
+   [ai.miniforge.response.interface :as response]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} single-file-under
+  "If exactly one .edn file lives under `dir/subdir`, return its abs path;
+   otherwise nil (caller decides whether to error)."
+  [dir subdir]
+  (let [sub (fs/file dir subdir)]
+    (when (fs/directory? sub)
+      (let [ednfiles (->> (fs/glob sub "*.edn") (map fs/file))]
+        (when (= 1 (count ednfiles))
+          (str (first ednfiles)))))))
+
+(defn- ^{:stratum 0} resolve-env-path
+  "Resolve `--env`, which may be a `.edn` path or a bare env name that
+   maps to `<pack-dir>/envs/<name>.edn`. Returns an absolute path or
+   throws on an unresolvable input."
+  [env pack-dir]
+  (cond
+    (nil? env)
+    (response/throw-anomaly! :anomalies/incorrect
+                             "missing --env <env.edn|name>"
+                             {})
+
+    (str/ends-with? env ".edn")
+    (str (fs/absolutize env))
+
+    pack-dir
+    (let [candidate (fs/file pack-dir "envs" (str env ".edn"))]
+      (if (fs/regular-file? candidate)
+        (str (fs/absolutize candidate))
+        (response/throw-anomaly! :anomalies/not-found
+                                 (str "env not found: " candidate)
+                                 {:env env :candidate (str candidate)})))
+
+    :else
+    (response/throw-anomaly! :anomalies/incorrect
+                             (str "--env was a name but pipeline was given directly; pass a .edn path instead: " env)
+                             {:env env})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} resolve-pipeline-path
+  "Resolve `pack-or-pipeline` into `[pack-dir pipeline-path]` as absolute
+   paths. `pack-dir` is nil when the caller passed a pipeline EDN
+   directly (no envs/ lookup possible)."
+  [pack-or-pipeline]
+  (let [f (fs/file pack-or-pipeline)]
+    (cond
+      (fs/directory? f)
+      (if-let [p (single-file-under f "pipelines")]
+        [(str (fs/absolutize f)) (str (fs/absolutize p))]
+        (response/throw-anomaly! :anomalies/not-found
+                                 (str "Could not find a single pipelines/*.edn under " f)
+                                 {:pack-dir (str (fs/absolutize f))}))
+
+      (and (fs/regular-file? f) (str/ends-with? (str f) ".edn"))
+      [nil (str (fs/absolutize f))]
+
+      :else
+      (response/throw-anomaly! :anomalies/incorrect
+                               (str "Not a pack directory or pipeline EDN: " pack-or-pipeline)
+                               {:input pack-or-pipeline}))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} resolve-pack-paths
+  "Given the positional arg to `etl run` / `etl validate` and the `--env`
+   flag, return `[pipeline-path env-path]` as absolute file paths, or
+   throw ex-info on an unresolvable input.
+
+   - If `pack-or-pipeline` is a directory, look for one `pipelines/*.edn`.
+   - If it's an .edn file, use it as the pipeline.
+   - `env` may be a path or a bare env name that resolves to
+     `<pack>/envs/<name>.edn` when pack-or-pipeline is a directory."
+  [pack-or-pipeline env]
+  (let [[pack-dir pipeline-path] (resolve-pipeline-path pack-or-pipeline)
+        env-path                 (resolve-env-path env pack-dir)]
+    [pipeline-path env-path]))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (resolve-pack-paths "packs/data-foundry/github-data" "local")
+  (resolve-pipeline-path "packs/data-foundry/github-data")
+  :end)

--- a/bases/cli/src/ai/miniforge/cli/main/commands/etl/repo.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/etl/repo.clj
@@ -1,0 +1,88 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.main.commands.etl.repo
+  "`etl repo <url>` support: git-URL validation, shallow-clone to a temp
+   directory, and running the repo-analyzer against the checkout.
+   Extracted from `ai.miniforge.cli.main.commands.etl` (rule 210: the
+   combined namespace measured 4 real layers, max 3)."
+  (:require
+   [babashka.fs :as fs]
+   [babashka.process :as process]
+   [clojure.string :as str]
+   [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.repo-analyzer.interface :as repo-analyzer]
+   [ai.miniforge.schema.interface :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} validate-git-url
+  "Return true when url begins with a recognised git transport prefix."
+  [url]
+  (boolean
+   (or (str/starts-with? url "https://")
+       (str/starts-with? url "git@")
+       (str/starts-with? url "ssh://")
+       (str/starts-with? url "http://"))))
+
+(defn- ^{:stratum 0} git-clone-temp
+  "Shallow-clone `url` into a temporary directory.
+   Returns a schema/success or schema/failure result."
+  [url]
+  (try
+    (let [tmp-dir (str (System/getProperty "java.io.tmpdir") "/miniforge-etl-"
+                       (System/currentTimeMillis))
+          result  (process/sh "git" "clone" "--depth" "1" url tmp-dir)]
+      (if (zero? (:exit result))
+        (schema/success :path tmp-dir)
+        (schema/failure :path (str/trim (:err result)))))
+    (catch Exception e
+      (schema/failure :path (ex-message e)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} analyze-repo-url!
+  "Clone repo and run repo-analyzer against the temporary checkout."
+  [url]
+  (let [clone-result (git-clone-temp url)]
+    (if (schema/failed? clone-result)
+      (do
+        (display/print-error (messages/t :etl/clone-failed {:error (:error clone-result)}))
+        1)
+      (let [repo-path (:path clone-result)]
+        (try
+          (let [analysis (repo-analyzer/analyze-repo repo-path)]
+            (display/print-success (messages/t :etl/analysis-complete))
+            (println (messages/t :etl/technologies {:value (pr-str (:technologies analysis))}))
+            (println (messages/t :etl/git-host {:value (get analysis :git-host "unknown")}))
+            (println (messages/t :etl/packs {:value (pr-str (:packs analysis))}))
+            (println)
+            (println (display/style (messages/t :etl/install-note) :foreground :yellow))
+            0)
+          (catch Exception e
+            (display/print-error (messages/t :etl/analysis-failed {:error (ex-message e)}))
+            1)
+          (finally
+            (try (fs/delete-tree repo-path)
+                 (catch Exception _ nil))))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (validate-git-url "https://github.com/miniforge-ai/miniforge")
+  (analyze-repo-url! "https://github.com/miniforge-ai/miniforge")
+  :end)

--- a/bases/cli/src/ai/miniforge/cli/main/commands/etl/shell.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/etl/shell.clj
@@ -1,0 +1,71 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.main.commands.etl.shell
+  "JVM shell-out used by `etl run|list|validate|registry`: locates the
+   miniforge checkout root and shells out to `ai.miniforge.etl.main` on
+   the JVM (source connectors use hato/POI which aren't BB-safe).
+   Extracted from `ai.miniforge.cli.main.commands.etl` (rule 210: the
+   combined namespace measured 4 real layers, max 3)."
+  (:require
+   [babashka.fs :as fs]
+   [babashka.process :as process]
+   [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.messages :as messages]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} find-miniforge-root
+  "Walk up from `start` until a directory containing both `workspace.edn`
+   and `bases/etl/deps.edn` is found. Returns the absolute path or nil
+   if no such ancestor exists (i.e., not inside a miniforge checkout
+   that ships the etl base)."
+  ([] (find-miniforge-root (fs/file (System/getProperty "user.dir"))))
+  ([start]
+   (loop [dir (fs/absolutize start)]
+     (cond
+       (nil? dir)
+       nil
+
+       (and (fs/exists? (fs/file dir "workspace.edn"))
+            (fs/exists? (fs/file dir "bases/etl/deps.edn")))
+       (str dir)
+
+       :else
+       (recur (fs/parent dir))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} shell-etl!
+  "Shell out to the JVM etl entry point from the miniforge root. `args`
+   are the post-`-m` args: the subcommand name and its flags. Streams
+   stdout/stderr to the user's terminal. Returns the subprocess exit
+   code."
+  [args]
+  (if-let [root (find-miniforge-root)]
+    (let [argv (into ["clojure" "-M:dev" "-m" "ai.miniforge.etl.main"] args)
+          {:keys [exit]} (deref (process/process argv {:dir  root
+                                                       :out  :inherit
+                                                       :err  :inherit}))]
+      exit)
+    (do (display/print-error (messages/t :etl/run-requires-checkout))
+        1)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (shell-etl! ["list" "."])
+  :end)

--- a/bases/cli/test/ai/miniforge/cli/anomaly/etl_anomaly_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/anomaly/etl_anomaly_test.clj
@@ -16,7 +16,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.cli.anomaly.etl-anomaly-test
-  "Coverage for `cli.main.commands.etl` boundary escalation via
+  "Coverage for `cli.main.commands.etl.paths` boundary escalation via
    `response/throw-anomaly!`.
 
    Pre-cleanup, each site was a raw `(throw (ex-info ...))`. Post-
@@ -26,7 +26,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [babashka.fs :as fs]
-   [ai.miniforge.cli.main.commands.etl :as etl])
+   [ai.miniforge.cli.main.commands.etl.paths :as etl-paths])
   (:import
    (clojure.lang ExceptionInfo)))
 
@@ -37,7 +37,7 @@
   (testing "empty pack dir with no pipelines/*.edn raises :anomalies/not-found"
     (let [tmp (fs/create-temp-dir {:prefix "cli-etl-test-"})]
       (try
-        (let [thrown (try (@#'etl/resolve-pipeline-path (str tmp))
+        (let [thrown (try (@#'etl-paths/resolve-pipeline-path (str tmp))
                           nil
                           (catch ExceptionInfo e e))]
           (is (some? thrown))
@@ -52,7 +52,7 @@
 
 (deftest ^{:stratum 0} resolve-pipeline-path-nonexistent-path-throws-incorrect
   (testing "non-dir non-edn path raises :anomalies/incorrect"
-    (let [thrown (try (@#'etl/resolve-pipeline-path "/no/such/thing")
+    (let [thrown (try (@#'etl-paths/resolve-pipeline-path "/no/such/thing")
                       nil
                       (catch ExceptionInfo e e))]
       (is (some? thrown))
@@ -64,7 +64,7 @@
   (testing "direct pipeline EDN file returns [nil <abs-path>]"
     (let [tmp (fs/create-temp-file {:suffix ".edn"})]
       (try
-        (let [result (@#'etl/resolve-pipeline-path (str tmp))]
+        (let [result (@#'etl-paths/resolve-pipeline-path (str tmp))]
           (is (= [nil (str (fs/absolutize tmp))] result)))
         (finally
           (fs/delete-if-exists tmp))))))
@@ -72,7 +72,7 @@
 ;------------------------------------------------------------------------------ resolve-env-path (private)
 (deftest ^{:stratum 0} resolve-env-path-nil-throws-incorrect
   (testing "nil env raises :anomalies/incorrect"
-    (let [thrown (try (@#'etl/resolve-env-path nil nil)
+    (let [thrown (try (@#'etl-paths/resolve-env-path nil nil)
                       nil
                       (catch ExceptionInfo e e))]
       (is (some? thrown))
@@ -81,7 +81,7 @@
 
 (deftest ^{:stratum 0} resolve-env-path-name-without-pack-dir-throws-incorrect
   (testing "env name without pack-dir raises :anomalies/incorrect"
-    (let [thrown (try (@#'etl/resolve-env-path "prod" nil)
+    (let [thrown (try (@#'etl-paths/resolve-env-path "prod" nil)
                       nil
                       (catch ExceptionInfo e e))]
       (is (some? thrown))
@@ -93,7 +93,7 @@
   (testing "env name not found under pack-dir/envs raises :anomalies/not-found"
     (let [tmp (fs/create-temp-dir {:prefix "cli-etl-pack-"})]
       (try
-        (let [thrown (try (@#'etl/resolve-env-path "prod" (str tmp))
+        (let [thrown (try (@#'etl-paths/resolve-env-path "prod" (str tmp))
                           nil
                           (catch ExceptionInfo e e))]
           (is (some? thrown))
@@ -107,7 +107,7 @@
   (testing "env .edn path returns absolutized path"
     (let [tmp (fs/create-temp-file {:suffix ".edn"})]
       (try
-        (let [result (@#'etl/resolve-env-path (str tmp) nil)]
+        (let [result (@#'etl-paths/resolve-env-path (str tmp) nil)]
           (is (= (str (fs/absolutize tmp)) result)))
         (finally
           (fs/delete-if-exists tmp))))))

--- a/bases/cli/test/ai/miniforge/cli/main/commands/etl_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/etl_test.clj
@@ -22,11 +22,12 @@
    [ai.miniforge.schema.interface :as schema]
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.cli.main.commands.etl :as sut]
+   [ai.miniforge.cli.main.commands.etl.repo :as etl-repo]
    [ai.miniforge.cli.main.commands.shared :as shared]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;------------------------------------------------------------------------------ Layer 0: Factory helpers
+;; Factory helpers
 (defn ^{:stratum 0} make-etl-opts
   "Build a minimal ETL opts map for testing."
   ([]
@@ -37,22 +38,22 @@
 ;; Tests
 (deftest ^{:stratum 0} validate-git-url-test
   (testing "HTTPS URL is valid"
-    (is (true? (sut/validate-git-url "https://github.com/org/repo"))))
+    (is (true? (etl-repo/validate-git-url "https://github.com/org/repo"))))
 
   (testing "SSH URL is valid"
-    (is (true? (sut/validate-git-url "ssh://git@github.com/org/repo"))))
+    (is (true? (etl-repo/validate-git-url "ssh://git@github.com/org/repo"))))
 
   (testing "git@ URL is valid"
-    (is (true? (sut/validate-git-url "git@github.com:org/repo"))))
+    (is (true? (etl-repo/validate-git-url "git@github.com:org/repo"))))
 
   (testing "HTTP URL is valid"
-    (is (true? (sut/validate-git-url "http://github.com/org/repo"))))
+    (is (true? (etl-repo/validate-git-url "http://github.com/org/repo"))))
 
   (testing "random string is invalid"
-    (is (false? (sut/validate-git-url "not-a-url"))))
+    (is (false? (etl-repo/validate-git-url "not-a-url"))))
 
   (testing "empty string is invalid"
-    (is (false? (sut/validate-git-url "")))))
+    (is (false? (etl-repo/validate-git-url "")))))
 
 (deftest ^{:stratum 0} etl-repo-cmd-missing-url-test
   (testing "command exits with error when no url provided"
@@ -76,7 +77,7 @@
                      (make-array java.nio.file.attribute.FileAttribute 0)))
           calls (atom [])]
       (.deleteOnExit repo-dir)
-      (with-redefs-fn {#'sut/git-clone-temp
+      (with-redefs-fn {#'etl-repo/git-clone-temp
                        (fn [url]
                          (swap! calls conj [:clone url])
                          (schema/success :path (.getAbsolutePath repo-dir)))
@@ -102,7 +103,7 @@
 (deftest ^{:stratum 0} etl-repo-cmd-exits-on-clone-failure-test
   (testing "clone failures become a non-zero command exit"
     (let [exit-code (atom nil)]
-      (with-redefs-fn {#'sut/git-clone-temp
+      (with-redefs-fn {#'etl-repo/git-clone-temp
                        (fn [_url]
                          (schema/failure :path "clone failed"))
                        #'shared/exit!
@@ -121,7 +122,7 @@
                      (make-array java.nio.file.attribute.FileAttribute 0)))
           exit-code (atom nil)]
       (.deleteOnExit repo-dir)
-      (with-redefs-fn {#'sut/git-clone-temp
+      (with-redefs-fn {#'etl-repo/git-clone-temp
                        (fn [_url]
                          (schema/success :path (.getAbsolutePath repo-dir)))
                        #'repo-analyzer/analyze-repo

--- a/docs/pull-requests/2026-08-18-refactor-split-cli-cmd-etl.md
+++ b/docs/pull-requests/2026-08-18-refactor-split-cli-cmd-etl.md
@@ -1,0 +1,112 @@
+<!--
+  Title: Split cli/main/commands/etl.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(cli): split etl.clj (rule 210)
+
+## Overview
+
+Splits `ai.miniforge.cli.main.commands.etl` into three sibling
+namespaces, resolving a stratum-lint SL003 finding (the combined
+namespace measured 4 real layers, over the rule 210 budget of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program's `bases/cli`
+batch: 13 `main/commands/*.clj` files being split concurrently as
+independent command handlers.
+
+## Changes in Detail
+
+- New file `commands/etl/paths.clj`
+  (`ai.miniforge.cli.main.commands.etl.paths`): pack-path resolution
+  shared by `etl run` and `etl validate` — `single-file-under`,
+  `resolve-env-path`, `resolve-pipeline-path` (all stay private),
+  `resolve-pack-paths` (made public, see below) — 3 layers.
+- New file `commands/etl/repo.clj`
+  (`ai.miniforge.cli.main.commands.etl.repo`): `etl repo` support —
+  `validate-git-url` (already public), `git-clone-temp` (stays
+  private), `analyze-repo-url!` (made public, see below) — 2 layers.
+- New file `commands/etl/shell.clj`
+  (`ai.miniforge.cli.main.commands.etl.shell`): JVM shell-out shared
+  by `run`/`list`/`validate`/`registry` — `find-miniforge-root` (stays
+  private), `shell-etl!` (made public, see below) — 2 layers.
+- `etl.clj`: now keeps only the five public command entry points
+  (`etl-repo-cmd`, `etl-list-cmd`, `etl-registry-cmd`, `etl-run-cmd`,
+  `etl-validate-cmd`), delegating to the three namespaces above. None
+  of the five call each other — each calls straight into a sibling
+  namespace, and those cross-namespace hops no longer count toward
+  this file's own layer depth — so all five now measure a single
+  layer (down from 4).
+- Visibility changes required by the new cross-namespace call sites
+  (pure code motion otherwise, same pattern as PR #1772's
+  `defn-`→`defn` precedent):
+  - `etl.repo/analyze-repo-url!`: `defn-` → `defn` (called from
+    `etl-repo-cmd`)
+  - `etl.shell/shell-etl!`: `defn-` → `defn` (called from 4 of the 5
+    commands)
+  - `etl.paths/resolve-pack-paths`: `defn-` → `defn` (called from
+    `etl-run-cmd`, `etl-validate-cmd`)
+- `etl_test.clj`: `validate-git-url-test` now calls
+  `etl-repo/validate-git-url`; the three `with-redefs-fn` targets on
+  `git-clone-temp` now reference `#'etl-repo/git-clone-temp` (moved to
+  `etl.repo`, stays private there — var-quote cross-namespace access
+  works regardless of privacy, the same mechanism the original tests
+  already relied on).
+- `etl_anomaly_test.clj`: `resolve-pipeline-path` and
+  `resolve-env-path` moved to `etl.paths` (stay private there);
+  var-quote targets updated to `#'etl-paths/resolve-pipeline-path` and
+  `#'etl-paths/resolve-env-path`.
+
+This is pure code motion aside from the three required visibility
+changes and the test call-site updates above — no behavior changed.
+
+## Testing Plan
+
+- `stratum-lint` clean on all four touched/added source files (exit
+  0, was SL003 exit 1 on the original `etl.clj`).
+- `clj-kondo` clean on all six touched files (0 errors, 0 warnings).
+- `bb pre-commit` green on all three commits (commit-budget, poly
+  check, lint, stratum-lint, smoke tests, GraalVM compatibility).
+- Repo-wide grep for the fully-qualified namespace
+  (`ai\.miniforge\.cli\.main\.commands\.etl\b`, not a symbol-prefix
+  guess) across `components/`, `bases/`, and `projects/` found exactly
+  two callers: `bases/cli/src/ai/miniforge/cli/main.clj` (calls only
+  the five public command fns, which stayed in `etl.clj` — no update
+  needed) and the two test files (updated above). No caller under
+  `projects/miniforge/test/`.
+- Both touched test namespaces verified directly (not just via `bb
+  pre-commit`'s smoke subset, which doesn't include them):
+  `clojure -M:dev:test -e "(require 'ai.miniforge.cli.main.commands.etl-test)
+  (clojure.test/run-tests 'ai.miniforge.cli.main.commands.etl-test)"` →
+  6 tests, 11 assertions, 0 failures/errors. Same for
+  `ai.miniforge.cli.anomaly.etl-anomaly-test` → 7 tests, 21 assertions,
+  0 failures/errors.
+- `ai.miniforge.cli.main` (the caller namespace) required directly to
+  confirm it still compiles against the new `etl.clj` shape — clean.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file. The
+other 12 `main/commands/*.clj` files in this batch are tracked
+separately (concurrent, independent PRs).
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 program's `bases/cli` batch (task
+  #38). Follows the extraction convention established by `loader.clj`
+  (miniforge#1772) and `knowledge_safety.clj`
+  (2026-08-09-refactor-split-policy-pack-knowledge-safety.md).
+
+## Checklist
+
+- [x] stratum-lint clean on all resulting files
+- [x] `bb pre-commit` green (commit-budget, poly:check, lint,
+      stratum-lint, smoke tests, GraalVM compatibility)
+- [x] Adversarial self-review: def set unchanged except the three
+      required `defn-`→`defn` visibility flips, documented above
+- [x] Test call sites updated for both white-box test files
+- [x] Zero fan-in surprises: repo-wide grep confirmed only the two
+      known callers (`main.clj`, the two `etl` test files)


### PR DESCRIPTION
<!--
  Title: Split cli/main/commands/etl.clj (rule 210)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(cli): split etl.clj (rule 210)

## Overview

Splits `ai.miniforge.cli.main.commands.etl` into three sibling
namespaces, resolving a stratum-lint SL003 finding (the combined
namespace measured 4 real layers, over the rule 210 budget of 3).

## Motivation

Part of the stratum-lint rule-210 remediation program's `bases/cli`
batch: 13 `main/commands/*.clj` files being split concurrently as
independent command handlers.

## Changes in Detail

- New file `commands/etl/paths.clj`
  (`ai.miniforge.cli.main.commands.etl.paths`): pack-path resolution
  shared by `etl run` and `etl validate` — `single-file-under`,
  `resolve-env-path`, `resolve-pipeline-path` (all stay private),
  `resolve-pack-paths` (made public, see below) — 3 layers.
- New file `commands/etl/repo.clj`
  (`ai.miniforge.cli.main.commands.etl.repo`): `etl repo` support —
  `validate-git-url` (already public), `git-clone-temp` (stays
  private), `analyze-repo-url!` (made public, see below) — 2 layers.
- New file `commands/etl/shell.clj`
  (`ai.miniforge.cli.main.commands.etl.shell`): JVM shell-out shared
  by `run`/`list`/`validate`/`registry` — `find-miniforge-root` (stays
  private), `shell-etl!` (made public, see below) — 2 layers.
- `etl.clj`: now keeps only the five public command entry points
  (`etl-repo-cmd`, `etl-list-cmd`, `etl-registry-cmd`, `etl-run-cmd`,
  `etl-validate-cmd`), delegating to the three namespaces above. None
  of the five call each other — each calls straight into a sibling
  namespace, and those cross-namespace hops no longer count toward
  this file's own layer depth — so all five now measure a single
  layer (down from 4).
- Visibility changes required by the new cross-namespace call sites
  (pure code motion otherwise, same pattern as PR #1772's
  `defn-`→`defn` precedent):
  - `etl.repo/analyze-repo-url!`: `defn-` → `defn` (called from
    `etl-repo-cmd`)
  - `etl.shell/shell-etl!`: `defn-` → `defn` (called from 4 of the 5
    commands)
  - `etl.paths/resolve-pack-paths`: `defn-` → `defn` (called from
    `etl-run-cmd`, `etl-validate-cmd`)
- `etl_test.clj`: `validate-git-url-test` now calls
  `etl-repo/validate-git-url`; the three `with-redefs-fn` targets on
  `git-clone-temp` now reference `#'etl-repo/git-clone-temp` (moved to
  `etl.repo`, stays private there — var-quote cross-namespace access
  works regardless of privacy, the same mechanism the original tests
  already relied on).
- `etl_anomaly_test.clj`: `resolve-pipeline-path` and
  `resolve-env-path` moved to `etl.paths` (stay private there);
  var-quote targets updated to `#'etl-paths/resolve-pipeline-path` and
  `#'etl-paths/resolve-env-path`.

This is pure code motion aside from the three required visibility
changes and the test call-site updates above — no behavior changed.

## Testing Plan

- `stratum-lint` clean on all four touched/added source files (exit
  0, was SL003 exit 1 on the original `etl.clj`).
- `clj-kondo` clean on all six touched files (0 errors, 0 warnings).
- `bb pre-commit` green on all three commits (commit-budget, poly
  check, lint, stratum-lint, smoke tests, GraalVM compatibility).
- Repo-wide grep for the fully-qualified namespace
  (`ai\.miniforge\.cli\.main\.commands\.etl\b`, not a symbol-prefix
  guess) across `components/`, `bases/`, and `projects/` found exactly
  two callers: `bases/cli/src/ai/miniforge/cli/main.clj` (calls only
  the five public command fns, which stayed in `etl.clj` — no update
  needed) and the two test files (updated above). No caller under
  `projects/miniforge/test/`.
- Both touched test namespaces verified directly (not just via `bb
  pre-commit`'s smoke subset, which doesn't include them):
  `clojure -M:dev:test -e "(require 'ai.miniforge.cli.main.commands.etl-test)
  (clojure.test/run-tests 'ai.miniforge.cli.main.commands.etl-test)"` →
  6 tests, 11 assertions, 0 failures/errors. Same for
  `ai.miniforge.cli.anomaly.etl-anomaly-test` → 7 tests, 21 assertions,
  0 failures/errors.
- `ai.miniforge.cli.main` (the caller namespace) required directly to
  confirm it still compiles against the new `etl.clj` shape — clean.

## Deployment Plan

Merges to `main` immediately; no follow-up needed for this file. The
other 12 `main/commands/*.clj` files in this batch are tracked
separately (concurrent, independent PRs).

## Related Issues/PRs

- Part of the stratum-lint rule-210 program's `bases/cli` batch (task
  #38). Follows the extraction convention established by `loader.clj`
  (miniforge#1772) and `knowledge_safety.clj`
  (2026-08-09-refactor-split-policy-pack-knowledge-safety.md).

## Checklist

- [x] stratum-lint clean on all resulting files
- [x] `bb pre-commit` green (commit-budget, poly:check, lint,
      stratum-lint, smoke tests, GraalVM compatibility)
- [x] Adversarial self-review: def set unchanged except the three
      required `defn-`→`defn` visibility flips, documented above
- [x] Test call sites updated for both white-box test files
- [x] Zero fan-in surprises: repo-wide grep confirmed only the two
      known callers (`main.clj`, the two `etl` test files)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)