### PR TITLE
refactor(cli): split tui.clj (rule 210)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/tui.clj
+++ b/bases/cli/src/ai/miniforge/cli/tui.clj
@@ -27,6 +27,8 @@
    The key insight: AI pre-digests content to reduce cognitive load.
    PRs get risk scores, summaries, and suggested actions."
   (:require
+   [ai.miniforge.cli.tui.risk :as risk]
+   [ai.miniforge.cli.tui.terminal :as terminal]
    [babashka.process :as process]
    [clojure.string :as str]))
 
@@ -187,6 +189,51 @@
     (str (subs s 0 (- max-len 1)) "…")
     s))
 
+(defn ^{:stratum 0} render-box
+  "Render a box with title and content lines.
+   Uses blue borders for XTreeGold-style visibility.
+   Returns vector of strings (one per line)."
+  [title lines width height]
+  (let [inner-width (- width 2)
+        title-str (terminal/truncate (or title "") (- inner-width 4))
+        ;; Blue borders with bright title
+        top-line (str (terminal/style "┌─ " :fg :blue) (terminal/style title-str :fg :bright-white :bold true)
+                      (terminal/style " " :fg :blue) (terminal/style (terminal/repeat-char "─" (- inner-width (count title-str) 3)) :fg :blue)
+                      (terminal/style "┐" :fg :blue))
+        bottom-line (str (terminal/style "└" :fg :blue) (terminal/style (terminal/repeat-char "─" inner-width) :fg :blue) (terminal/style "┘" :fg :blue))
+        content-height (- height 2)
+        padded-lines (take content-height
+                           (concat (map #(str (terminal/style "│" :fg :blue)
+                                              (terminal/pad-right (terminal/truncate % inner-width) inner-width)
+                                              (terminal/style "│" :fg :blue))
+                                        lines)
+                                   (repeat (str (terminal/style "│" :fg :blue)
+                                                (terminal/repeat-char " " inner-width)
+                                                (terminal/style "│" :fg :blue)))))]
+    (vec (concat [top-line] padded-lines [bottom-line]))))
+
+(defn ^{:stratum 0} render-tree-item
+  "Render a single tree item with proper indentation and icons.
+   Uses XTreeGold-inspired blue highlight for selected items."
+  [{:keys [label selected? expanded? has-children? depth risk]} width]
+  (let [indent (terminal/repeat-char " " (* 2 depth))
+        icon (cond
+               (and has-children? expanded?) "▼"
+               has-children? "▸"
+               :else " ")
+        risk-indicator (when risk
+                         (str (terminal/style (get risk/risk-icons risk "○")
+                                     :fg (get risk/risk-colors risk :white)) " "))
+        prefix (str indent icon " " (or risk-indicator ""))
+        label-width (- width (count prefix) 2)
+        formatted-label (terminal/truncate label label-width)
+        line-content (terminal/pad-right (str prefix formatted-label) width)]
+    (if selected?
+      ;; XTreeGold style: bright white on blue background
+      (terminal/style line-content :fg :bright-white :bg :bg-blue :bold true)
+      ;; Normal: bright cyan text for visibility
+      (terminal/style line-content :fg :bright-cyan))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} style
@@ -217,51 +264,6 @@
       (str s (repeat-char " " (- width len))))))
 
 ;------------------------------------------------------------------------------ Layer 2
-
-(defn ^{:stratum 2} render-box
-  "Render a box with title and content lines.
-   Uses blue borders for XTreeGold-style visibility.
-   Returns vector of strings (one per line)."
-  [title lines width height]
-  (let [inner-width (- width 2)
-        title-str (truncate (or title "") (- inner-width 4))
-        ;; Blue borders with bright title
-        top-line (str (style "┌─ " :fg :blue) (style title-str :fg :bright-white :bold true)
-                      (style " " :fg :blue) (style (repeat-char "─" (- inner-width (count title-str) 3)) :fg :blue)
-                      (style "┐" :fg :blue))
-        bottom-line (str (style "└" :fg :blue) (style (repeat-char "─" inner-width) :fg :blue) (style "┘" :fg :blue))
-        content-height (- height 2)
-        padded-lines (take content-height
-                           (concat (map #(str (style "│" :fg :blue)
-                                              (pad-right (truncate % inner-width) inner-width)
-                                              (style "│" :fg :blue))
-                                        lines)
-                                   (repeat (str (style "│" :fg :blue)
-                                                (repeat-char " " inner-width)
-                                                (style "│" :fg :blue)))))]
-    (vec (concat [top-line] padded-lines [bottom-line]))))
-
-(defn ^{:stratum 2} render-tree-item
-  "Render a single tree item with proper indentation and icons.
-   Uses XTreeGold-inspired blue highlight for selected items."
-  [{:keys [label selected? expanded? has-children? depth risk]} width]
-  (let [indent (repeat-char " " (* 2 depth))
-        icon (cond
-               (and has-children? expanded?) "▼"
-               has-children? "▸"
-               :else " ")
-        risk-indicator (when risk
-                         (str (style (get risk-icons risk "○")
-                                     :fg (get risk-colors risk :white)) " "))
-        prefix (str indent icon " " (or risk-indicator ""))
-        label-width (- width (count prefix) 2)
-        formatted-label (truncate label label-width)
-        line-content (pad-right (str prefix formatted-label) width)]
-    (if selected?
-      ;; XTreeGold style: bright white on blue background
-      (style line-content :fg :bright-white :bg :bg-blue :bold true)
-      ;; Normal: bright cyan text for visibility
-      (style line-content :fg :bright-cyan))))
 
 ;; PR detail rendering
 (defn ^{:stratum 2} render-pr-detail
@@ -294,9 +296,7 @@
                  "[c] Chat      [o] Open in browser"
                  "[j/k] Navigate   [q] Back"]}]}))
 
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} render-two-pane
+(defn ^{:stratum 2} render-two-pane
   "Render a two-pane layout with XTreeGold-inspired color scheme.
 
    left-pane: {:title string :items [{:label :selected? :expanded? :has-children? :depth :risk}]}

--- a/bases/cli/src/ai/miniforge/cli/tui.clj
+++ b/bases/cli/src/ai/miniforge/cli/tui.clj
@@ -28,8 +28,7 @@
    PRs get risk scores, summaries, and suggested actions."
   (:require
    [babashka.process :as process]
-   [clojure.string :as str]
-   [cheshire.core :as json]))
+   [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -188,78 +187,6 @@
     (str (subs s 0 (- max-len 1)) "…")
     s))
 
-(defn ^{:stratum 0} render-repo-item
-  "Render a repo as a tree item."
-  [repo pr-count expanded? selected?]
-  {:label (str repo " (" pr-count ")")
-   :selected? selected?
-   :expanded? expanded?
-   :has-children? (pos? pr-count)
-   :depth 0})
-
-;; Interactive navigation state
-(defn ^{:stratum 0} create-nav-state
-  "Create initial navigation state for the two-pane view."
-  [repos-with-prs]
-  {:repos repos-with-prs
-   :expanded-repos #{}
-   :selected-index 0
-   :flat-items [] ; computed from repos + expansion state
-   :mode :browse})  ; :browse, :detail, :chat
-
-(defn ^{:stratum 0} flatten-nav-items
-  "Flatten repos and PRs into a navigable list based on expansion state."
-  [{:keys [repos expanded-repos]}]
-  (vec (mapcat (fn [{:keys [repo prs]}]
-                 (let [expanded? (contains? expanded-repos repo)]
-                   (concat [{:type :repo :repo repo :prs prs :expanded? expanded?}]
-                           (when expanded?
-                             (map #(assoc % :type :pr :repo repo) prs)))))
-               repos)))
-
-(defn ^{:stratum 0} nav-up [state]
-  (update state :selected-index #(max 0 (dec %))))
-
-(defn ^{:stratum 0} nav-down [state]
-  (let [max-idx (dec (count (:flat-items state)))]
-    (update state :selected-index #(min max-idx (inc %)))))
-
-(defn ^{:stratum 0} get-selected-item [state]
-  (get-in state [:flat-items (:selected-index state)]))
-
-;; GitHub integration
-(defn ^{:stratum 0} fetch-pr-details
-  "Fetch detailed PR info including additions/deletions."
-  [repo number]
-  (let [result (process/sh "gh" "pr" "view" (str number)
-                           "--repo" repo
-                           "--json" "number,title,state,author,url,additions,deletions,changedFiles,body")]
-    (when (zero? (:exit result))
-      (try
-        (json/parse-string (:out result) true)
-        (catch Exception _ nil)))))
-
-;; Keyboard input handling
-(defn ^{:stratum 0} map-char-to-key
-  "Map a character to a key command."
-  [c]
-  (case c
-    \j :down
-    \k :up
-    \q :quit
-    \a :approve
-    \r :reject
-    \d :diff
-    \c :chat
-    \o :open
-    \b :batch-approve
-    \n :next-risky
-    \space :toggle
-    \return :enter
-    \newline :enter
-    ;; Default
-    c))
-
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} style
@@ -288,62 +215,6 @@
     (if (>= len width)
       (subs s 0 width)
       (str s (repeat-char " " (- width len))))))
-
-(defn ^{:stratum 1} render-pr-list-item
-  "Render a PR as a tree item."
-  [{:keys [number title]} analysis selected?]
-  {:label (str "#" number " " (truncate title 35))
-   :selected? selected?
-   :expanded? false
-   :has-children? false
-   :depth 1
-   :risk (:risk analysis)})
-
-(defn ^{:stratum 1} update-flat-items
-  "Recompute flat items after state change."
-  [state]
-  (assoc state :flat-items (flatten-nav-items state)))
-
-(defn ^{:stratum 1} fetch-prs-for-repos
-  "Fetch PRs for multiple repos with analysis."
-  [repos]
-  (vec (for [repo repos]
-         (let [result (process/sh "gh" "pr" "list" "--repo" repo
-                                  "--json" "number,title,state,author,url,additions,deletions,changedFiles"
-                                  "--limit" "20")
-               prs (when (zero? (:exit result))
-                     (try
-                       (json/parse-string (:out result) true)
-                       (catch Exception _ [])))]
-           {:repo repo
-            :prs (vec (for [pr prs]
-                        (assoc pr
-                               :repo repo
-                               :analysis (analyze-pr-risk pr))))}))))
-
-(defn ^{:stratum 1} read-key
-  "Read a single keypress without requiring Enter.
-   Uses stty raw mode with direct /dev/tty access.
-   Returns keyword for special keys, char otherwise."
-  []
-  (try
-    ;; Set terminal to raw mode, read one char, restore
-    (process/sh "stty" "raw" "-echo" :in (java.io.File. "/dev/tty"))
-    (let [tty-stream (java.io.FileInputStream. "/dev/tty")
-          char-code (.read tty-stream)]
-      (.close tty-stream)
-      (process/sh "stty" "cooked" "echo" :in (java.io.File. "/dev/tty"))
-      (cond
-        ;; EOF or error
-        (neg? char-code) :escape
-        ;; Escape key (ASCII 27)
-        (= char-code 27) :escape
-        ;; Map character to command
-        :else (map-char-to-key (char char-code))))
-    (catch Exception _
-      ;; Try to restore terminal on error
-      (try (process/sh "stty" "cooked" "echo" :in (java.io.File. "/dev/tty")) (catch Exception _))
-      :error)))
 
 ;------------------------------------------------------------------------------ Layer 2
 
@@ -422,16 +293,6 @@
        :content ["[a] Approve   [r] Reject   [d] View diff"
                  "[c] Chat      [o] Open in browser"
                  "[j/k] Navigate   [q] Back"]}]}))
-
-(defn ^{:stratum 2} toggle-expand [state]
-  (let [item (get-in state [:flat-items (:selected-index state)])]
-    (if (= :repo (:type item))
-      (-> state
-          (update :expanded-repos #(if (contains? % (:repo item))
-                                     (disj % (:repo item))
-                                     (conj % (:repo item))))
-          update-flat-items)
-      state)))
 
 ;------------------------------------------------------------------------------ Layer 3
 

--- a/bases/cli/src/ai/miniforge/cli/tui.clj
+++ b/bases/cli/src/ai/miniforge/cli/tui.clj
@@ -25,169 +25,25 @@
    - Information density with progressive disclosure
 
    The key insight: AI pre-digests content to reduce cognitive load.
-   PRs get risk scores, summaries, and suggested actions."
+   PRs get risk scores, summaries, and suggested actions.
+
+   Layer 0: Box/tree/detail rendering (each only calls
+            `ai.miniforge.cli.tui.terminal`/`.risk`, not each other)
+   Layer 1: Two-pane composition, orchestrating the layer-0 renderers
+
+   ANSI/terminal primitives, risk heuristics, and nav/keyboard/GitHub
+   interaction live in sibling `ai.miniforge.cli.tui.*` namespaces
+   (rule 210: the combined namespace measured 4 real layers, max 3).
+   Extracting those also shortened this namespace's own in-file call
+   chain — the moved code's hops no longer count toward local layer
+   depth, so the remaining rendering code now measures 2 real layers
+   on its own, within budget."
   (:require
    [ai.miniforge.cli.tui.risk :as risk]
    [ai.miniforge.cli.tui.terminal :as terminal]
-   [babashka.process :as process]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-;; Terminal utilities
-(def ^{:stratum 0} ansi-colors
-  "ANSI color codes for foreground colors."
-  {:red     "31"
-   :green   "32"
-   :yellow  "33"
-   :blue    "34"
-   :magenta "35"
-   :cyan    "36"
-   :white   "37"
-   :gray    "90"
-   :bright-red "91"
-   :bright-green "92"
-   :bright-yellow "93"
-   :bright-blue "94"
-   :bright-magenta "95"
-   :bright-cyan "96"
-   :bright-white "97"})
-
-(def ^{:stratum 0} ansi-bg-colors
-  "ANSI color codes for background colors."
-  {:bg-black "40"
-   :bg-red "41"
-   :bg-green "42"
-   :bg-yellow "43"
-   :bg-blue "44"
-   :bg-magenta "45"
-   :bg-cyan "46"
-   :bg-white "47"
-   :bg-bright-blue "104"
-   :bg-bright-cyan "106"})
-
-(defn ^{:stratum 0} clear-screen []
-  (print "\033[2J\033[H")
-  (flush))
-
-(defn ^{:stratum 0} move-cursor [row col]
-  (print (str "\033[" row ";" col "H"))
-  (flush))
-
-(defn ^{:stratum 0} get-terminal-size
-  "Get terminal dimensions [width height]."
-  []
-  (try
-    (let [result (process/sh "stty" "size" :in (java.io.FileInputStream. "/dev/tty"))
-          [h w] (str/split (str/trim (:out result)) #" ")]
-      [(Integer/parseInt w) (Integer/parseInt h)])
-    (catch Exception _
-      [120 40])))  ; fallback
-
-(defn ^{:stratum 0} hide-cursor []
-  (print "\033[?25l")
-  (flush))
-
-(defn ^{:stratum 0} show-cursor []
-  (print "\033[?25h")
-  (flush))
-
-;; Risk/complexity scoring
-(def ^{:stratum 0} risk-colors
-  {:low :green
-   :medium :yellow
-   :high :red})
-
-(def ^{:stratum 0} risk-icons
-  {:low "●"
-   :medium "◐"
-   :high "◉"})
-
-(defn ^{:stratum 0} analyze-pr-risk
-  "Analyze a PR and return risk assessment.
-
-   This is a heuristic-based analysis. In the future, this could
-   call an LLM for deeper analysis.
-
-   Returns:
-   {:risk :low/:medium/:high
-    :complexity :trivial/:simple/:moderate/:complex
-    :summary string
-    :suggested-action string
-    :reasons [string]}"
-  [{:keys [title additions deletions changedFiles] :as _pr}]
-  (let [;; Size-based heuristics
-        total-changes (+ (or additions 0) (or deletions 0))
-        file-count (or changedFiles 0)
-
-        ;; Pattern matching on title
-        title-lower (str/lower-case (or title ""))
-        is-deps? (or (str/includes? title-lower "bump")
-                     (str/includes? title-lower "deps")
-                     (str/includes? title-lower "dependency"))
-        is-docs? (or (str/includes? title-lower "readme")
-                     (str/includes? title-lower "docs")
-                     (str/includes? title-lower "documentation"))
-        is-fix? (str/includes? title-lower "fix")
-        is-refactor? (str/includes? title-lower "refactor")
-        is-feature? (or (str/includes? title-lower "add")
-                        (str/includes? title-lower "feat")
-                        (str/includes? title-lower "implement"))
-
-        ;; Calculate risk
-        risk (cond
-               ;; Low risk patterns
-               (and is-docs? (< total-changes 100)) :low
-               (and is-deps? (< file-count 3)) :low
-               (and (< total-changes 50) (< file-count 3)) :low
-
-               ;; High risk patterns
-               (> total-changes 500) :high
-               (> file-count 20) :high
-               (and is-refactor? (> total-changes 200)) :high
-
-               ;; Medium by default
-               :else :medium)
-
-        complexity (cond
-                     (< total-changes 20) :trivial
-                     (< total-changes 100) :simple
-                     (< total-changes 300) :moderate
-                     :else :complex)
-
-        ;; Generate summary
-        summary (cond
-                  is-docs? "Documentation update"
-                  is-deps? "Dependency version bump"
-                  is-fix? "Bug fix"
-                  is-refactor? "Code refactoring"
-                  is-feature? "New feature"
-                  :else "Code changes")
-
-        suggested-action (case risk
-                           :low "✓ Safe to merge"
-                           :medium "Review recommended"
-                           :high "⚠ Careful review needed")
-
-        reasons (cond-> []
-                  (> total-changes 300) (conj (str total-changes " lines changed"))
-                  (> file-count 10) (conj (str file-count " files modified"))
-                  is-refactor? (conj "Refactoring changes"))]
-
-    {:risk risk
-     :complexity complexity
-     :summary summary
-     :suggested-action suggested-action
-     :reasons reasons}))
-
-;; Two-pane layout rendering
-(defn ^{:stratum 0} repeat-char [c n]
-  (apply str (repeat n c)))
-
-(defn ^{:stratum 0} truncate [s max-len]
-  (if (> (count s) max-len)
-    (str (subs s 0 (- max-len 1)) "…")
-    s))
 
 (defn ^{:stratum 0} render-box
   "Render a box with title and content lines.
@@ -234,50 +90,19 @@
       ;; Normal: bright cyan text for visibility
       (terminal/style line-content :fg :bright-cyan))))
 
-;------------------------------------------------------------------------------ Layer 1
-
-(defn ^{:stratum 1} style
-  "Apply ANSI styling to text.
-
-   Options:
-   - :fg - Foreground color keyword
-   - :bg - Background color keyword (e.g. :bg-blue)
-   - :bold - Bold text
-   - :dim - Dim text
-   - :reverse - Reverse video (swap fg/bg)"
-  [text & {:keys [fg bg bold dim reverse]}]
-  (let [codes (cond-> []
-                bold (conj "1")
-                dim (conj "2")
-                reverse (conj "7")
-                fg (conj (get ansi-colors fg "37"))
-                bg (conj (get ansi-bg-colors bg)))]
-    (if (seq codes)
-      (str "\033[" (str/join ";" (remove nil? codes)) "m" text "\033[0m")
-      text)))
-
-(defn ^{:stratum 1} pad-right [s width]
-  (let [s (or s "")
-        len (count s)]
-    (if (>= len width)
-      (subs s 0 width)
-      (str s (repeat-char " " (- width len))))))
-
-;------------------------------------------------------------------------------ Layer 2
-
 ;; PR detail rendering
-(defn ^{:stratum 2} render-pr-detail
+(defn ^{:stratum 0} render-pr-detail
   "Render detailed view of a PR for the right pane."
   [{:keys [number title author state repo] :as _pr} analysis]
   (let [{:keys [risk complexity summary suggested-action reasons]} analysis]
-    {:title (str "PR #" number " " (truncate repo 30))
+    {:title (str "PR #" number " " (terminal/truncate repo 30))
      :sections
      [{:title "OVERVIEW"
        :content [(str "Title: " title)
                  (str "Author: " (get author :login "unknown"))
                  (str "State: " state)
-                 (str "Risk: " (style (str/upper-case (name risk))
-                                      :fg (get risk-colors risk :white) :bold true)
+                 (str "Risk: " (terminal/style (str/upper-case (name risk))
+                                      :fg (get risk/risk-colors risk :white) :bold true)
                       "  Complexity: " (str/upper-case (name complexity)))]}
 
       {:title "AI SUMMARY"
@@ -287,7 +112,7 @@
                    (str "Factors: " (str/join ", " reasons)))]}
 
       {:title "SUGGESTED ACTION"
-       :content [(style suggested-action
+       :content [(terminal/style suggested-action
                         :fg (case risk :low :green :medium :yellow :red)
                         :bold true)]}
 
@@ -296,7 +121,9 @@
                  "[c] Chat      [o] Open in browser"
                  "[j/k] Navigate   [q] Back"]}]}))
 
-(defn ^{:stratum 2} render-two-pane
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} render-two-pane
   "Render a two-pane layout with XTreeGold-inspired color scheme.
 
    left-pane: {:title string :items [{:label :selected? :expanded? :has-children? :depth :risk}]}
@@ -306,7 +133,7 @@
 
    Returns string ready to print."
   [{:keys [left-pane right-pane status-bar key-hints]}]
-  (let [[term-width term-height] (get-terminal-size)
+  (let [[term-width term-height] (terminal/get-terminal-size)
         left-width (int (* 0.4 term-width))
         right-width (- term-width left-width 1)
         content-height (- term-height 4) ; room for status + hints
@@ -317,43 +144,29 @@
 
         ;; Render right pane sections with better visibility
         right-lines (mapcat (fn [{:keys [title content]}]
-                              (concat [(style title :fg :bright-yellow :bold true)
-                                       (style (repeat-char "─" (- right-width 4)) :fg :blue)]
-                                      (map #(style % :fg :bright-white) content)
+                              (concat [(terminal/style title :fg :bright-yellow :bold true)
+                                       (terminal/style (terminal/repeat-char "─" (- right-width 4)) :fg :blue)]
+                                      (map #(terminal/style % :fg :bright-white) content)
                                       [""]))
                             (:sections right-pane))
         right-box (render-box (:title right-pane) right-lines right-width content-height)
 
         ;; Combine horizontally with blue separator
-        combined-lines (map (fn [l r] (str l (style "│" :fg :blue) r))
+        combined-lines (map (fn [l r] (str l (terminal/style "│" :fg :blue) r))
                             left-box
                             right-box)
 
         ;; Status bar: visible on dark background
-        status-line (pad-right (str " " (or status-bar "")) term-width)
+        status-line (terminal/pad-right (str " " (or status-bar "")) term-width)
         ;; Key hints: bright and visible, NOT dim
-        hints-line (pad-right (str " " (or key-hints "")) term-width)]
+        hints-line (terminal/pad-right (str " " (or key-hints "")) term-width)]
 
     (str/join "\n" (concat combined-lines
-                           [(style status-line :fg :bright-white :bg :bg-blue)]
-                           [(style hints-line :fg :bright-cyan :bold true)]))))
+                           [(terminal/style status-line :fg :bright-white :bg :bg-blue)]
+                           [(terminal/style hints-line :fg :bright-cyan :bold true)]))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
-  ;; Test risk analysis
-  (analyze-pr-risk {:title "Bump dependencies"
-                    :additions 10
-                    :deletions 5
-                    :changedFiles 2})
-
-  (analyze-pr-risk {:title "Refactor authentication system"
-                    :additions 500
-                    :deletions 300
-                    :changedFiles 25})
-
-  ;; Test terminal size
-  (get-terminal-size)
-
   ;; Test two-pane rendering
   (println (render-two-pane
             {:left-pane {:title "FLEET PRs"

--- a/bases/cli/src/ai/miniforge/cli/tui/interaction.clj
+++ b/bases/cli/src/ai/miniforge/cli/tui/interaction.clj
@@ -1,0 +1,181 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.tui.interaction
+  "Navigation state, GitHub data fetching, and keyboard input for the
+   two-pane TUI: the tree-item view models, the flat-list nav state
+   machine, `gh` CLI integration, and raw-mode key reading. Extracted
+   from `ai.miniforge.cli.tui` (rule 210: the combined namespace
+   measured 4 real layers, max 3)."
+  (:require
+   [ai.miniforge.cli.tui.risk :as risk]
+   [ai.miniforge.cli.tui.terminal :as terminal]
+   [babashka.process :as process]
+   [cheshire.core :as json]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Two-pane layout rendering
+(defn ^{:stratum 0} render-repo-item
+  "Render a repo as a tree item."
+  [repo pr-count expanded? selected?]
+  {:label (str repo " (" pr-count ")")
+   :selected? selected?
+   :expanded? expanded?
+   :has-children? (pos? pr-count)
+   :depth 0})
+
+;; Interactive navigation state
+(defn ^{:stratum 0} create-nav-state
+  "Create initial navigation state for the two-pane view."
+  [repos-with-prs]
+  {:repos repos-with-prs
+   :expanded-repos #{}
+   :selected-index 0
+   :flat-items [] ; computed from repos + expansion state
+   :mode :browse})  ; :browse, :detail, :chat
+
+(defn ^{:stratum 0} flatten-nav-items
+  "Flatten repos and PRs into a navigable list based on expansion state."
+  [{:keys [repos expanded-repos]}]
+  (vec (mapcat (fn [{:keys [repo prs]}]
+                 (let [expanded? (contains? expanded-repos repo)]
+                   (concat [{:type :repo :repo repo :prs prs :expanded? expanded?}]
+                           (when expanded?
+                             (map #(assoc % :type :pr :repo repo) prs)))))
+               repos)))
+
+(defn ^{:stratum 0} nav-up [state]
+  (update state :selected-index #(max 0 (dec %))))
+
+(defn ^{:stratum 0} nav-down [state]
+  (let [max-idx (dec (count (:flat-items state)))]
+    (update state :selected-index #(min max-idx (inc %)))))
+
+(defn ^{:stratum 0} get-selected-item [state]
+  (get-in state [:flat-items (:selected-index state)]))
+
+;; GitHub integration
+(defn ^{:stratum 0} fetch-pr-details
+  "Fetch detailed PR info including additions/deletions."
+  [repo number]
+  (let [result (process/sh "gh" "pr" "view" (str number)
+                           "--repo" repo
+                           "--json" "number,title,state,author,url,additions,deletions,changedFiles,body")]
+    (when (zero? (:exit result))
+      (try
+        (json/parse-string (:out result) true)
+        (catch Exception _ nil)))))
+
+;; Keyboard input handling
+(defn ^{:stratum 0} map-char-to-key
+  "Map a character to a key command."
+  [c]
+  (case c
+    \j :down
+    \k :up
+    \q :quit
+    \a :approve
+    \r :reject
+    \d :diff
+    \c :chat
+    \o :open
+    \b :batch-approve
+    \n :next-risky
+    \space :toggle
+    \return :enter
+    \newline :enter
+    ;; Default
+    c))
+
+(defn ^{:stratum 0} render-pr-list-item
+  "Render a PR as a tree item."
+  [{:keys [number title]} analysis selected?]
+  {:label (str "#" number " " (terminal/truncate title 35))
+   :selected? selected?
+   :expanded? false
+   :has-children? false
+   :depth 1
+   :risk (:risk analysis)})
+
+(defn ^{:stratum 0} fetch-prs-for-repos
+  "Fetch PRs for multiple repos with analysis."
+  [repos]
+  (vec (for [repo repos]
+         (let [result (process/sh "gh" "pr" "list" "--repo" repo
+                                  "--json" "number,title,state,author,url,additions,deletions,changedFiles"
+                                  "--limit" "20")
+               prs (when (zero? (:exit result))
+                     (try
+                       (json/parse-string (:out result) true)
+                       (catch Exception _ [])))]
+           {:repo repo
+            :prs (vec (for [pr prs]
+                        (assoc pr
+                               :repo repo
+                               :analysis (risk/analyze-pr-risk pr))))}))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} update-flat-items
+  "Recompute flat items after state change."
+  [state]
+  (assoc state :flat-items (flatten-nav-items state)))
+
+(defn ^{:stratum 1} read-key
+  "Read a single keypress without requiring Enter.
+   Uses stty raw mode with direct /dev/tty access.
+   Returns keyword for special keys, char otherwise."
+  []
+  (try
+    ;; Set terminal to raw mode, read one char, restore
+    (process/sh "stty" "raw" "-echo" :in (java.io.File. "/dev/tty"))
+    (let [tty-stream (java.io.FileInputStream. "/dev/tty")
+          char-code (.read tty-stream)]
+      (.close tty-stream)
+      (process/sh "stty" "cooked" "echo" :in (java.io.File. "/dev/tty"))
+      (cond
+        ;; EOF or error
+        (neg? char-code) :escape
+        ;; Escape key (ASCII 27)
+        (= char-code 27) :escape
+        ;; Map character to command
+        :else (map-char-to-key (char char-code))))
+    (catch Exception _
+      ;; Try to restore terminal on error
+      (try (process/sh "stty" "cooked" "echo" :in (java.io.File. "/dev/tty")) (catch Exception _))
+      :error)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} toggle-expand [state]
+  (let [item (get-in state [:flat-items (:selected-index state)])]
+    (if (= :repo (:type item))
+      (-> state
+          (update :expanded-repos #(if (contains? % (:repo item))
+                                     (disj % (:repo item))
+                                     (conj % (:repo item))))
+          update-flat-items)
+      state)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (create-nav-state [{:repo "miniforge-ai/miniforge" :prs []}])
+
+  (map-char-to-key \j)
+
+  :end)

--- a/bases/cli/src/ai/miniforge/cli/tui/risk.clj
+++ b/bases/cli/src/ai/miniforge/cli/tui/risk.clj
@@ -1,0 +1,127 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.tui.risk
+  "PR risk/complexity heuristics: color and icon tables plus the
+   heuristic-based risk analysis. Extracted from `ai.miniforge.cli.tui`
+   (rule 210: the combined namespace measured 4 real layers, max 3)."
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Risk/complexity scoring
+(def ^{:stratum 0} risk-colors
+  {:low :green
+   :medium :yellow
+   :high :red})
+
+(def ^{:stratum 0} risk-icons
+  {:low "●"
+   :medium "◐"
+   :high "◉"})
+
+(defn ^{:stratum 0} analyze-pr-risk
+  "Analyze a PR and return risk assessment.
+
+   This is a heuristic-based analysis. In the future, this could
+   call an LLM for deeper analysis.
+
+   Returns:
+   {:risk :low/:medium/:high
+    :complexity :trivial/:simple/:moderate/:complex
+    :summary string
+    :suggested-action string
+    :reasons [string]}"
+  [{:keys [title additions deletions changedFiles] :as _pr}]
+  (let [;; Size-based heuristics
+        total-changes (+ (or additions 0) (or deletions 0))
+        file-count (or changedFiles 0)
+
+        ;; Pattern matching on title
+        title-lower (str/lower-case (or title ""))
+        is-deps? (or (str/includes? title-lower "bump")
+                     (str/includes? title-lower "deps")
+                     (str/includes? title-lower "dependency"))
+        is-docs? (or (str/includes? title-lower "readme")
+                     (str/includes? title-lower "docs")
+                     (str/includes? title-lower "documentation"))
+        is-fix? (str/includes? title-lower "fix")
+        is-refactor? (str/includes? title-lower "refactor")
+        is-feature? (or (str/includes? title-lower "add")
+                        (str/includes? title-lower "feat")
+                        (str/includes? title-lower "implement"))
+
+        ;; Calculate risk
+        risk (cond
+               ;; Low risk patterns
+               (and is-docs? (< total-changes 100)) :low
+               (and is-deps? (< file-count 3)) :low
+               (and (< total-changes 50) (< file-count 3)) :low
+
+               ;; High risk patterns
+               (> total-changes 500) :high
+               (> file-count 20) :high
+               (and is-refactor? (> total-changes 200)) :high
+
+               ;; Medium by default
+               :else :medium)
+
+        complexity (cond
+                     (< total-changes 20) :trivial
+                     (< total-changes 100) :simple
+                     (< total-changes 300) :moderate
+                     :else :complex)
+
+        ;; Generate summary
+        summary (cond
+                  is-docs? "Documentation update"
+                  is-deps? "Dependency version bump"
+                  is-fix? "Bug fix"
+                  is-refactor? "Code refactoring"
+                  is-feature? "New feature"
+                  :else "Code changes")
+
+        suggested-action (case risk
+                           :low "✓ Safe to merge"
+                           :medium "Review recommended"
+                           :high "⚠ Careful review needed")
+
+        reasons (cond-> []
+                  (> total-changes 300) (conj (str total-changes " lines changed"))
+                  (> file-count 10) (conj (str file-count " files modified"))
+                  is-refactor? (conj "Refactoring changes"))]
+
+    {:risk risk
+     :complexity complexity
+     :summary summary
+     :suggested-action suggested-action
+     :reasons reasons}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (analyze-pr-risk {:title "Bump dependencies"
+                    :additions 10
+                    :deletions 5
+                    :changedFiles 2})
+
+  (analyze-pr-risk {:title "Refactor authentication system"
+                    :additions 500
+                    :deletions 300
+                    :changedFiles 25})
+
+  :end)

--- a/bases/cli/src/ai/miniforge/cli/tui/terminal.clj
+++ b/bases/cli/src/ai/miniforge/cli/tui/terminal.clj
@@ -1,0 +1,132 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.tui.terminal
+  "ANSI/terminal primitives: raw escape-sequence control, color tables,
+   ANSI styling, and small string layout helpers. Extracted from
+   `ai.miniforge.cli.tui` (rule 210: the combined namespace measured 4
+   real layers, max 3)."
+  (:require
+   [babashka.process :as process]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Terminal utilities
+(def ^{:stratum 0} ansi-colors
+  "ANSI color codes for foreground colors."
+  {:red     "31"
+   :green   "32"
+   :yellow  "33"
+   :blue    "34"
+   :magenta "35"
+   :cyan    "36"
+   :white   "37"
+   :gray    "90"
+   :bright-red "91"
+   :bright-green "92"
+   :bright-yellow "93"
+   :bright-blue "94"
+   :bright-magenta "95"
+   :bright-cyan "96"
+   :bright-white "97"})
+
+(def ^{:stratum 0} ansi-bg-colors
+  "ANSI color codes for background colors."
+  {:bg-black "40"
+   :bg-red "41"
+   :bg-green "42"
+   :bg-yellow "43"
+   :bg-blue "44"
+   :bg-magenta "45"
+   :bg-cyan "46"
+   :bg-white "47"
+   :bg-bright-blue "104"
+   :bg-bright-cyan "106"})
+
+(defn ^{:stratum 0} clear-screen []
+  (print "\033[2J\033[H")
+  (flush))
+
+(defn ^{:stratum 0} move-cursor [row col]
+  (print (str "\033[" row ";" col "H"))
+  (flush))
+
+(defn ^{:stratum 0} get-terminal-size
+  "Get terminal dimensions [width height]."
+  []
+  (try
+    (let [result (process/sh "stty" "size" :in (java.io.FileInputStream. "/dev/tty"))
+          [h w] (str/split (str/trim (:out result)) #" ")]
+      [(Integer/parseInt w) (Integer/parseInt h)])
+    (catch Exception _
+      [120 40])))  ; fallback
+
+(defn ^{:stratum 0} hide-cursor []
+  (print "\033[?25l")
+  (flush))
+
+(defn ^{:stratum 0} show-cursor []
+  (print "\033[?25h")
+  (flush))
+
+(defn ^{:stratum 0} repeat-char [c n]
+  (apply str (repeat n c)))
+
+(defn ^{:stratum 0} truncate [s max-len]
+  (if (> (count s) max-len)
+    (str (subs s 0 (- max-len 1)) "…")
+    s))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} style
+  "Apply ANSI styling to text.
+
+   Options:
+   - :fg - Foreground color keyword
+   - :bg - Background color keyword (e.g. :bg-blue)
+   - :bold - Bold text
+   - :dim - Dim text
+   - :reverse - Reverse video (swap fg/bg)"
+  [text & {:keys [fg bg bold dim reverse]}]
+  (let [codes (cond-> []
+                bold (conj "1")
+                dim (conj "2")
+                reverse (conj "7")
+                fg (conj (get ansi-colors fg "37"))
+                bg (conj (get ansi-bg-colors bg)))]
+    (if (seq codes)
+      (str "\033[" (str/join ";" (remove nil? codes)) "m" text "\033[0m")
+      text)))
+
+(defn ^{:stratum 1} pad-right [s width]
+  (let [s (or s "")
+        len (count s)]
+    (if (>= len width)
+      (subs s 0 width)
+      (str s (repeat-char " " (- width len))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (get-terminal-size)
+
+  (style "hello" :fg :bright-cyan :bold true)
+
+  (pad-right "abc" 6)
+
+  :end)

--- a/docs/pull-requests/2026-08-19-refactor-split-cli-tui.md
+++ b/docs/pull-requests/2026-08-19-refactor-split-cli-tui.md
@@ -136,7 +136,9 @@ already-known SL003 finding this PR exists to fix — not for anything
       existing test file to run instead)
 - [x] Pre-commit smoke suite green on every commit (not just the last)
 - [x] PR-diff and commit-diff budgets checked (492 insertions / 378
-      deletions across 4 files, 199 reportable lines max per commit)
+      deletions across the 4 code files — 5 files counting this PR
+      doc, which the reportable-line filter excludes — 199 reportable
+      lines max per commit)
 - [x] Adversarial self-review: diffed `tui.clj` end to end against the
       original — every relocated def is byte-identical apart from its
       `:stratum` tag/heading and call-site qualification; no def

--- a/docs/pull-requests/2026-08-19-refactor-split-cli-tui.md
+++ b/docs/pull-requests/2026-08-19-refactor-split-cli-tui.md
@@ -1,0 +1,143 @@
+<!--
+  Title: Split cli/tui.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(cli): split tui.clj (rule 210)
+
+## Overview
+
+Splits `ai.miniforge.cli.tui` (bases/cli) into three new sibling
+namespaces, resolving a stratum-lint SL003 finding (the combined
+namespace measured 4 real layers, over the rule 210 budget of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program, bases/cli
+batch. `tui.clj` (508 lines) was flagged directly: `stratum-lint`
+reported `SL003 file uses 4 distinct layers (max 3)`.
+
+## Changes in Detail
+
+- New file `tui/terminal.clj` (`ai.miniforge.cli.tui.terminal`): ANSI
+  color tables (`ansi-colors`, `ansi-bg-colors`), raw terminal control
+  (`clear-screen`, `move-cursor`, `get-terminal-size`, `hide-cursor`,
+  `show-cursor`), and small layout helpers (`repeat-char`, `truncate`,
+  `style`, `pad-right`). 2 real layers.
+- New file `tui/risk.clj` (`ai.miniforge.cli.tui.risk`): PR
+  risk/complexity heuristics (`risk-colors`, `risk-icons`,
+  `analyze-pr-risk`). 1 real layer.
+- New file `tui/interaction.clj` (`ai.miniforge.cli.tui.interaction`):
+  nav-tree item view models, the flat-list nav state machine, `gh` CLI
+  integration, and raw-mode keyboard input (`render-repo-item`,
+  `create-nav-state`, `flatten-nav-items`, `nav-up`, `nav-down`,
+  `get-selected-item`, `fetch-pr-details`, `map-char-to-key`,
+  `render-pr-list-item`, `update-flat-items`, `fetch-prs-for-repos`,
+  `read-key`, `toggle-expand`). 3 real layers.
+- `tui.clj`: the 27 defs above are deleted. What's left —
+  `render-box`, `render-tree-item`, `render-pr-detail`, and
+  `render-two-pane` — now calls `ai.miniforge.cli.tui.terminal` and
+  `ai.miniforge.cli.tui.risk` (qualified) instead of same-file defs.
+  With those hops no longer counting toward local layer depth, the
+  remaining rendering code measures 2 real layers on its own
+  (`stratum-lint` exit 0, confirmed directly). The ns docstring is
+  updated to describe the new layer shape and the sibling namespaces.
+  430 lines removed net, down to 182.
+
+This is pure code motion — no def was added, removed, or behaviorally
+altered beyond the call-site qualification the split itself requires.
+
+## Testing Plan
+
+- Repo-wide grep on the fully-qualified namespace
+  (`ai\.miniforge\.cli\.tui\b`, across `components`/`bases`/`projects`,
+  not a symbol-prefix guess) found **zero** external callers, before
+  and after the split — confirmed again on the final state. No test
+  file exists for `ai.miniforge.cli.tui` itself (none of the
+  `bases/cli/test/ai/miniforge/cli/` fixtures cover it), and no
+  `projects/miniforge/test/` caller references it either. Distinct
+  from the separate `ai.miniforge.tui-views.*` / `ai.miniforge.tui-engine.*`
+  components, which this PR does not touch.
+- `stratum-lint` clean (exit 0) on all four touched/new files,
+  confirmed directly (not just via the pre-commit autofix).
+- `clj-kondo` clean on all four files (0 errors, 0 warnings).
+- Direct namespace verification (no test file exists to run, so this
+  is a load + assertion smoke check exercising every def moved):
+  `clojure -Sdeps '{:paths ["src"] ...cli deps.edn deps...}' -M` a
+  script that requires all four namespaces and asserts on
+  `terminal/get-terminal-size`, `risk/analyze-pr-risk`,
+  `interaction/map-char-to-key`, `interaction/create-nav-state`, and
+  `tui/render-two-pane` — `ALL ASSERTIONS PASSED`, `REAL_EXIT_CODE=0`.
+- Pre-commit's smoke suite (`bb pre-commit`, cross-component) ran clean
+  on every one of the five commits: 345 tests / 1301 assertions, plus
+  8 GraalVM compatibility tests / 626 assertions, 0 failures
+  throughout.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file.
+
+## Related Issues/PRs
+
+- Precedent: `loader.clj` split, miniforge#1772 (the established
+  convention: extract cohesive layer-groups into sibling files under a
+  subdirectory named after the original file).
+- Precedent: `knowledge_safety.clj` split (2026-08-09) for the PR-doc
+  shape this follows.
+- Part of the stratum-lint rule-210 remediation program, bases/cli
+  batch.
+
+## Notes on commit sequencing
+
+Landing the full split in one commit would have exceeded the 200-line
+`commit-budget` ceiling (measured at 307 lines for the three new files
+alone, and 360 for the final `tui.clj` rewrite alone). Split into five
+commits instead:
+
+1. Add `tui/terminal.clj` + `tui/risk.clj` (176 reportable lines).
+2. Add `tui/interaction.clj` (131 reportable lines) — `tui.clj` still
+   carried its own copies of the moved defs at this point; nothing in
+   the repo called `tui.interaction` yet, so the duplication was inert.
+3. Remove the now-duplicated interaction-bound defs from `tui.clj`
+   (119 reportable lines). `tui.clj` still measured 4 real layers
+   here (the ansi/risk primitives hadn't moved yet) — committed with
+   `MINIFORGE_STRATUM_BUDGET_MODE=warn`, the documented escape hatch
+   for "a file legitimately mid-way through its own namespace-split
+   wave" (`tasks/stratum.clj`'s own wording for the equivalent
+   merge-in-progress case).
+4. Requalify `render-box`/`render-tree-item` to `tui.terminal`/`tui.risk`
+   (38 reportable lines) — `render-pr-detail`/`render-two-pane` still
+   used the local ansi/risk defs at this point, so the file kept
+   compiling; `MINIFORGE_STRATUM_BUDGET_MODE=warn` used again for the
+   same reason. (In practice `stratum-lint --fix`'s autofix regrouped
+   the remaining defs by their real dependency graph after this commit
+   and the file came out already SL003-clean — confirmed directly —
+   ahead of the plan.)
+5. Requalify the remaining call sites and delete the now-fully-
+   superseded local ansi/risk defs (199 reportable lines, no override
+   needed — `stratum-lint` was already clean going in).
+
+Every commit's own `bb pre-commit` run (full smoke + GraalVM suites)
+passed; the two mid-split commits are the only ones that needed the
+`MINIFORGE_STRATUM_BUDGET_MODE=warn` override, and only for the
+already-known SL003 finding this PR exists to fix — not for anything
+`--fix` couldn't otherwise resolve.
+
+## Checklist
+
+- [x] Zero unaccounted-for fan-in confirmed via fully-qualified
+      namespace grep, before starting and again at the end
+- [x] Pure code motion — no logic/behavior changes
+- [x] `stratum-lint` clean on every touched/new file at the final
+      commit
+- [x] `clj-kondo` clean
+- [x] Direct namespace load + assertion smoke check passed (no
+      existing test file to run instead)
+- [x] Pre-commit smoke suite green on every commit (not just the last)
+- [x] PR-diff and commit-diff budgets checked (492 insertions / 378
+      deletions across 4 files, 199 reportable lines max per commit)
+- [x] Adversarial self-review: diffed `tui.clj` end to end against the
+      original — every relocated def is byte-identical apart from its
+      `:stratum` tag/heading and call-site qualification; no def
+      added, removed, or behaviorally altered


### PR DESCRIPTION
## Overview

Splits `ai.miniforge.cli.tui` (bases/cli) into three new sibling namespaces (`tui/terminal.clj`, `tui/risk.clj`, `tui/interaction.clj`), resolving a stratum-lint SL003 finding (the combined namespace measured 4 real layers, over the rule 210 budget of 3).

Full details, testing plan, and commit-sequencing rationale in `docs/pull-requests/2026-08-19-refactor-split-cli-tui.md`.

## Summary

- Pure code motion, no behavior change.
- Zero fan-in confirmed repo-wide (`components`/`bases`/`projects`) via fully-qualified namespace grep, before and after.
- `stratum-lint` and `clj-kondo` clean on all four touched/new files.
- No existing test file for `ai.miniforge.cli.tui`; verified via a direct namespace-load + assertion smoke script exercising every moved def (`ALL ASSERTIONS PASSED`).
- `bb pre-commit` (345 tests/1301 assertions + 8 GraalVM tests/626 assertions) green on every one of the 5 code commits.
- Split into 5 commits to respect the 200-line commit budget; two mid-split commits used the documented `MINIFORGE_STRATUM_BUDGET_MODE=warn` escape hatch for the known, already-tracked SL003 finding (see PR doc for detail).

Part of the stratum-lint rule-210 remediation program, bases/cli batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

MINIFORGE_PR_BUDGET_OVERRIDE: Pure code motion splitting one 4-layer namespace into three siblings (667 reportable lines, budget 600). The split is a single atomic ownership transfer — slicing it under 600 would require a stacked intermediate PR whose head state duplicates defs across namespaces. Commit-level budget respected throughout (5 commits, ≤199 reportable lines each), and every moved def verified byte-identical.
