### PR TITLE
feat(phase): promote :stale-references into policy-gates

### DIFF
--- a/components/phase/src/ai/miniforge/phase/registry.clj
+++ b/components/phase/src/ai/miniforge/phase/registry.clj
@@ -61,7 +61,12 @@
    provenance for the codex warning surface, and the canonical-sdlc v2
    implement `:gates` override was silently dropping it — exactly the
    footgun this set exists to close."
-  #{:policy-verify :policy-review :policy-pack :codex-consultation})
+  ;; :stale-references joined 2026-08-12 under the operator directive that
+   ;; the contract-drift worry be deterministically enforced: the trap bench
+   ;; measured prose delivery changing nothing (eight of eight sprung), so
+   ;; the check lives here where a workflow override cannot drop it.
+  #{:policy-verify :policy-review :policy-pack :codex-consultation
+    :stale-references})
 
 ;; Phase status predicates
 ;;

--- a/components/phase/test/ai/miniforge/phase/registry_test.clj
+++ b/components/phase/test/ai/miniforge/phase/registry_test.clj
@@ -64,6 +64,15 @@
 ;; merge-with-defaults
 (def ^{:stratum 0} ^:private verify-like-phase :registry-test/verify-like)
 
+(deftest ^{:stratum 0} merge-gates-preserves-stale-references-gate-test
+  (testing "the canonical-sdlc v2 implement override shape cannot drop
+            :stale-references — promoted to policy-gates 2026-08-12 so the
+            contract-drift check runs in every workflow"
+    (is (= [:syntax :lint :no-secrets :codex-consultation :stale-references]
+           (registry/merge-gates
+            [:syntax :format :lint :codex-consultation :stale-references]
+            [:syntax :lint :no-secrets :codex-consultation])))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (deftest ^{:stratum 1} merge-with-defaults-no-gates-override-keeps-defaults-test


### PR DESCRIPTION
Second half of #1756, per the operator directive that the contract-drift worry be enforced deterministically: :stale-references joins policy-gates, so a workflow's :gates override (canonical-sdlc v2's implement vector was the one dropping it) can no longer disable the check. Lockstep merge-gates test covers the exact override shape.

Calibration plan: the trap-a demonstration runs (bench re-provision at this tip) double as the false-positive watch; if the gate over-fires on real work, demotion returns with data rather than staying by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)