### PR TITLE
refactor(cli): split web/components.clj — add sibling fragment namespaces (1/2)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/web/components/batch_approve.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/components/batch_approve.clj
@@ -1,0 +1,77 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.web.components.batch-approve
+  "Batch-approve button and fleet-summary banner fragments."
+  (:require
+   [hiccup2.core :as h]
+   [ai.miniforge.cli.messages :as messages]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:const batch-approve-style
+  "padding: 6px 12px;")
+
+(defn- ^{:stratum 0} t
+  ([message-key]
+   (messages/t message-key))
+  ([message-key params]
+   (messages/t message-key params)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} batch-approve-confirm
+  [count]
+  (t :web-ui/batch-approve-confirm {:count count}))
+
+(defn- ^{:stratum 1} batch-approve-label
+  [count]
+  (t :web-ui/batch-approve-label {:count count}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} batch-approve-safe-button
+  [safe-count]
+  [:button.btn.btn-success
+   {:hx-post "/api/batch-approve"
+    :hx-target "#toast-container"
+    :hx-swap "innerHTML"
+    :hx-confirm (batch-approve-confirm safe-count)
+    :style batch-approve-style}
+   (t :web-ui/batch-approve-safe)])
+
+(defn ^{:stratum 2} fleet-summary [summary]
+  (let [{:keys [total recommendation high-risk medium-risk low-risk]} summary
+        icon (cond
+               (pos? (:count high-risk)) "🚨"
+               (pos? (:count medium-risk)) "📋"
+               (pos? (:count low-risk)) "✅"
+               :else "🎉")]
+    (h/html
+     [:div.fleet-summary
+      [:div.fleet-summary-icon icon]
+      [:div.fleet-summary-content
+       [:div.fleet-summary-title (t :web-ui/open-prs-title {:count total})]
+       [:div.fleet-summary-recommendation recommendation]]
+      [:div.fleet-summary-actions
+       (when (pos? (:count low-risk))
+         [:button.btn.btn-success
+          {:hx-post "/api/batch-approve"
+           :hx-target "#toast-container"
+           :hx-swap "innerHTML"
+           :hx-confirm (batch-approve-confirm (:count low-risk))}
+          (batch-approve-label (:count low-risk))])]])))

--- a/bases/cli/src/ai/miniforge/cli/web/components/chat.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/components/chat.clj
@@ -1,0 +1,106 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.web.components.chat
+  "AI-summary and chat-panel dashboard fragments."
+  (:require
+   [hiccup2.core :as h]
+   [ai.miniforge.cli.messages :as messages]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:const ai-placeholder-style
+  "color: var(--text-muted); font-style: italic; padding: 12px;")
+
+(def ^{:stratum 0} ^:const chat-empty-style
+  "color: var(--text-muted); font-size: 13px;")
+
+(def ^{:stratum 0} ^:const chat-response-style
+  "white-space: pre-wrap; word-wrap: break-word;")
+
+(defn- ^{:stratum 0} t
+  ([message-key]
+   (messages/t message-key))
+  ([message-key params]
+   (messages/t message-key params)))
+
+(defn- ^{:stratum 0} pr-url [repo number]
+  (str "/api/pr/" (java.net.URLEncoder/encode repo "UTF-8") "/" number))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} chat-message [question response]
+  (h/html
+   [:div
+    [:div.chat-message.user question]
+    [:div.chat-message.assistant
+     [:pre {:style chat-response-style} response]]]))
+
+(defn ^{:stratum 1} ai-summary [summary]
+  (h/html
+   [:div.ai-summary
+    [:div.ai-summary-header [:span "🤖"] [:span (t :web-ui/ai-analysis)]]
+    [:div.ai-summary-content (:summary summary)]]))
+
+(defn ^{:stratum 1} ai-summary-error [message]
+  (h/html
+   [:div.ai-summary
+    [:div.ai-summary-header [:span "⚠️"] [:span (t :web-ui/summary-unavailable)]]
+    [:div.ai-summary-content {:style "color: var(--text-muted)"} message]]))
+
+(defn ^{:stratum 1} ai-summary-placeholder [repo number]
+  (h/html
+   [:div
+    {:hx-post (str "/api/pr/" (java.net.URLEncoder/encode repo "UTF-8") "/" number "/summary")
+     :hx-trigger "load" :hx-target "this" :hx-swap "outerHTML"}
+    [:div {:style ai-placeholder-style}
+     (t :web-ui/ai-summary-loading)]]))
+
+(defn- ^{:stratum 1} quick-question-buttons
+  [repo number]
+  (for [{:keys [label prompt]} (t :web-ui/chat-quick-questions)]
+    [:button.quick-question
+     {:hx-post (str (pr-url repo number) "/chat")
+      :hx-target "#chat-messages"
+      :hx-swap "beforeend"
+      :hx-vals (str "{\"question\": \"" prompt "\"}")}
+     label]))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} chat-section
+  [repo number]
+  [:div.chat-section
+   [:div.chat-header
+    [:span "💬"]
+    [:span (t :web-ui/chat-heading)]]
+   [:div#chat-messages.chat-messages
+    [:div {:style chat-empty-style}
+     (t :web-ui/chat-empty-state)]]
+   [:div.quick-questions
+    (quick-question-buttons repo number)]
+   [:form.chat-input-container
+    {:hx-post (str (pr-url repo number) "/chat")
+     :hx-target "#chat-messages"
+     :hx-swap "beforeend"}
+    [:input.chat-input
+     {:type "text"
+      :name "question"
+      :placeholder (t :web-ui/chat-placeholder)
+      :autocomplete "off"}]
+    [:button.btn.btn-primary {:type "submit"}
+     (t :web-ui/chat-submit-button)]]])

--- a/bases/cli/src/ai/miniforge/cli/web/components/overview.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/components/overview.clj
@@ -1,0 +1,70 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.web.components.overview
+  "Fleet header, keyboard-hint, and dashboard stat-pill fragments."
+  (:require
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.web.components.batch-approve :as batch-approve]
+   [ai.miniforge.cli.web.components.status :as status-components]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} t
+  ([message-key]
+   (messages/t message-key))
+  ([message-key params]
+   (messages/t message-key params)))
+
+(defn- ^{:stratum 0} stat-pill
+  [class-name text]
+  [:span {:class class-name} text])
+
+(defn- ^{:stratum 0} keyboard-hint
+  [prefix-key suffix-key label]
+  [:span
+   [:kbd prefix-key]
+   "/"
+   [:kbd suffix-key]
+   (str " " label)])
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} fleet-header
+  [fleet-status]
+  [:div.header
+   [:div {:style "display: flex; align-items: center; gap: 16px;"}
+    [:h1 (t :web-ui/fleet-dashboard-heading)]
+    (status-components/status-indicator fleet-status)]])
+
+(defn ^{:stratum 1} keyboard-hints
+  []
+  [:div.keyboard-hints
+   (keyboard-hint "j" "k" (t :web-ui/hint-navigate))
+   [:span [:kbd "r"] (str " " (t :web-ui/hint-refresh))]
+   [:span [:kbd "a"] (str " " (t :web-ui/hint-approve))]
+   [:span [:kbd "x"] (str " " (t :web-ui/hint-reject))]])
+
+(defn ^{:stratum 1} dashboard-stats
+  [{:keys [total low medium high]}]
+  [:div.header-stats
+   (stat-pill "stat" (t :web-ui/pr-total {:count total}))
+   (stat-pill "stat stat-low" (t :web-ui/pr-low {:count low}))
+   (stat-pill "stat stat-medium" (t :web-ui/pr-medium {:count medium}))
+   (stat-pill "stat stat-high" (t :web-ui/pr-high {:count high}))
+   (when (pos? low)
+     (batch-approve/batch-approve-safe-button low))])

--- a/bases/cli/src/ai/miniforge/cli/web/components/pr_actions.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/components/pr_actions.clj
@@ -1,0 +1,74 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.web.components.pr-actions
+  "PR detail header and action-button fragments."
+  (:require
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.web.components.pr-stats :as pr-stats]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} t
+  ([message-key]
+   (messages/t message-key))
+  ([message-key params]
+   (messages/t message-key params)))
+
+(defn- ^{:stratum 0} pr-url [repo number]
+  (str "/api/pr/" (java.net.URLEncoder/encode repo "UTF-8") "/" number))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} detail-header
+  [risk-level number repo author additions deletions]
+  (let [author-login (get author :login (t :web-ui/unknown-author))]
+    [:div.detail-header
+     [:div.detail-title
+      [:span.risk-badge {:class (name risk-level)}
+       (case risk-level :low "●" :medium "◐" :high "◉")
+       (pr-stats/risk-label risk-level)]
+      (t :web-ui/pr-number {:number number})]
+     [:div.detail-meta
+      [:span (t :web-ui/repo-meta {:repo repo})]
+      [:span (t :web-ui/author-meta {:author author-login})]
+      [:span (t :web-ui/change-meta {:additions additions :deletions deletions})]]]))
+
+(defn- ^{:stratum 1} action-buttons
+  [repo number url]
+  [:div.actions
+   [:button.btn.btn-success
+    {:hx-post (str (pr-url repo number) "/approve")
+     :hx-target "#toast-container"
+     :hx-swap "innerHTML"}
+    (t :web-ui/approve-button)]
+   [:button.btn.btn-danger
+    {:hx-post (str (pr-url repo number) "/reject")
+     :hx-target "#toast-container"
+     :hx-swap "innerHTML"
+     :hx-prompt (t :web-ui/reject-prompt)}
+    (t :web-ui/reject-button)]
+   [:a.btn.btn-secondary {:href url :target "_blank"}
+    (t :web-ui/open-github-button)]])
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} detail-actions
+  [repo number url]
+  [:div.section
+   [:div.section-title (t :web-ui/actions-heading)]
+   (action-buttons repo number url)])

--- a/bases/cli/src/ai/miniforge/cli/web/components/pr_analysis.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/components/pr_analysis.clj
@@ -1,0 +1,67 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.web.components.pr-analysis
+  "AI-analysis section assembly for the PR detail panel."
+  (:require
+   [clojure.string :as str]
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.web.components.chat :as chat]
+   [ai.miniforge.cli.web.components.pr-stats :as pr-stats]
+   [ai.miniforge.cli.web.risk :as risk]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:const factors-style
+  "margin-top: 8px; color: var(--text-secondary);")
+
+(def ^{:stratum 0} ^:const summary-message-style
+  "margin-top: 16px;")
+
+(defn- ^{:stratum 0} t
+  ([message-key]
+   (messages/t message-key))
+  ([message-key params]
+   (messages/t message-key params)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} recommendation-box
+  [risk-level suggested-action]
+  (let [background-color (get risk/bg-colors risk-level)
+        style-value (str "margin-top: 16px; padding: 12px; border-radius: 6px; background: "
+                         background-color)]
+    [:div {:style style-value}
+     [:strong (t :web-ui/recommendation-prefix)]
+     suggested-action]))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} ai-analysis-section
+  [repo number {:keys [risk complexity summary suggested-action reasons total-changes file-count]}]
+  [:div.section
+   [:div.section-title (t :web-ui/ai-analysis)]
+   (pr-stats/analysis-stats risk complexity total-changes file-count)
+   [:div {:style summary-message-style}
+    [:strong (t :web-ui/summary-prefix)]
+    summary]
+   (when (seq reasons)
+     [:div {:style factors-style}
+      [:strong (t :web-ui/factors-prefix)]
+      (str/join ", " reasons)])
+   (recommendation-box risk suggested-action)
+   [:div#ai-summary-container (chat/ai-summary-placeholder repo number)]])

--- a/bases/cli/src/ai/miniforge/cli/web/components/pr_stats.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/components/pr_stats.clj
@@ -1,0 +1,60 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.web.components.pr-stats
+  "PR risk/complexity stat-card fragments."
+  (:require
+   [clojure.string :as str]
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.web.risk :as risk]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} t
+  ([message-key]
+   (messages/t message-key))
+  ([message-key params]
+   (messages/t message-key params)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} risk-label
+  [risk-level]
+  (t (case risk-level
+       :low :web-ui/risk-low
+       :medium :web-ui/risk-medium
+       :high :web-ui/risk-high
+       :web-ui/risk-unknown)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} analysis-stats
+  [risk-level complexity total-changes file-count]
+  [:div.stats-grid
+   [:div.stat-card
+    [:div.stat-card-value {:style (str "color: " (get risk/colors risk-level))}
+     (risk-label risk-level)]
+    [:div.stat-card-label (t :web-ui/risk-level-label)]]
+   [:div.stat-card
+    [:div.stat-card-value (str/capitalize (name complexity))]
+    [:div.stat-card-label (t :web-ui/complexity-label)]]
+   [:div.stat-card
+    [:div.stat-card-value total-changes]
+    [:div.stat-card-label (t :web-ui/lines-changed-label)]]
+   [:div.stat-card
+    [:div.stat-card-value file-count]
+    [:div.stat-card-label (t :web-ui/files-modified-label)]]])

--- a/bases/cli/src/ai/miniforge/cli/web/components/sidebar.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/components/sidebar.clj
@@ -1,0 +1,83 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.web.components.sidebar
+  "Repository/PR sidebar tree fragments."
+  (:require
+   [ai.miniforge.cli.messages :as messages]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:const selected-class
+  "selected")
+
+(def ^{:stratum 0} ^:const sidebar-refresh-style
+  "padding: 4px 8px; font-size: 11px;")
+
+(defn- ^{:stratum 0} t
+  ([message-key]
+   (messages/t message-key))
+  ([message-key params]
+   (messages/t message-key params)))
+
+(defn- ^{:stratum 0} pr-url [repo number]
+  (str "/api/pr/" (java.net.URLEncoder/encode repo "UTF-8") "/" number))
+
+(defn- ^{:stratum 0} repo-item-selected?
+  [selected-pr repo number]
+  (and selected-pr
+       (= (:repo selected-pr) repo)
+       (= (:number selected-pr) number)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} sidebar-header
+  []
+  [:div.sidebar-header
+   [:span (t :web-ui/repositories-heading)]
+   [:button.btn.btn-secondary
+    {:hx-get "/api/refresh"
+     :hx-target "#main-content"
+     :hx-swap "innerHTML"
+     :style sidebar-refresh-style}
+    (t :web-ui/refresh-button)]])
+
+(defn- ^{:stratum 1} repo-pr-item
+  [repo selected-pr {:keys [number title analysis]}]
+  (let [selected? (repo-item-selected? selected-pr repo number)
+        item-class (when selected? selected-class)]
+    [:div.pr-item
+     {:class item-class
+      :hx-get (pr-url repo number)
+      :hx-target "#detail-panel"
+      :hx-swap "innerHTML"}
+     [:span.pr-risk-dot {:class (str "pr-risk-" (name (:risk analysis)))}]
+     [:span.pr-number (str "#" number)]
+     [:span.pr-title title]]))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} repo-group
+  [selected-pr {:keys [repo prs]}]
+  [:div.repo-group
+   [:div.repo-header.expanded
+    [:span.repo-icon "📦"]
+    [:span.repo-name repo]
+    [:span.repo-count (count prs)]]
+   [:div.pr-list
+    (for [pr prs]
+      (repo-pr-item repo selected-pr pr))]])

--- a/docs/pull-requests/2026-08-18-refactor-split-cli-web-components-1.md
+++ b/docs/pull-requests/2026-08-18-refactor-split-cli-web-components-1.md
@@ -1,0 +1,85 @@
+<!--
+  Title: Split cli/web/components.clj (rule 210), part 1/2
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(cli): split web/components.clj — add sibling fragment namespaces (1/2)
+
+## Overview
+
+Part 1 of a 2-PR train resolving a stratum-lint SL003 finding on
+`bases/cli/src/ai/miniforge/cli/web/components.clj` (7 distinct
+layers, over the rule 210 budget of 3). Adds seven new sibling
+namespaces under `ai.miniforge.cli.web.components.*`, each holding a
+cohesive group of dashboard-fragment functions moved unchanged out of
+`components.clj`. This PR only adds files; `components.clj` itself is
+untouched and still fails SL003 until PR 2/2 wires these in.
+
+## Motivation
+
+`bases/cli/src/ai/miniforge/cli/web/components.clj` mixes seven
+independent concerns (page shell, chat/AI-summary, risk stat cards,
+sidebar tree, PR detail header/actions, fleet overview, batch-approve)
+in one namespace. Follows the established convention from this
+program (`detection.clj`/`loader.clj` 2-PR trains): extract cohesive
+layer-groups into sibling files under a subdirectory named after the
+original file, each passing the 3-layer budget on its own.
+
+Split into two PRs rather than one because the local pre-commit hook
+runs `stratum-lint` on every staged file and hard-blocks a commit
+that leaves a touched file over budget. That makes it impossible to
+edit `components.clj` incrementally (e.g. extract-and-rewire one
+group at a time) the way the `detection.clj` train did — any partial
+rewiring of `components.clj` still leaves it over 3 layers until
+every extraction lands, so the edit to that file can only be
+committed once, atomically, after all seven sibling files already
+exist. This PR supplies those seven files first; PR 2/2 is the single
+atomic rewrite of `components.clj`.
+
+## Changes in Detail
+
+New files (all pure code motion, no behavior change):
+
+- `components/chat.clj` — AI-summary and chat-panel fragments:
+  `chat-message`, `ai-summary`, `ai-summary-error`,
+  `ai-summary-placeholder`, `quick-question-buttons` (private),
+  `chat-section`. 3 layers.
+- `components/pr_stats.clj` — risk/complexity stat-card fragments:
+  `risk-label`, `analysis-stats`. 2 layers.
+- `components/pr_analysis.clj` — AI-analysis section assembly:
+  `recommendation-box` (private), `ai-analysis-section`. Requires
+  `pr-stats` and `chat`. 2 layers.
+- `components/sidebar.clj` — repo-tree sidebar fragments:
+  `sidebar-header`, `repo-pr-item` (private), `repo-group`. 3 layers.
+- `components/pr_actions.clj` — PR detail header/action fragments:
+  `detail-header`, `action-buttons` (private), `detail-actions`.
+  Requires `pr-stats` (for `risk-label`). 3 layers.
+- `components/overview.clj` — fleet header and dashboard stat-pill
+  fragments: `fleet-header`, `keyboard-hint` (private),
+  `keyboard-hints`, `dashboard-stats`. Requires `batch-approve` (for
+  `batch-approve-safe-button`) and `status`. 2 layers.
+- `components/batch_approve.clj` — batch-approve button and
+  fleet-summary banner: `batch-approve-confirm`/`batch-approve-label`
+  (private), `batch-approve-safe-button`, `fleet-summary`. 3 layers.
+
+Each new file duplicates the small `t` (message-catalog lookup) and,
+where needed, `pr-url` private helpers rather than requiring the
+parent `components` namespace back — the same pattern already used by
+the existing `components/status.clj` sibling, and necessary here to
+avoid a circular dependency (the parent will require these siblings,
+not the reverse).
+
+`components.clj` itself is unchanged in this PR (still 7 layers,
+SL003 still firing) — cleared in PR 2/2.
+
+## Testing Plan
+
+- `stratum-lint` clean (exit 0) on all seven new files.
+- Each new file compiles standalone: `clojure -M:dev:test -e
+  "(require 'ai.miniforge.cli.web.components.chat ...)"` — exit 0.
+- Full `bb pre-commit` (commit-budget, poly:check, lint:clj,
+  lint:stratum, pre-commit smoke tests, GraalVM/Babashka
+  compatibility) green on every commit in this PR.
+- No behavior change possible to observe yet — nothing requires these
+  namespaces until PR 2/2 wires them into `components.clj`.


### PR DESCRIPTION
Part 1 of a 2-PR train resolving stratum-lint SL003 on `bases/cli/src/ai/miniforge/cli/web/components.clj` (7 distinct layers, over the rule 210 budget of 3).

Adds seven new sibling namespaces under `ai.miniforge.cli.web.components.*` (`chat`, `pr-stats`, `pr-analysis`, `sidebar`, `pr-actions`, `overview`, `batch-approve`), each a cohesive group of fragment functions moved unchanged out of `components.clj`, each passing the 3-layer budget on its own. Pure code motion, no behavior change.

`components.clj` itself is untouched in this PR and still fails SL003 — PR 2/2 is the single atomic rewrite that wires these in and clears the finding. See `docs/pull-requests/2026-08-18-refactor-split-cli-web-components-1.md` for the full writeup, including why this had to be a 2-PR train (the local pre-commit hook hard-blocks any commit that leaves a touched file over the 3-layer budget, so `components.clj` can only be edited once, atomically, after all seven siblings already exist).

Testing: `stratum-lint` clean on all seven new files; each compiles standalone; full `bb pre-commit` (commit-budget, poly:check, lint:clj, lint:stratum, smoke tests, GraalVM/Babashka compatibility) green on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)