### PR TITLE
fix(pr-scoring): wire structured logging for scorer exceptions

### DIFF
--- a/components/pr-scoring/deps.edn
+++ b/components/pr-scoring/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/event-stream {:local/root "../event-stream"}}
+ :deps {ai.miniforge/event-stream {:local/root "../event-stream"}
+        ai.miniforge/logging {:local/root "../logging"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {io.github.cognitect-labs/test-runner
                                {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/pr-scoring/src/ai/miniforge/pr_scoring/core.clj
+++ b/components/pr-scoring/src/ai/miniforge/pr_scoring/core.clj
@@ -113,10 +113,11 @@
       (emit-scored! stream scorer-fn event)
       (catch Exception e
         (log/warn logger :pr-scoring :pr-scoring/handler-error
-                  {:message  (ex-message e)
-                   :event-type (:event/type event)
-                   :pr-repo  (:pr/repo event)
-                   :pr-number (:pr/number event)})))))
+                  {:message (or (ex-message e) (str (type e)))
+                   :data    {:event-type (:event/type event)
+                             :pr-repo    (:pr/repo event)
+                             :pr-number  (:pr/number event)
+                             :ex-data    (ex-data e)}})))))
 
 (defn ^{:stratum 1} stop!
   "Unsubscribe. Idempotent."

--- a/components/pr-scoring/src/ai/miniforge/pr_scoring/core.clj
+++ b/components/pr-scoring/src/ai/miniforge/pr_scoring/core.clj
@@ -56,7 +56,8 @@
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [ai.miniforge.event-stream.interface :as es]
-   [ai.miniforge.event-stream.interface.events :as events]))
+   [ai.miniforge.event-stream.interface.events :as events]
+   [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -103,14 +104,19 @@
 
 (defn- ^{:stratum 1} handle-event!
   "Entry point for every event the stream delivers. No-op unless the
-   event type is in `triggers`. A scorer-fn that throws is suppressed
-   silently (for the scaffold) — a follow-up PR wires proper structured
-   logging once the real scoring integration lands."
-  [triggers scorer-fn stream event]
+   event type is in `triggers`. A scorer-fn that throws is logged at
+   WARN and then suppressed so a transient scorer error never kills the
+   subscription loop. `logger` may be nil (no-op)."
+  [triggers scorer-fn stream logger event]
   (when (contains? triggers (:event/type event))
     (try
       (emit-scored! stream scorer-fn event)
-      (catch Throwable _t nil))))
+      (catch Exception e
+        (log/warn logger :pr-scoring :pr-scoring/handler-error
+                  {:message  (ex-message e)
+                   :event-type (:event/type event)
+                   :pr-repo  (:pr/repo event)
+                   :pr-number (:pr/number event)})))))
 
 (defn ^{:stratum 1} stop!
   "Unsubscribe. Idempotent."
@@ -129,10 +135,10 @@
 (defn ^{:stratum 2} start!
   "Subscribe to the stream. Idempotent — repeat calls are no-ops."
   [component]
-  (let [{:keys [stream scorer-fn triggers subscribed?]} @component]
+  (let [{:keys [stream scorer-fn triggers logger subscribed?]} @component]
     (when-not subscribed?
       (es/subscribe! stream subscriber-id
-                     (fn [event] (handle-event! triggers scorer-fn stream event)))
+                     (fn [event] (handle-event! triggers scorer-fn stream logger event)))
       (swap! component assoc :subscribed? true))
     component))
 
@@ -148,13 +154,16 @@
                             to [[default-scorer-fn]] which emits nothing
      :trigger-event-types — set of event-type keywords that trigger
                             scoring; defaults to the EDN set at
-                            [[trigger-config-resource]]"
+                            [[trigger-config-resource]]
+     :logger              — logging/logger for scorer errors; nil (default)
+                            suppresses all log output (backwards-compatible)"
   ([stream] (create stream {}))
-  ([stream {:keys [scorer-fn trigger-event-types]
+  ([stream {:keys [scorer-fn trigger-event-types logger]
             :or   {scorer-fn default-scorer-fn}}]
    (atom {:stream stream
           :scorer-fn scorer-fn
           :triggers (or trigger-event-types @default-trigger-event-types)
+          :logger logger
           :subscribed? false})))
 
 ;------------------------------------------------------------------------------ Layer 4

--- a/components/pr-scoring/src/ai/miniforge/pr_scoring/core.clj
+++ b/components/pr-scoring/src/ai/miniforge/pr_scoring/core.clj
@@ -113,7 +113,7 @@
       (emit-scored! stream scorer-fn event)
       (catch Exception e
         (log/warn logger :loop :inner/handler-error
-                  {:message (or (ex-message e) (str (type e)))
+                  {:message (or (not-empty (ex-message e)) (str (type e)))
                    :data    {:event-type (:event/type event)
                              :pr-repo    (:pr/repo event)
                              :pr-number  (:pr/number event)

--- a/components/pr-scoring/src/ai/miniforge/pr_scoring/core.clj
+++ b/components/pr-scoring/src/ai/miniforge/pr_scoring/core.clj
@@ -112,7 +112,7 @@
     (try
       (emit-scored! stream scorer-fn event)
       (catch Exception e
-        (log/warn logger :pr-scoring :pr-scoring/handler-error
+        (log/warn logger :loop :inner/handler-error
                   {:message (or (ex-message e) (str (type e)))
                    :data    {:event-type (:event/type event)
                              :pr-repo    (:pr/repo event)

--- a/components/pr-scoring/src/ai/miniforge/pr_scoring/interface.clj
+++ b/components/pr-scoring/src/ai/miniforge/pr_scoring/interface.clj
@@ -47,9 +47,11 @@
                             to [[default-scorer-fn]] (emits nothing)
      :trigger-event-types — set of event-type keywords that trigger scoring;
                             defaults to the EDN set at [[trigger-config-resource]]
+     :logger              — logging/logger for scorer errors; nil (default)
+                            suppresses all log output (backwards-compatible)
 
    Returns an atom holding the component state map
-   {:stream :scorer-fn :triggers :subscribed?}."
+   {:stream :scorer-fn :triggers :logger :subscribed?}."
   core/create)
 
 (def ^{:stratum 0} start!

--- a/components/pr-scoring/test/ai/miniforge/pr_scoring/core_test.clj
+++ b/components/pr-scoring/test/ai/miniforge/pr_scoring/core_test.clj
@@ -167,11 +167,11 @@
                                            (throw (ex-info "boom" {:ctx :test})))
                               :logger logger})]
     (es/publish! s (pr-created-event s "acme/widget" 42))
-    (let [warnings (filter #(= :warn (:level %)) @entries)]
+    (let [warnings (filter #(= :warn (:log/level %)) @entries)]
       (is (= 1 (count warnings))
           "exactly one :warn entry is emitted per scorer exception")
       (let [w (first warnings)]
-        (is (= :pr-scoring/handler-error (:event w)))
+        (is (= :inner/handler-error (:log/event w)))
         (is (= :pr/created (get-in w [:data :event-type])))
         (is (= "acme/widget" (get-in w [:data :pr-repo])))
         (is (= 42 (get-in w [:data :pr-number])))

--- a/components/pr-scoring/test/ai/miniforge/pr_scoring/core_test.clj
+++ b/components/pr-scoring/test/ai/miniforge/pr_scoring/core_test.clj
@@ -23,6 +23,7 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.logging.interface :as log]
    [ai.miniforge.pr-scoring.interface :as scoring]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -158,6 +159,23 @@
     (es/publish! s (pr-created-event s "acme/widget" 42))
     (is (empty? (scored-events @captured))
         "scorer throwing does not crash the component nor emit partial events")))
+
+(deftest ^{:stratum 2} scorer-fn-exception-is-logged-with-structured-data
+  (let [[s _captured] (captured-stream)
+        [logger entries] (log/collecting-logger)
+        _ (scoring/attach! s {:scorer-fn (fn [_]
+                                           (throw (ex-info "boom" {:ctx :test})))
+                              :logger logger})]
+    (es/publish! s (pr-created-event s "acme/widget" 42))
+    (let [warnings (filter #(= :warn (:level %)) @entries)]
+      (is (= 1 (count warnings))
+          "exactly one :warn entry is emitted per scorer exception")
+      (let [w (first warnings)]
+        (is (= :pr-scoring/handler-error (:event w)))
+        (is (= :pr/created (get-in w [:data :event-type])))
+        (is (= "acme/widget" (get-in w [:data :pr-repo])))
+        (is (= 42 (get-in w [:data :pr-number])))
+        (is (= {:ctx :test} (get-in w [:data :ex-data])))))))
 
 (deftest ^{:stratum 2} partial-score-maps-pass-through
   (testing "Scorer returns only readiness; emitted event carries only that field"

--- a/components/schema/src/ai/miniforge/schema/logging_vocab.clj
+++ b/components/schema/src/ai/miniforge/schema/logging_vocab.clj
@@ -55,6 +55,7 @@
    :inner/validation-failed
    :inner/repair-attempted
    :inner/escalated
+   :inner/handler-error
    :outer/phase-entered
    :outer/phase-completed
    :outer/phase-failed


### PR DESCRIPTION
## Summary

- `handle-event!` was catching `Throwable` and returning `nil` silently — the docstring itself called it a scaffold gap and promised a follow-up PR with structured logging
- Wire `ai.miniforge.logging.interface` into `pr-scoring` and emit a `:inner/handler-error` WARN (category `:loop`) when the scorer throws, rather than swallowing the error invisibly

## Motivation

Every PR event that caused the scorer to throw was silently dropped with no trace in logs. In production this makes it impossible to distinguish "no PRs scored yet" from "every scoring attempt is failing". The fix also narrows the catch from `Throwable` (which includes `OutOfMemoryError`) to `Exception` per rule 211.

## Changes

| File/Area | Change |
|-----------|--------|
| `components/pr-scoring/deps.edn` | Add `ai.miniforge/logging` dependency |
| `components/pr-scoring/core.clj` | Add `log` require; change `catch Throwable` → `catch Exception`; emit `:loop`/`:inner/handler-error` WARN with diagnostic fields under `:data`; add `:logger` option to `create` (nil-default, backwards-compatible); thread logger through `start!` → `handle-event!` |
| `components/pr-scoring/interface.clj` | Document `:logger` option and `:logger` in returned state-map shape |
| `components/schema/logging_vocab.clj` | Register `:inner/handler-error` in `loop-events` so schema-validating consumers accept the entry |
| `components/pr-scoring/core_test.clj` | Add `scorer-fn-exception-is-logged-with-structured-data` test using `log/collecting-logger`; verify `:log/level`, `:log/event`, and all `:data` fields |

## Testing

- [ ] Existing tests pass — the `scorer-fn-exceptions-are-swallowed` test still holds (exception suppressed, no `:pr/scored` emitted); it now logs at WARN before returning
- [ ] New `scorer-fn-exception-is-logged-with-structured-data` test confirms the warn entry is emitted with correct event, category, and structured data fields

## Checklist

### Required

- [ ] All tests pass (`bb test`)
- [ ] Pre-commit validation passes (no `--no-verify`)
- [ ] No commented-out tests
- [ ] No giant functions
- [ ] Functions are small and composable
- [ ] New behavior has tests

### Best Practices

- [ ] Code follows development guidelines
- [ ] Focused PR (single concern)

## Related

- Follows up on the scaffold gap noted in `handle-event!` docstring
- Companion to #1822 (control-plane swallowed exceptions)

---
_Generated by [Claude Code](https://claude.ai/code/session_019jgix6pE8bANQ1Br1zQbYZ)_