### PR TITLE
refactor(cli): split main.clj — extract main/util.clj (1/9)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -50,6 +50,7 @@
    [ai.miniforge.cli.config :as config]
    [ai.miniforge.cli.observability :as observability]
    [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.main.util :as util]
    [ai.miniforge.cli.main.commands.run :as cmd-run]
    [ai.miniforge.cli.main.commands.resume :as cmd-resume]
    [ai.miniforge.cli.main.commands.shared :as cmd-shared]
@@ -242,9 +243,7 @@
                        {:command (app-config/command-string "help")}))
   (System/exit 1))
 
-;------------------------------------------------------------------------------ Layer 1
-
-(defn- ^{:stratum 1} create-pr-train-manager
+(defn- ^{:stratum 0} create-pr-train-manager
   "Build the PR-train manager bound to `event-stream` so train
    mutations (add-pr, complete-merge) publish governed events that
    supervisory-state materializes for the consoles."
@@ -257,42 +256,42 @@
        (pr-train/create-manager))
      (catch Object e
        (println (messages/t :web/pr-train-warning
-                            {:error (caught-message e (:throwable &throw-context))}))
+                            {:error (util/caught-message e (:throwable &throw-context))}))
        nil))))
 
-(defn- ^{:stratum 1} create-repo-dag-manager
+(defn- ^{:stratum 0} create-repo-dag-manager
   []
   (try+
     (repo-dag/create-manager)
     (catch Object e
       (println (messages/t :web/repo-dag-warning
-                           {:error (caught-message e (:throwable &throw-context))}))
+                           {:error (util/caught-message e (:throwable &throw-context))}))
       nil)))
 
 ;; TUI components loaded conditionally (only in JVM/jlink bundled runtime).
 ;; This is an optional composition seam: miniforge-core includes the CLI
 ;; without bundling the JVM TUI component.
-(def ^{:stratum 1} tui-launcher
-  (optional-composition-var 'ai.miniforge.tui-views.interface 'start-standalone-tui!))
+(def ^{:stratum 0} tui-launcher
+  (util/optional-composition-var 'ai.miniforge.tui-views.interface 'start-standalone-tui!))
 
-(defn- ^{:stratum 1} stale-running?
+(defn- ^{:stratum 0} stale-running?
   [last-updated]
-  (when-let [last-updated-ms (timestamp->epoch-ms last-updated)]
+  (when-let [last-updated-ms (util/timestamp->epoch-ms last-updated)]
     (let [configured-threshold-ms (:running-stale-threshold-ms (app-config/status-config))
           default-threshold-ms (:running-stale-threshold-ms app-config/default-status-config)
           threshold-ms (if (nat-int? configured-threshold-ms)
                          configured-threshold-ms
                          default-threshold-ms)]
-      (> (- (current-time-ms) last-updated-ms)
+      (> (- (util/current-time-ms) last-updated-ms)
          threshold-ms))))
 
-(defn- ^{:stratum 1} print-workflow-status
+(defn- ^{:stratum 0} print-workflow-status
   [{:keys [workflow-id status spec-name event-count completed-phases
            completed-dag-task-count last-updated]}]
   (let [unknown (messages/t :status/value-unknown)
         none    (messages/t :status/value-none)]
     (display/print-info (messages/t :status/workflow {:workflow-id workflow-id}))
-    (println (messages/t :status/field-status {:value (status-label status)}))
+    (println (messages/t :status/field-status {:value (util/status-label status)}))
     (println (messages/t :status/field-spec {:value (or spec-name unknown)}))
     (println (messages/t :status/field-events {:value event-count}))
     (println (messages/t :status/field-last-updated {:value (or last-updated unknown)}))
@@ -303,20 +302,14 @@
     (println (messages/t :status/field-completed-dag-tasks
                          {:value completed-dag-task-count}))))
 
-;; Command implementations
-(defn ^{:stratum 1} version-cmd
-  [_m]
-  (println (str (:name version-info) " " (:version version-info)))
-  (println (:description version-info)))
-
-(defn ^{:stratum 1} doctor-cmd
+(defn ^{:stratum 0} doctor-cmd
   [_m]
   (println "\n" (display/style (app-config/system-check-title) :foreground :cyan :bold true) "\n")
 
   (let [checks (messages/t :doctor/checks)]
 
     (doseq [[cmd name desc] checks]
-      (let [available? (check-command cmd)
+      (let [available? (util/check-command cmd)
             status (if available?
                      (display/style "✓" :foreground :green)
                      (display/style "✗" :foreground :red))
@@ -343,28 +336,28 @@
     (println)))
 
 ;; Config commands — one-liner delegates
-(defn ^{:stratum 1} config-init-cmd [m] (config/cmd-init (get-opts m)))
+(defn ^{:stratum 0} config-init-cmd [m] (config/cmd-init (util/get-opts m)))
 
-(defn ^{:stratum 1} config-list-cmd [m] (config/cmd-list (get-opts m)))
+(defn ^{:stratum 0} config-list-cmd [m] (config/cmd-list (util/get-opts m)))
 
-(defn ^{:stratum 1} config-get-cmd [m] (config/cmd-get (get-opts m)))
+(defn ^{:stratum 0} config-get-cmd [m] (config/cmd-get (util/get-opts m)))
 
-(defn ^{:stratum 1} config-set-cmd [m] (config/cmd-set (get-opts m)))
+(defn ^{:stratum 0} config-set-cmd [m] (config/cmd-set (util/get-opts m)))
 
-(defn ^{:stratum 1} config-edit-cmd [m] (config/cmd-edit (get-opts m)))
+(defn ^{:stratum 0} config-edit-cmd [m] (config/cmd-edit (util/get-opts m)))
 
-(defn ^{:stratum 1} config-reset-cmd [m] (config/cmd-reset (get-opts m)))
+(defn ^{:stratum 0} config-reset-cmd [m] (config/cmd-reset (util/get-opts m)))
 
-(defn ^{:stratum 1} config-backends-cmd [m] (config/cmd-backends (get-opts m)))
+(defn ^{:stratum 0} config-backends-cmd [m] (config/cmd-backends (util/get-opts m)))
 
-(defn ^{:stratum 1} config-backend-cmd [m] (config/cmd-backend (get-opts m)))
+(defn ^{:stratum 0} config-backend-cmd [m] (config/cmd-backend (util/get-opts m)))
 
-(defn ^{:stratum 1} config-validate-cmd [m] (config/cmd-validate (get-opts m)))
+(defn ^{:stratum 0} config-validate-cmd [m] (config/cmd-validate (util/get-opts m)))
 
 ;; Workflow commands
-(defn ^{:stratum 1} workflow-run-cmd
+(defn ^{:stratum 0} workflow-run-cmd
   [m]
-  (let [{:keys [workflow-id version input input-json output quiet dashboard-url]} (get-opts m)]
+  (let [{:keys [workflow-id version input input-json output quiet dashboard-url]} (util/get-opts m)]
     (if-not workflow-id
       (display/print-error (messages/t :workflow-run/usage
                                        {:command (app-config/command-string "workflow run <workflow-id> [options]")}))
@@ -382,20 +375,20 @@
                                            {:error (ex-message e)})))))))
 
 ;; Workflow subcommands — spec-driven execution and lifecycle (N5)
-(defn ^{:stratum 1} workflow-execute-cmd [m] (cmd-workflow/workflow-execute-cmd (get-opts m)))
+(defn ^{:stratum 0} workflow-execute-cmd [m] (cmd-workflow/workflow-execute-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} workflow-inspect-cmd [m] (cmd-workflow/workflow-inspect-cmd (get-opts m)))
+(defn ^{:stratum 0} workflow-inspect-cmd [m] (cmd-workflow/workflow-inspect-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} workflow-status-cmd  [m] (cmd-workflow/workflow-status-cmd  (get-opts m)))
+(defn ^{:stratum 0} workflow-status-cmd  [m] (cmd-workflow/workflow-status-cmd  (util/get-opts m)))
 
-(defn ^{:stratum 1} workflow-cancel-cmd  [m] (cmd-workflow/workflow-cancel-cmd  (get-opts m)))
+(defn ^{:stratum 0} workflow-cancel-cmd  [m] (cmd-workflow/workflow-cancel-cmd  (util/get-opts m)))
 
-(defn ^{:stratum 1} workflow-gc-scratch-cmd [m] (cmd-workflow/workflow-gc-scratch-cmd (get-opts m)))
+(defn ^{:stratum 0} workflow-gc-scratch-cmd [m] (cmd-workflow/workflow-gc-scratch-cmd (util/get-opts m)))
 
 ;; Chain commands
-(defn ^{:stratum 1} chain-run-cmd
+(defn ^{:stratum 0} chain-run-cmd
   [m]
-  (let [{:keys [chain-id version spec input-json quiet]} (get-opts m)]
+  (let [{:keys [chain-id version spec input-json quiet]} (util/get-opts m)]
     (if-not chain-id
       (display/print-error (messages/t :chain-run/usage
                                        {:command (app-config/command-string "chain run <chain-id> [options]")}))
@@ -411,25 +404,25 @@
                                            {:error (ex-message e)})))))))
 
 ;; Observability commands
-(defn ^{:stratum 1} logs-tail-cmd [m] (observability/handle-logs (assoc (get-opts m) :subcommand "tail")))
+(defn ^{:stratum 0} logs-tail-cmd [m] (observability/handle-logs (assoc (util/get-opts m) :subcommand "tail")))
 
-(defn ^{:stratum 1} events-tail-cmd [m] (observability/handle-events (assoc (get-opts m) :subcommand "tail")))
+(defn ^{:stratum 0} events-tail-cmd [m] (observability/handle-events (assoc (util/get-opts m) :subcommand "tail")))
 
-(defn ^{:stratum 1} events-show-cmd
+(defn ^{:stratum 0} events-show-cmd
   "Render a human-readable timeline for a workflow from the local event log.
    Delegates to the GROUP 3b events command module."
   [m]
-  (cmd-events/events-show-cmd (get-opts m)))
+  (cmd-events/events-show-cmd (util/get-opts m)))
 
 ;; Delegated commands
-(defn ^{:stratum 1} run-cmd [m] (cmd-run/run-cmd (get-opts m)))
+(defn ^{:stratum 0} run-cmd [m] (cmd-run/run-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} resume-cmd
+(defn ^{:stratum 0} resume-cmd
   "First-class `mf resume <workflow-id>` subcommand. The `<workflow-id>`
    can be passed positionally, or via `--workflow-id`/`-w` / the legacy
    `--resume`/`-r` flag (kept so existing docs keep working)."
   [m]
-  (let [opts (get-opts m)
+  (let [opts (util/get-opts m)
         args (:args m)
         wf-id (or (:workflow-id opts)
                   (:resume opts)
@@ -438,87 +431,87 @@
       (display/print-error (messages/t :resume/missing-workflow-id))
       (cmd-resume/resume-workflow wf-id opts))))
 
-(defn ^{:stratum 1} scan-cmd [m] (cmd-scan/scan-cmd (get-opts m)))
+(defn ^{:stratum 0} scan-cmd [m] (cmd-scan/scan-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} init-cmd [m] (cmd-init/init-cmd (get-opts m)))
+(defn ^{:stratum 0} init-cmd [m] (cmd-init/init-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} web-cmd [m] (cmd-monitoring/web-cmd (get-opts m)))
+(defn ^{:stratum 0} web-cmd [m] (cmd-monitoring/web-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} tui-cmd [m] (cmd-monitoring/tui-cmd (get-opts m)))
+(defn ^{:stratum 0} tui-cmd [m] (cmd-monitoring/tui-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} fleet-start-cmd [m] (cmd-fleet/fleet-start-cmd (get-opts m)))
+(defn ^{:stratum 0} fleet-start-cmd [m] (cmd-fleet/fleet-start-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} fleet-stop-cmd [m] (cmd-fleet/fleet-stop-cmd (get-opts m)))
+(defn ^{:stratum 0} fleet-stop-cmd [m] (cmd-fleet/fleet-stop-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} fleet-status-cmd [m] (cmd-fleet/fleet-status-cmd (get-opts m) config/default-user-config-path config/default-config))
+(defn ^{:stratum 0} fleet-status-cmd [m] (cmd-fleet/fleet-status-cmd (util/get-opts m) config/default-user-config-path config/default-config))
 
-(defn ^{:stratum 1} fleet-add-cmd [m] (cmd-fleet/fleet-add-cmd (get-opts m) config/default-user-config-path config/default-config))
+(defn ^{:stratum 0} fleet-add-cmd [m] (cmd-fleet/fleet-add-cmd (util/get-opts m) config/default-user-config-path config/default-config))
 
-(defn ^{:stratum 1} fleet-remove-cmd [m] (cmd-fleet/fleet-remove-cmd (get-opts m) config/default-user-config-path config/default-config))
+(defn ^{:stratum 0} fleet-remove-cmd [m] (cmd-fleet/fleet-remove-cmd (util/get-opts m) config/default-user-config-path config/default-config))
 
-(defn ^{:stratum 1} fleet-watch-cmd [m] (cmd-fleet/fleet-watch-cmd (get-opts m)))
+(defn ^{:stratum 0} fleet-watch-cmd [m] (cmd-fleet/fleet-watch-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} fleet-prs-cmd [m] (cmd-fleet/fleet-prs-cmd (get-opts m) config/default-user-config-path config/default-config))
+(defn ^{:stratum 0} fleet-prs-cmd [m] (cmd-fleet/fleet-prs-cmd (util/get-opts m) config/default-user-config-path config/default-config))
 
-(defn ^{:stratum 1} pr-list-cmd [m]
-  (cmd-pr/pr-list-cmd (get-opts m)
+(defn ^{:stratum 0} pr-list-cmd [m]
+  (cmd-pr/pr-list-cmd (util/get-opts m)
                       (fn [config-path]
                         (cmd-fleet/load-config config-path config/default-user-config-path config/default-config))))
 
-(defn ^{:stratum 1} pr-review-cmd [m] (cmd-pr/pr-review-cmd (get-opts m)))
+(defn ^{:stratum 0} pr-review-cmd [m] (cmd-pr/pr-review-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} pr-respond-cmd [m] (cmd-pr/pr-respond-cmd (get-opts m)))
+(defn ^{:stratum 0} pr-respond-cmd [m] (cmd-pr/pr-respond-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} pr-merge-cmd [m] (cmd-pr/pr-merge-cmd (get-opts m)))
+(defn ^{:stratum 0} pr-merge-cmd [m] (cmd-pr/pr-merge-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} pr-monitor-cmd [m] (cmd-pr/pr-monitor-cmd (get-opts m)))
+(defn ^{:stratum 0} pr-monitor-cmd [m] (cmd-pr/pr-monitor-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} pr-review-monitor-cmd [m] (cmd-pr-review-monitor/pr-review-monitor-cmd (get-opts m)))
+(defn ^{:stratum 0} pr-review-monitor-cmd [m] (cmd-pr-review-monitor/pr-review-monitor-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} pr-resume-dispatcher-cmd [m] (cmd-pr-resume/pr-resume-dispatcher-cmd (get-opts m)))
+(defn ^{:stratum 0} pr-resume-dispatcher-cmd [m] (cmd-pr-resume/pr-resume-dispatcher-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} pr-policy-respond-cmd [m] (cmd-pr-policy/pr-policy-respond-cmd (get-opts m)))
+(defn ^{:stratum 0} pr-policy-respond-cmd [m] (cmd-pr-policy/pr-policy-respond-cmd (util/get-opts m)))
 
 ;; Control Plane commands
-(defn ^{:stratum 1} cp-status-cmd [m] (cmd-cp/status-cmd (get-opts m)))
+(defn ^{:stratum 0} cp-status-cmd [m] (cmd-cp/status-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} cp-decisions-cmd [m] (cmd-cp/decisions-cmd (get-opts m)))
+(defn ^{:stratum 0} cp-decisions-cmd [m] (cmd-cp/decisions-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} cp-resolve-cmd [m] (cmd-cp/resolve-cmd (get-opts m)))
+(defn ^{:stratum 0} cp-resolve-cmd [m] (cmd-cp/resolve-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} cp-terminate-cmd [m] (cmd-cp/terminate-cmd (get-opts m)))
+(defn ^{:stratum 0} cp-terminate-cmd [m] (cmd-cp/terminate-cmd (util/get-opts m)))
 
 ;; Policy commands (N5)
-(defn ^{:stratum 1} policy-list-cmd    [m] (cmd-policy/policy-list-cmd    (get-opts m)))
+(defn ^{:stratum 0} policy-list-cmd    [m] (cmd-policy/policy-list-cmd    (util/get-opts m)))
 
-(defn ^{:stratum 1} policy-show-cmd    [m] (cmd-policy/policy-show-cmd    (get-opts m)))
+(defn ^{:stratum 0} policy-show-cmd    [m] (cmd-policy/policy-show-cmd    (util/get-opts m)))
 
-(defn ^{:stratum 1} policy-install-cmd [m] (cmd-policy/policy-install-cmd (get-opts m)))
+(defn ^{:stratum 0} policy-install-cmd [m] (cmd-policy/policy-install-cmd (util/get-opts m)))
 
 ;; Evidence commands (N5)
-(defn ^{:stratum 1} evidence-list-cmd   [m] (cmd-evidence/evidence-list-cmd   (get-opts m)))
+(defn ^{:stratum 0} evidence-list-cmd   [m] (cmd-evidence/evidence-list-cmd   (util/get-opts m)))
 
-(defn ^{:stratum 1} evidence-show-cmd   [m] (cmd-evidence/evidence-show-cmd   (get-opts m)))
+(defn ^{:stratum 0} evidence-show-cmd   [m] (cmd-evidence/evidence-show-cmd   (util/get-opts m)))
 
-(defn ^{:stratum 1} evidence-export-cmd [m] (cmd-evidence/evidence-export-cmd (get-opts m)))
+(defn ^{:stratum 0} evidence-export-cmd [m] (cmd-evidence/evidence-export-cmd (util/get-opts m)))
 
 ;; Artifact commands (N5)
-(defn ^{:stratum 1} artifact-list-cmd       [m] (cmd-artifact/artifact-list-cmd       (get-opts m)))
+(defn ^{:stratum 0} artifact-list-cmd       [m] (cmd-artifact/artifact-list-cmd       (util/get-opts m)))
 
-(defn ^{:stratum 1} artifact-provenance-cmd [m] (cmd-artifact/artifact-provenance-cmd (get-opts m)))
+(defn ^{:stratum 0} artifact-provenance-cmd [m] (cmd-artifact/artifact-provenance-cmd (util/get-opts m)))
 
 ;; ETL commands (N5)
-(defn ^{:stratum 1} etl-repo-cmd     [m] (cmd-etl/etl-repo-cmd     (get-opts m)))
+(defn ^{:stratum 0} etl-repo-cmd     [m] (cmd-etl/etl-repo-cmd     (util/get-opts m)))
 
-(defn ^{:stratum 1} etl-run-cmd      [m] (cmd-etl/etl-run-cmd      (get-opts m)))
+(defn ^{:stratum 0} etl-run-cmd      [m] (cmd-etl/etl-run-cmd      (util/get-opts m)))
 
-(defn ^{:stratum 1} etl-list-cmd     [m] (cmd-etl/etl-list-cmd     (get-opts m)))
+(defn ^{:stratum 0} etl-list-cmd     [m] (cmd-etl/etl-list-cmd     (util/get-opts m)))
 
-(defn ^{:stratum 1} etl-validate-cmd [m] (cmd-etl/etl-validate-cmd (get-opts m)))
+(defn ^{:stratum 0} etl-validate-cmd [m] (cmd-etl/etl-validate-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} etl-registry-cmd [m] (cmd-etl/etl-registry-cmd (get-opts m)))
+(defn ^{:stratum 0} etl-registry-cmd [m] (cmd-etl/etl-registry-cmd (util/get-opts m)))
 
-(defn ^{:stratum 1} context-server-cmd
+(defn ^{:stratum 0} context-server-cmd
   "Run the MCP context server (internal — spawned as subprocess by the agent).
 
    Reads JSON-RPC 2.0 from stdin, serves context_read/context_grep/context_glob
@@ -526,15 +519,21 @@
    writes to --workdir (the agent's worktree). Invoked automatically; not
    intended for direct user use."
   [m]
-  (let [{:keys [artifact-dir source-root workdir]} (get-opts m)]
+  (let [{:keys [artifact-dir source-root workdir]} (util/get-opts m)]
     (mcp-context-server/start-server artifact-dir source-root workdir)))
 
-;------------------------------------------------------------------------------ Layer 2
+;------------------------------------------------------------------------------ Layer 1
 
-(defn- ^{:stratum 2} optional-web-launcher
+;; Command implementations
+(defn ^{:stratum 1} version-cmd
+  [_m]
+  (println (str (:name version-info) " " (:version version-info)))
+  (println (:description version-info)))
+
+(defn- ^{:stratum 1} optional-web-launcher
   "Compose the dashboard command when the product includes web-dashboard."
   []
-  (when-let [start! (optional-composition-var
+  (when-let [start! (util/optional-composition-var
                      'ai.miniforge.web-dashboard.interface
                      'start!)]
     (fn [{:keys [port]}]
@@ -547,10 +546,10 @@
                  :pr-train-manager pr-train-manager
                  :repo-dag-manager repo-dag-manager})))))
 
-(def ^{:stratum 2} tui-available?
+(def ^{:stratum 1} tui-available?
   (some? tui-launcher))
 
-(defn- ^{:stratum 2} reconstructed-status
+(defn- ^{:stratum 1} reconstructed-status
   [reconstructed last-updated]
   (cond
     (wr/completed? reconstructed) :completed
@@ -559,12 +558,12 @@
     (stale-running? last-updated) :stale
     :else :running))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 2
 
-(def ^{:stratum 3} web-launcher
+(def ^{:stratum 2} web-launcher
   (optional-web-launcher))
 
-(defn- ^{:stratum 3} workflow-status-summary
+(defn- ^{:stratum 2} workflow-status-summary
   [workflow-id]
   (let [events-dir (app-config/events-dir)
         events (es/read-workflow-events-by-id events-dir workflow-id)
@@ -580,12 +579,12 @@
      :completed-dag-task-count (count (:completed-dag-tasks reconstructed))
      :last-updated (:event/timestamp last-event)}))
 
-;------------------------------------------------------------------------------ Layer 4
+;------------------------------------------------------------------------------ Layer 3
 
-(def ^{:stratum 4} web-available?
+(def ^{:stratum 3} web-available?
   (some? web-launcher))
 
-(defn- ^{:stratum 4} all-workflow-summaries
+(defn- ^{:stratum 3} all-workflow-summaries
   []
   (let [events-dir (app-config/events-dir)]
     (if (fs/exists? events-dir)
@@ -599,11 +598,11 @@
            (sort-by :last-updated #(compare %2 %1)))
       [])))
 
-;------------------------------------------------------------------------------ Layer 5
+;------------------------------------------------------------------------------ Layer 4
 
-(defn ^{:stratum 5} status-cmd
+(defn ^{:stratum 4} status-cmd
   [m]
-  (let [{:keys [workflow-id]} (get-opts m)]
+  (let [{:keys [workflow-id]} (util/get-opts m)]
     (if workflow-id
       (try
         (print-workflow-status (workflow-status-summary (str workflow-id)))
@@ -617,16 +616,16 @@
           (doseq [{:keys [workflow-id status spec-name last-updated]} summaries]
             (println (messages/t :status/summary-row
                                  {:workflow-id (format "%-36s" workflow-id)
-                                  :status      (format "%-10s" (status-label status))
+                                  :status      (format "%-10s" (util/status-label status))
                                   :spec-name   (or spec-name unknown)}))
             (println (messages/t :status/summary-last-updated
                                  {:value (or last-updated unknown)})))
           (println (str "  " none)))))))
 
-;------------------------------------------------------------------------------ Layer 6
+;------------------------------------------------------------------------------ Layer 5
 
 ;; CLI dispatch
-(def ^{:stratum 6} dispatch-table
+(def ^{:stratum 5} dispatch-table
   [{:cmds ["version"] :fn version-cmd}
    {:cmds ["doctor"]  :fn doctor-cmd}
    {:cmds ["help"]    :fn help-cmd}
@@ -896,9 +895,9 @@
    {:cmds ["etl" "validate"]  :fn etl-validate-cmd :args->opts [:pack]}
    {:cmds ["etl" "registry"]  :fn etl-registry-cmd}])
 
-;------------------------------------------------------------------------------ Layer 7
+;------------------------------------------------------------------------------ Layer 6
 
-(defn ^{:stratum 7} -main
+(defn ^{:stratum 6} -main
   "CLI entry point."
   [& args]
   (try+
@@ -921,7 +920,7 @@
    'ai.miniforge.tui-views.interface/start-standalone-tui!
    tui-launcher))
 
-(when-let [start-fleet-tui! (optional-composition-var 'ai.miniforge.tui-views.interface
+(when-let [start-fleet-tui! (util/optional-composition-var 'ai.miniforge.tui-views.interface
                                                       'start-fleet-tui!)]
   (cmd-shared/register-optional-fn!
    'ai.miniforge.tui-views.interface/start-fleet-tui!

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -40,7 +40,6 @@
   (:require
    [babashka.cli :as cli]
    [babashka.fs :as fs]
-   [babashka.process :as process]
    [clojure.string :as str]
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.messages :as messages]
@@ -87,76 +86,11 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Composition seams (optional web/TUI providers) and pure helpers
-(defn- ^{:stratum 0} optional-composition-var
-  "Resolve a provider whose entire component is optional for this CLI product.
-   This is the CLI's only late-binding boundary: miniforge-core loads this
-   namespace without web-dashboard or TUI components on its classpath."
-  [ns-sym var-sym]
-  (try
-    (require ns-sym)
-    (ns-resolve ns-sym var-sym)
-    (catch Throwable _ nil)))
-
-(defn- ^{:stratum 0} caught-message
-  [caught throwable]
-  (cond
-    (instance? Throwable caught)
-    (or (.getMessage ^Throwable caught)
-        (some-> caught class .getName)
-        "unknown exception")
-
-    throwable
-    (or (.getMessage ^Throwable throwable)
-        (some-> throwable class .getName)
-        "unknown exception")
-
-    :else
-    (str caught)))
-
 ;; ── Constants and pure helpers ──────────────────────────────────────────────
 (def ^{:stratum 0} version-info
   {:name (app-config/binary-name)
    :version "2026.01.20.1"
    :description (app-config/description)})
-
-(defn ^{:stratum 0} current-time-ms
-  "Current epoch time in milliseconds. Public so CLI tests can rebind it."
-  []
-  (System/currentTimeMillis))
-
-(defn ^{:stratum 0} get-opts
-  "Extract opts from dispatch result."
-  [m]
-  (if (contains? m :opts)
-    (:opts m)
-    m))
-
-(defn ^{:stratum 0} check-command
-  "Check if a command is available."
-  [cmd]
-  (let [{:keys [exit]} (process/sh "which" cmd)]
-    (zero? exit)))
-
-(defn- ^{:stratum 0} timestamp->epoch-ms
-  [timestamp]
-  (cond
-    (instance? java.util.Date timestamp)
-    (.getTime ^java.util.Date timestamp)
-
-    (instance? java.time.Instant timestamp)
-    (.toEpochMilli ^java.time.Instant timestamp)
-
-    (string? timestamp)
-    (try
-      (.toEpochMilli (java.time.Instant/parse timestamp))
-      (catch Exception _ nil))
-
-    :else nil))
-
-(defn- ^{:stratum 0} status-label
-  [status]
-  (messages/t (keyword "status" (str "value-" (name status)))))
 
 (defn ^{:stratum 0} workflow-list-cmd [_m] (workflow-runner/list-workflows!))
 

--- a/bases/cli/src/ai/miniforge/cli/main/util.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/util.clj
@@ -1,0 +1,93 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.main.util
+  "Dependency-light leaf helpers shared across `ai.miniforge.cli.main` and
+   its sibling command-dispatch namespaces: process/time/opts primitives,
+   the optional-composition-var late-binding helper, and status-label
+   formatting. Every def here is independent of every other def in this
+   file (no same-file references), so the whole namespace is one real
+   layer."
+  (:require
+   [babashka.process :as process]
+   [ai.miniforge.cli.messages :as messages]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} optional-composition-var
+  "Resolve a provider whose entire component is optional for this CLI product.
+   This is the CLI's only late-binding boundary: miniforge-core loads this
+   namespace without web-dashboard or TUI components on its classpath."
+  [ns-sym var-sym]
+  (try
+    (require ns-sym)
+    (ns-resolve ns-sym var-sym)
+    (catch Throwable _ nil)))
+
+(defn ^{:stratum 0} caught-message
+  [caught throwable]
+  (cond
+    (instance? Throwable caught)
+    (or (.getMessage ^Throwable caught)
+        (some-> caught class .getName)
+        "unknown exception")
+
+    throwable
+    (or (.getMessage ^Throwable throwable)
+        (some-> throwable class .getName)
+        "unknown exception")
+
+    :else
+    (str caught)))
+
+(defn ^{:stratum 0} current-time-ms
+  "Current epoch time in milliseconds. Public so CLI tests can rebind it."
+  []
+  (System/currentTimeMillis))
+
+(defn ^{:stratum 0} get-opts
+  "Extract opts from dispatch result."
+  [m]
+  (if (contains? m :opts)
+    (:opts m)
+    m))
+
+(defn ^{:stratum 0} check-command
+  "Check if a command is available."
+  [cmd]
+  (let [{:keys [exit]} (process/sh "which" cmd)]
+    (zero? exit)))
+
+(defn ^{:stratum 0} timestamp->epoch-ms
+  [timestamp]
+  (cond
+    (instance? java.util.Date timestamp)
+    (.getTime ^java.util.Date timestamp)
+
+    (instance? java.time.Instant timestamp)
+    (.toEpochMilli ^java.time.Instant timestamp)
+
+    (string? timestamp)
+    (try
+      (.toEpochMilli (java.time.Instant/parse timestamp))
+      (catch Exception _ nil))
+
+    :else nil))
+
+(defn ^{:stratum 0} status-label
+  [status]
+  (messages/t (keyword "status" (str "value-" (name status)))))

--- a/bases/cli/test/ai/miniforge/cli/main_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main_test.clj
@@ -21,6 +21,7 @@
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.main :as sut]
+   [ai.miniforge.cli.main.util :as util]
    [ai.miniforge.cli.main.commands.pr-monitor :as cmd-pr-monitor]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.pr-train.interface :as pr-train]
@@ -128,7 +129,7 @@
                        :failed? false
                        :dag-paused? false
                        :event-count test-reconstructed-event-count})
-                    sut/current-time-ms (constantly now-ms)]
+                    util/current-time-ms (constantly now-ms)]
         (is (= :stale
                (:status (#'sut/workflow-status-summary "workflow-id"))))))))
 
@@ -149,7 +150,7 @@
                        :failed? false
                        :dag-paused? false
                        :event-count test-reconstructed-event-count})
-                    sut/current-time-ms (constantly now-ms)]
+                    util/current-time-ms (constantly now-ms)]
         (is (= :running
                (:status (#'sut/workflow-status-summary "workflow-id"))))))))
 
@@ -170,7 +171,7 @@
                        :failed? false
                        :dag-paused? false
                        :event-count test-reconstructed-event-count})
-                    sut/current-time-ms (constantly now-ms)]
+                    util/current-time-ms (constantly now-ms)]
         (is (= :stale
                (:status (#'sut/workflow-status-summary "workflow-id"))))))))
 

--- a/docs/pull-requests/2026-08-18-refactor-split-cli-main-1.md
+++ b/docs/pull-requests/2026-08-18-refactor-split-cli-main-1.md
@@ -1,0 +1,136 @@
+<!--
+  Title: Split bases/cli/.../main.clj — extract main/util.clj (1/9)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(cli): split main.clj — extract main/util.clj (1/9)
+
+## Overview
+
+`bases/cli/src/ai/miniforge/cli/main.clj` trips stratum-lint SL003: 8
+distinct real layers, max 3 (rule 210, `standards/miniforge`). This is
+slice 1 of a 9-PR split following the mdc_compiler.clj (#1729-#1743)
+and loader.clj (#1772) precedent: one cohesive concern per namespace,
+each new file within the 3-layer budget, mechanical moves only.
+
+This slice extracts `ai.miniforge.cli.main.util`: the seven
+dependency-light leaf helpers used throughout the rest of the file —
+`optional-composition-var`, `caught-message`, `current-time-ms`,
+`get-opts`, `check-command`, `timestamp->epoch-ms`, `status-label`.
+None of the seven reference each other, so the new namespace is one
+real layer.
+
+## Motivation
+
+`main.clj` is the CLI entry point (bases/cli), 899 lines, the largest
+file in this batch of the stratum-lint rule-210 program. It has real
+fan-in (checked below), unlike most components split so far in this
+program, so the split is done carefully: `util.clj` first because
+nearly every other function in the file calls at least one of these
+seven helpers, and every remaining namespace introduced later in the
+train needs `util` available to require.
+
+## Changes in Detail
+
+- New file `main/util.clj`: `optional-composition-var`,
+  `caught-message`, `current-time-ms`, `get-opts`, `check-command`,
+  `timestamp->epoch-ms`, `status-label`. 1 real layer. Four of the
+  seven (`optional-composition-var`, `caught-message`,
+  `timestamp->epoch-ms`, `status-label`) were `defn-` (private) in
+  `main.clj`; made public (`defn`) since callers now cross a namespace
+  boundary — the only visibility change in this slice.
+- `main.clj`: the seven bodies removed; every call site across the
+  file (~50 of them, spanning nearly every command function) requalified
+  to `util/<name>`. Split across two commits to stay under the
+  200-line commit budget: 2a requalifies call sites (defs still present,
+  now dead code — kept temporarily so the intermediate state compiles
+  clean), 2b deletes the seven dead defs and drops the now-unused
+  `babashka.process` require (`check-command` was its only caller).
+  `main.clj` is still over the SL003 budget (7 layers, down from 8)
+  until the rest of the train lands —
+  `MINIFORGE_STRATUM_BUDGET_MODE=warn` used for both intermediate
+  commits, same convention as the mdc_compiler.clj train.
+- `main_test.clj`: `with-redefs [sut/current-time-ms ...]` (three
+  call sites, all in the `workflow-status-summary` staleness tests)
+  updated to `util/current-time-ms` — `current-time-ms` moved, and
+  `workflow-status-summary` (still in `main.clj`, moves in a later
+  slice) now calls the qualified var, so the test must redefine the
+  var where it now lives.
+
+This is pure code motion aside from the two required visibility
+changes and the one test call-site update above — no helper's logic
+changed.
+
+## Fan-in Check
+
+`main.clj` is a CLI entry point, so fan-in was checked carefully
+(fully-qualified namespace grep, not a symbol-prefix guess) across
+`components`, `bases`, and `projects` before starting:
+
+- `bases/cli/test/ai/miniforge/cli/main_test.clj` — `:as sut`, direct
+  white-box test of `main.clj` (updated above).
+- `projects/miniforge-core/test/ai/miniforge/workflow/kernel_loader_integration_test.clj`
+  — `:as main`, calls `main/help-cmd` — a project-level test not in
+  `bb test`'s change-scope, verified directly. `help-cmd` is untouched
+  in this slice (moves in a later slice); no change needed here.
+- `projects/{miniforge,miniforge-core,miniforge-tui}/deps.edn` — `:main
+  ai.miniforge.cli.main` entry-point declarations (data, not code);
+  the namespace itself isn't renamed, so these are unaffected.
+- No other fully-qualified reference to `ai.miniforge.cli.main`
+  anywhere in the repo.
+
+None of the seven moved symbols (`get-opts`, `check-command`,
+`current-time-ms`, `timestamp->epoch-ms`, `status-label`,
+`caught-message`, `optional-composition-var`) had any caller outside
+`main.clj` itself before this slice.
+
+## Testing Plan
+
+- `stratum-lint`: `main/util.clj` clean (exit 0). `main.clj` still
+  SL003 (7 layers) — expected, tracked, resolves across the rest of
+  the train.
+- `clj-kondo` clean on every touched/new file (0 errors, 0 warnings).
+- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.main-test)
+  (clojure.test/run-tests 'ai.miniforge.cli.main-test)"`: 10 tests / 37
+  assertions, 0 failures, 0 errors.
+- `projects/miniforge-core`'s `kernel_loader_integration_test.clj` not
+  re-run in this slice (untouched code path — `help-cmd` didn't move);
+  will be re-verified directly in the slice that moves `help-cmd`.
+- Pre-commit's smoke suite (`bb pre-commit`) ran clean on all three
+  commits: 345 tests / 1301 assertions, plus 8 GraalVM compatibility
+  tests / 638 assertions, 0 failures throughout.
+
+## Deployment Plan
+
+Merges to `main` as part of an ongoing 9-PR train. Each subsequent PR
+rebases onto the updated `main` after the prior one merges.
+
+## Related Issues/PRs
+
+- Precedent: [mdc_compiler.clj split, miniforge#1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1729) (6-PR
+  train, closest precedent for a file this size)
+- Precedent: [loader.clj split, miniforge#1772](https://github.com/miniforge-ai/miniforge/pull/1772) (fan-in-check
+  methodology this PR follows)
+- Part of the stratum-lint rule-210 remediation program (bases/cli batch)
+
+## Checklist
+
+- [x] Zero unaccounted-for fan-in confirmed via fully-qualified
+      namespace grep before starting, including project-level tests
+- [x] Pure code motion — no behavior changes, two required
+      defn-\-\>defn visibility flips documented above
+- [x] `stratum-lint` clean on the new file; `main.clj`'s remaining
+      over-budget state tracked and expected mid-train
+- [x] `clj-kondo` clean
+- [x] Tests green (10/10, 37 assertions) + full pre-commit smoke suite
+      (345/345, 1301 assertions) on every commit
+- [x] PR-diff and commit-diff budgets checked (3 commits: 62, 146, 53
+      reportable lines; well under the 600/200 ceilings)
+- [x] Adversarial self-review: diffed `main.clj` end to end against
+      the original — every relocated def is byte-identical apart from
+      its `:stratum` tag/heading and call-site qualification; no def
+      added, removed, or behaviorally altered beyond the two
+      documented visibility flips
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/pull-requests/2026-08-18-refactor-split-cli-main-1.md
+++ b/docs/pull-requests/2026-08-18-refactor-split-cli-main-1.md
@@ -39,7 +39,7 @@ train needs `util` available to require.
   seven (`optional-composition-var`, `caught-message`,
   `timestamp->epoch-ms`, `status-label`) were `defn-` (private) in
   `main.clj`; made public (`defn`) since callers now cross a namespace
-  boundary — the only visibility change in this slice.
+  boundary — the only visibility changes in this slice.
 - `main.clj`: the seven bodies removed; every call site across the
   file (~50 of them, spanning nearly every command function) requalified
   to `util/<name>`. Split across two commits to stay under the
@@ -58,7 +58,7 @@ train needs `util` available to require.
   slice) now calls the qualified var, so the test must redefine the
   var where it now lives.
 
-This is pure code motion aside from the two required visibility
+This is pure code motion aside from the four required visibility
 changes and the one test call-site update above — no helper's logic
 changed.
 
@@ -118,7 +118,7 @@ rebases onto the updated `main` after the prior one merges.
 
 - [x] Zero unaccounted-for fan-in confirmed via fully-qualified
       namespace grep before starting, including project-level tests
-- [x] Pure code motion — no behavior changes, two required
+- [x] Pure code motion — no behavior changes, four required
       defn-\-\>defn visibility flips documented above
 - [x] `stratum-lint` clean on the new file; `main.clj`'s remaining
       over-budget state tracked and expected mid-train
@@ -130,7 +130,7 @@ rebases onto the updated `main` after the prior one merges.
 - [x] Adversarial self-review: diffed `main.clj` end to end against
       the original — every relocated def is byte-identical apart from
       its `:stratum` tag/heading and call-site qualification; no def
-      added, removed, or behaviorally altered beyond the two
+      added, removed, or behaviorally altered beyond the four
       documented visibility flips
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
<!--
  Title: Split bases/cli/.../main.clj — extract main/util.clj (1/9)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(cli): split main.clj — extract main/util.clj (1/9)

## Overview

`bases/cli/src/ai/miniforge/cli/main.clj` trips stratum-lint SL003: 8
distinct real layers, max 3 (rule 210, `standards/miniforge`). This is
slice 1 of a 9-PR split following the mdc_compiler.clj (#1729-#1743)
and loader.clj (#1772) precedent: one cohesive concern per namespace,
each new file within the 3-layer budget, mechanical moves only.

This slice extracts `ai.miniforge.cli.main.util`: the seven
dependency-light leaf helpers used throughout the rest of the file —
`optional-composition-var`, `caught-message`, `current-time-ms`,
`get-opts`, `check-command`, `timestamp->epoch-ms`, `status-label`.
None of the seven reference each other, so the new namespace is one
real layer.

## Motivation

`main.clj` is the CLI entry point (bases/cli), 899 lines, the largest
file in this batch of the stratum-lint rule-210 program. It has real
fan-in (checked below), unlike most components split so far in this
program, so the split is done carefully: `util.clj` first because
nearly every other function in the file calls at least one of these
seven helpers, and every remaining namespace introduced later in the
train needs `util` available to require.

## Changes in Detail

- New file `main/util.clj`: `optional-composition-var`,
  `caught-message`, `current-time-ms`, `get-opts`, `check-command`,
  `timestamp->epoch-ms`, `status-label`. 1 real layer. Four of the
  seven (`optional-composition-var`, `caught-message`,
  `timestamp->epoch-ms`, `status-label`) were `defn-` (private) in
  `main.clj`; made public (`defn`) since callers now cross a namespace
  boundary — the only visibility change in this slice.
- `main.clj`: the seven bodies removed; every call site across the
  file (~50 of them, spanning nearly every command function) requalified
  to `util/<name>`. Split across two commits to stay under the
  200-line commit budget: 2a requalifies call sites (defs still present,
  now dead code — kept temporarily so the intermediate state compiles
  clean), 2b deletes the seven dead defs and drops the now-unused
  `babashka.process` require (`check-command` was its only caller).
  `main.clj` is still over the SL003 budget (7 layers, down from 8)
  until the rest of the train lands —
  `MINIFORGE_STRATUM_BUDGET_MODE=warn` used for both intermediate
  commits, same convention as the mdc_compiler.clj train.
- `main_test.clj`: `with-redefs [sut/current-time-ms ...]` (three
  call sites, all in the `workflow-status-summary` staleness tests)
  updated to `util/current-time-ms` — `current-time-ms` moved, and
  `workflow-status-summary` (still in `main.clj`, moves in a later
  slice) now calls the qualified var, so the test must redefine the
  var where it now lives.

This is pure code motion aside from the two required visibility
changes and the one test call-site update above — no helper's logic
changed.

## Fan-in Check

`main.clj` is a CLI entry point, so fan-in was checked carefully
(fully-qualified namespace grep, not a symbol-prefix guess) across
`components`, `bases`, and `projects` before starting:

- `bases/cli/test/ai/miniforge/cli/main_test.clj` — `:as sut`, direct
  white-box test of `main.clj` (updated above).
- `projects/miniforge-core/test/ai/miniforge/workflow/kernel_loader_integration_test.clj`
  — `:as main`, calls `main/help-cmd` — a project-level test not in
  `bb test`'s change-scope, verified directly. `help-cmd` is untouched
  in this slice (moves in a later slice); no change needed here.
- `projects/{miniforge,miniforge-core,miniforge-tui}/deps.edn` — `:main
  ai.miniforge.cli.main` entry-point declarations (data, not code);
  the namespace itself isn't renamed, so these are unaffected.
- No other fully-qualified reference to `ai.miniforge.cli.main`
  anywhere in the repo.

None of the seven moved symbols (`get-opts`, `check-command`,
`current-time-ms`, `timestamp->epoch-ms`, `status-label`,
`caught-message`, `optional-composition-var`) had any caller outside
`main.clj` itself before this slice.

## Testing Plan

- `stratum-lint`: `main/util.clj` clean (exit 0). `main.clj` still
  SL003 (7 layers) — expected, tracked, resolves across the rest of
  the train.
- `clj-kondo` clean on every touched/new file (0 errors, 0 warnings).
- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.main-test)
  (clojure.test/run-tests 'ai.miniforge.cli.main-test)"`: 10 tests / 37
  assertions, 0 failures, 0 errors.
- `projects/miniforge-core`'s `kernel_loader_integration_test.clj` not
  re-run in this slice (untouched code path — `help-cmd` didn't move);
  will be re-verified directly in the slice that moves `help-cmd`.
- Pre-commit's smoke suite (`bb pre-commit`) ran clean on all three
  commits: 345 tests / 1301 assertions, plus 8 GraalVM compatibility
  tests / 638 assertions, 0 failures throughout.

## Deployment Plan

Merges to `main` as part of an ongoing 9-PR train. Each subsequent PR
rebases onto the updated `main` after the prior one merges.

## Related Issues/PRs

- Precedent: [mdc_compiler.clj split, miniforge#1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1729) (6-PR
  train, closest precedent for a file this size)
- Precedent: [loader.clj split, miniforge#1772](https://github.com/miniforge-ai/miniforge/pull/1772) (fan-in-check
  methodology this PR follows)
- Part of the stratum-lint rule-210 remediation program (bases/cli batch)

## Checklist

- [x] Zero unaccounted-for fan-in confirmed via fully-qualified
      namespace grep before starting, including project-level tests
- [x] Pure code motion — no behavior changes, two required
      defn-\-\>defn visibility flips documented above
- [x] `stratum-lint` clean on the new file; `main.clj`'s remaining
      over-budget state tracked and expected mid-train
- [x] `clj-kondo` clean
- [x] Tests green (10/10, 37 assertions) + full pre-commit smoke suite
      (345/345, 1301 assertions) on every commit
- [x] PR-diff and commit-diff budgets checked (3 commits: 62, 146, 53
      reportable lines; well under the 600/200 ceilings)
- [x] Adversarial self-review: diffed `main.clj` end to end against
      the original — every relocated def is byte-identical apart from
      its `:stratum` tag/heading and call-site qualification; no def
      added, removed, or behaviorally altered beyond the two
      documented visibility flips

🤖 Generated with [Claude Code](https://claude.com/claude-code)
