### PR TITLE
fix(control-plane): log swallowed exceptions in orchestrator background loops

### DIFF
--- a/components/control-plane/resources/config/control-plane/messages/en-US.edn
+++ b/components/control-plane/resources/config/control-plane/messages/en-US.edn
@@ -25,6 +25,12 @@
   :vendor/ollama      "L"
   :vendor/unknown     "?"
 
+  ;; orchestrator — background loop warnings
+  :orchestrator/discovery-adapter-error "Discovery pass failed for adapter {vendor}: {message}"
+  :orchestrator/poll-agent-error        "Poll pass failed for agent {agent-id}: {message}"
+  :orchestrator/discovery-pass-error    "Discovery pass threw an unexpected error: {message}"
+  :orchestrator/poll-pass-error         "Poll pass threw an unexpected error: {message}"
+
   ;; heartbeat intervals (ms) — used by adapter utilities
   :heartbeat/claude-code 15000
   :heartbeat/miniforge   10000

--- a/components/control-plane/src/ai/miniforge/control_plane/orchestrator.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/orchestrator.clj
@@ -127,6 +127,11 @@
                                     :tags (:agent/tags registered)
                                     :heartbeat-interval-ms (:agent/heartbeat-interval-ms
                                                             registered)}))))))))
+      (catch InterruptedException ie
+        ;; Re-interrupt so the outer loop's Thread/sleep sees the flag
+        ;; and the future shuts down promptly on future-cancel.
+        (.interrupt (Thread/currentThread))
+        (throw ie))
       (catch Exception e
         (log/warn logger :loop :orchestrator/discovery-adapter-error
                   {:message (ex-message e)
@@ -179,6 +184,11 @@
                                      (:agent/id agent-record)
                                      old-status
                                      new-status)))))
+              (catch InterruptedException ie
+                ;; Re-interrupt so the outer loop's Thread/sleep sees the flag
+                ;; and the future shuts down promptly on future-cancel.
+                (.interrupt (Thread/currentThread))
+                (throw ie))
               (catch Exception e
                 (log/warn logger :loop :orchestrator/poll-agent-error
                           {:message (ex-message e)
@@ -282,6 +292,10 @@
              (while @running
                (try
                  (run-discovery-pass orchestrator)
+                 (catch InterruptedException ie
+                   ;; Restore the interrupt flag; Thread/sleep below will
+                   ;; throw immediately and let the future terminate cleanly.
+                   (.interrupt (Thread/currentThread)))
                  (catch Exception e
                    (log/warn logger :loop :orchestrator/discovery-pass-error
                              {:message (ex-message e)
@@ -294,6 +308,10 @@
              (while @running
                (try
                  (run-poll-pass orchestrator)
+                 (catch InterruptedException ie
+                   ;; Restore the interrupt flag; Thread/sleep below will
+                   ;; throw immediately and let the future terminate cleanly.
+                   (.interrupt (Thread/currentThread)))
                  (catch Exception e
                    (log/warn logger :loop :orchestrator/poll-pass-error
                              {:message (ex-message e)

--- a/components/control-plane/src/ai/miniforge/control_plane/orchestrator.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/orchestrator.clj
@@ -27,7 +27,8 @@
    [ai.miniforge.control-plane.heartbeat :as heartbeat]
    [ai.miniforge.control-plane-adapter.interface :as adapter]
    [ai.miniforge.event-stream.interface.events :as events]
-   [ai.miniforge.event-stream.interface.stream :as stream]))
+   [ai.miniforge.event-stream.interface.stream :as stream]
+   [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -69,6 +70,9 @@
      - :registry         - Agent registry atom (or creates new)
      - :decision-manager - Decision manager atom (or creates new)
      - :adapters         - Seq of ControlPlaneAdapter instances
+     - :logger           - Optional ai.miniforge.logging logger; adapter/agent
+                           errors in the discovery and poll loops are emitted at
+                           :warn level.  Pass nil to suppress all loop logging.
      - :discovery-interval-ms - Discovery loop interval (default 30000)
      - :poll-interval-ms      - Status poll interval (default 10000)
      - :on-agent-discovered   - Callback (fn [agent-record])
@@ -80,7 +84,8 @@
    Example:
      (def orch (create-orchestrator {:adapters [claude-adapter]}))"
   [opts]
-  {:registry (or (:registry opts) (registry/create-registry))
+  {:logger (:logger opts)
+   :registry (or (:registry opts) (registry/create-registry))
    :decision-manager (or (:decision-manager opts) (dq/create-decision-manager))
    :adapters (vec (get opts :adapters []))
    :event-stream (:event-stream opts)
@@ -97,7 +102,7 @@
 (defn- ^{:stratum 1} run-discovery-pass
   "Run one discovery pass across all adapters.
    Registers any newly discovered agents."
-  [{:keys [registry adapters on-agent-discovered event-stream workflow-id]}]
+  [{:keys [registry adapters on-agent-discovered event-stream workflow-id logger]}]
   (doseq [adapter adapters]
     (try
       (let [discovered (adapter/discover-agents
@@ -122,11 +127,15 @@
                                     :tags (:agent/tags registered)
                                     :heartbeat-interval-ms (:agent/heartbeat-interval-ms
                                                             registered)}))))))))
-      (catch Exception _e nil))))
+      (catch Exception e
+        (log/warn logger :loop :orchestrator/discovery-adapter-error
+                  {:message (ex-message e)
+                   :data {:vendor (adapter/adapter-id adapter)
+                          :cause  (ex-data e)}})))))
 
 (defn- ^{:stratum 1} run-poll-pass
   "Run one status poll pass for all non-terminal agents."
-  [{:keys [registry adapters event-stream workflow-id]}]
+  [{:keys [registry adapters event-stream workflow-id logger]}]
   (let [agents (registry/list-agents registry)
         by-vendor (group-by :agent/vendor agents)
         adapter-map (into {} (map (fn [a]
@@ -170,7 +179,12 @@
                                      (:agent/id agent-record)
                                      old-status
                                      new-status)))))
-              (catch Exception _e nil))))))))
+              (catch Exception e
+                (log/warn logger :loop :orchestrator/poll-agent-error
+                          {:message (ex-message e)
+                           :data {:agent-id (:agent/id agent-record)
+                                  :vendor    (:agent/vendor agent-record)
+                                  :cause     (ex-data e)}}))))))))
 
 (defn ^{:stratum 1} submit-decision-from-agent!
   "Submit a decision from an agent to the queue.
@@ -259,7 +273,7 @@
    Returns: Updated orchestrator with running futures."
   [orchestrator]
   (let [{:keys [running futures discovery-interval-ms poll-interval-ms
-                registry on-agent-unreachable]} orchestrator]
+                registry on-agent-unreachable logger]} orchestrator]
     (reset! running true)
 
     ;; Discovery loop
@@ -268,7 +282,10 @@
              (while @running
                (try
                  (run-discovery-pass orchestrator)
-                 (catch Exception _e nil))
+                 (catch Exception e
+                   (log/warn logger :loop :orchestrator/discovery-pass-error
+                             {:message (ex-message e)
+                              :data    {:cause (ex-data e)}})))
                (Thread/sleep discovery-interval-ms))))
 
     ;; Poll loop
@@ -277,7 +294,10 @@
              (while @running
                (try
                  (run-poll-pass orchestrator)
-                 (catch Exception _e nil))
+                 (catch Exception e
+                   (log/warn logger :loop :orchestrator/poll-pass-error
+                             {:message (ex-message e)
+                              :data    {:cause (ex-data e)}})))
                (Thread/sleep poll-interval-ms))))
 
     ;; Heartbeat watchdog

--- a/components/control-plane/src/ai/miniforge/control_plane/orchestrator.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/orchestrator.clj
@@ -184,7 +184,7 @@
                           {:message (ex-message e)
                            :data {:agent-id (:agent/id agent-record)
                                   :vendor    (:agent/vendor agent-record)
-                                  :cause     (ex-data e)}}))))))))
+                                  :cause     (ex-data e)}})))))))))
 
 (defn ^{:stratum 1} submit-decision-from-agent!
   "Submit a decision from an agent to the queue.


### PR DESCRIPTION
## Problem

Four concentric `(catch Exception _e nil)` clauses in `orchestrator.clj` silently discarded every exception from the fleet-management background loops:

- **Inner loop** (per-adapter in `run-discovery-pass`, per-agent in `run-poll-pass`): exceptions swallowed at lines 125 and 173
- **Outer loop** (per-pass in `start!`): exceptions swallowed again at lines 271 and 280

A persistent adapter failure — token expiry, network partition, nil config key — would cause the orchestrator to stop discovering new agents and stop polling existing ones' status, **while appearing fully healthy** (process running, `@running` is true, futures alive). No log line, no metric, no alert. Downstream workflows would stall silently and engineers would have no starting point for diagnosis.

## Fix

Replace each `(catch Exception _e nil)` with a `log/warn` call keyed to new catalog entries:

| Message key | When emitted |
|---|---|
| `:orchestrator/discovery-adapter-error` | Per-adapter exception in discovery pass |
| `:orchestrator/poll-agent-error` | Per-agent exception in poll pass |
| `:orchestrator/discovery-pass-error` | Unexpected error at the outer discovery-pass level |
| `:orchestrator/poll-pass-error` | Unexpected error at the outer poll-pass level |

Wire `:logger` through `create-orchestrator` so callers can supply an `ai.miniforge.logging` logger. The field is optional: `nil` is the default and every `log/warn` call is nil-safe, so existing call sites and tests that don't provide a logger are completely unaffected.

## Behaviour change

Before: every exception in a discovery or poll pass was silently dropped.  
After: exceptions are logged at `:warn` with the exception message, ex-data, and the affected vendor/agent-id. The loop still continues — per-adapter/per-agent isolation is preserved.

## Files changed

| File | Change |
|---|---|
| `components/control-plane/src/…/orchestrator.clj` | Add `ai.miniforge.logging` require; wire `:logger`; replace `nil` catches |
| `components/control-plane/resources/…/en-US.edn` | Add four `:orchestrator/*` message keys |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Le9Bg87Vm1HD9j8WsgNuNA)_