### PR TITLE
fix(codex): consultation provenance survives implement and plan failures

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
@@ -76,6 +76,22 @@
                             :anomaly (name anomaly)
                             :reason reason})))))
 
+(defn ^{:stratum 0} attach-consultation
+  "Record `summary` at [:output :codex/consultation] on a phase result,
+   on success AND failure — a failed phase that consulted must not be
+   ledgered as one that never did. Normalizes a non-map :output (the
+   specialized-agent failure path can leave a scalar there) under
+   :agent/raw-output instead of throwing away the diagnostic or crashing
+   the enter interceptor. Non-map results pass through untouched."
+  [result summary]
+  (if (map? result)
+    (let [out (:output result)
+          out (if (map? out)
+                out
+                (cond-> {} (some? out) (assoc :agent/raw-output out)))]
+      (assoc result :output (assoc out :codex/consultation summary)))
+    result))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} pin-outcome

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -920,12 +920,15 @@
         ;; enter-context stores it — gates run between enter and leave and
         ;; read [:result :output]. Reads come from the agent result's
         ;; :context-reads (host-mode sessions); curator-result branches drop
-        ;; that key, so read it off impl-result directly.
-        result (if (map? (:output result))
-                 (assoc-in result [:output :codex/consultation]
+        ;; that key, so read it off impl-result directly. Attached on
+        ;; FAILURES too (:output starts nil on response/failure): a failed
+        ;; implement that consulted must not be ledgered as one that never
+        ;; did — the gap instrument's :undelivered bucket depends on it.
+        result (cond-> result
+                 (map? result)
+                 (assoc-in [:output :codex/consultation]
                            (codex-pin/consultation-summary
-                             codex-outcome (:context-reads impl-result)))
-                 result)]
+                             codex-outcome (:context-reads impl-result))))]
     (-> (phase/enter-context ctx :implement :implementer gates budget start-time result)
         (assoc-in [:phase :rules-manifest] rules-manifest)
         (assoc-in [:phase :watchdog-state]

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -924,11 +924,10 @@
         ;; FAILURES too (:output starts nil on response/failure): a failed
         ;; implement that consulted must not be ledgered as one that never
         ;; did — the gap instrument's :undelivered bucket depends on it.
-        result (cond-> result
-                 (map? result)
-                 (assoc-in [:output :codex/consultation]
-                           (codex-pin/consultation-summary
-                             codex-outcome (:context-reads impl-result))))]
+        result (codex-pin/attach-consultation
+                 result
+                 (codex-pin/consultation-summary
+                   codex-outcome (:context-reads impl-result)))]
     (-> (phase/enter-context ctx :implement :implementer gates budget start-time result)
         (assoc-in [:phase :rules-manifest] rules-manifest)
         (assoc-in [:phase :watchdog-state]

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -270,6 +270,20 @@
   (or (:artifact result)
       (:output result)))
 
+(defn- ^{:stratum 0} raw-agent-output
+  "The agent's scalar output text, whether it still sits at :output or
+   was preserved under [:output :agent/raw-output] when
+   codex-pin/attach-consultation normalized a scalar into a map. Every
+   classifier that reads the raw text (rate-limit detection, error
+   message, summary fallback) must go through this accessor or it goes
+   blind after normalization."
+  [result]
+  (let [out (:output result)]
+    (cond
+      (string? out) out
+      (map? out) (let [raw (:agent/raw-output out)]
+                   (when (string? raw) raw)))))
+
 (defn- ^{:stratum 0} lightweight-curated-artifact
   "Persist only lightweight curated metadata in phase results.
    Serialized code stays in the worktree and can be rehydrated later."
@@ -430,8 +444,7 @@
   "Build a structured phase error map from an agent result."
   [result agent-status rate-limited? iterations]
   {:message (or (extract-error-message result nil)
-                (when (string? (:output result))
-                  (not-empty (:output result)))
+                (not-empty (raw-agent-output result))
                 (messages/t :implement/exhausted-retries))
    :agent-status agent-status
    :rate-limited? (boolean rate-limited?)
@@ -459,7 +472,7 @@
   (or (some (fn [text]
               (and (string? text) (re-find rate-limit-pattern text)))
             [(get-in result [:error :message])
-             (when (string? (:output result)) (:output result))])
+             (raw-agent-output result)])
       (suspicious-short-termination? result)))
 
 ;------------------------------------------------------------------------------ Layer 3
@@ -621,7 +634,7 @@
         degraded-handoff? (true? (:degraded-handoff? result))
         raw-agent-status (or (:raw-agent-status result) agent-status)
         summary (or (get-in result [:output :code/summary])
-                    (when (string? (:output result)) (:output result))
+                    (raw-agent-output result)
                     (messages/t :implement/summary-default))
         on-fail (get-in ctx [:phase-config :on-fail])
         ;; Phase 3c verdict — only meaningful for terminal phase

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
@@ -231,10 +231,8 @@
                ;; Attached on failures too (:output starts nil on
                ;; response/failure): a failed plan that consulted must not be
                ;; ledgered as one that never did.
-               (cond-> r
-                 (map? r)
-                 (assoc-in [:output :codex/consultation]
-                           (codex-pin/consultation-summary codex-outcome nil))))
+               (codex-pin/attach-consultation
+                 r (codex-pin/consultation-summary codex-outcome nil)))
      :rules-manifest rules-manifest}))
 
 ;------------------------------------------------------------------------------ Layer 2

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
@@ -228,10 +228,13 @@
                                                   :metrics {:tokens toks}})))))]
                ;; SPEC §7.4.3 consultation provenance. The planner session does
                ;; not surface :context-reads yet, so :pin-read? is nil (unknown).
-               (if (map? (:output r))
-                 (assoc-in r [:output :codex/consultation]
-                           (codex-pin/consultation-summary codex-outcome nil))
-                 r))
+               ;; Attached on failures too (:output starts nil on
+               ;; response/failure): a failed plan that consulted must not be
+               ;; ledgered as one that never did.
+               (cond-> r
+                 (map? r)
+                 (assoc-in [:output :codex/consultation]
+                           (codex-pin/consultation-summary codex-outcome nil))))
      :rules-manifest rules-manifest}))
 
 ;------------------------------------------------------------------------------ Layer 2

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/artifact_persistence_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/artifact_persistence_test.clj
@@ -182,7 +182,7 @@
           ;; Result should have environment-id, not serialized code
           (is (= env-id (get-in ctx-left [:phase :result :environment-id]))
               "Phase result should reference the environment-id")
-          (is (nil? (get-in ctx-left [:phase :result :output]))
+          (is (= [:codex/consultation] (keys (get-in ctx-left [:phase :result :output])))
               "Phase result should not carry serialized :output / :code/files")
 
           ;; Files written by agent should exist in the worktree

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
@@ -93,3 +93,23 @@
     (testing "no pegs presented records nil, not an empty claim"
       (is (nil? (:pegs (codex-pin/consultation-summary
                          (assoc outcome :pegs []) nil)))))))
+
+(deftest ^{:stratum 0} attach-consultation-shapes
+  (let [summary {:status :unconfigured :pinned? false}]
+    (testing "failure result with nil :output gains the marker"
+      (is (= summary
+             (get-in (codex-pin/attach-consultation
+                      {:status :error :error {:message "x"} :output nil} summary)
+                     [:output :codex/consultation]))))
+    (testing "scalar :output (specialized-agent failure path) is preserved
+              under :agent/raw-output instead of crashing assoc-in"
+      (let [r (codex-pin/attach-consultation
+               {:status :error :output "raw agent text"} summary)]
+        (is (= "raw agent text" (get-in r [:output :agent/raw-output])))
+        (is (= summary (get-in r [:output :codex/consultation])))))
+    (testing "map :output keeps its keys"
+      (is (= {:code/summary "s" :codex/consultation summary}
+             (:output (codex-pin/attach-consultation
+                       {:status :success :output {:code/summary "s"}} summary)))))
+    (testing "non-map result passes through untouched"
+      (is (nil? (codex-pin/attach-consultation nil summary))))))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -522,8 +522,11 @@
             "Phase should complete when agent returns success with nil output")
         (is (= env-id (get-in final-result [:phase :result :environment-id]))
             "Result should reference the environment-id")
-        (is (nil? (get-in final-result [:phase :result :output]))
-            "Result should NOT contain serialized :output / :code/files")))))
+        (is (= [:codex/consultation]
+               (keys (get-in final-result [:phase :result :output])))
+            "Result should NOT contain serialized :output / :code/files —
+             only consultation provenance survives (attached on every
+             result since the consultation-on-failure fix)")))))
 
 (deftest ^{:stratum 2} leave-implement-preserves-codex-consultation-test
   (testing "the lightweight success result keeps :codex/consultation — the
@@ -847,6 +850,23 @@
         (is (= :failed (get-in final-result [:phase :status])))
         (is (empty? (get-in final-result [:execution :phases-completed] []))
             "Failed implement must not be counted as completed")))))
+
+(deftest ^{:stratum 2} enter-implement-attaches-consultation-on-failure-test
+  (testing "a failed implement still carries :codex/consultation on its
+            result — the gap instrument must not ledger a consulted
+            failure as one that never consulted (the release-phase
+            review finding, applied here)"
+    (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
+                  agent/invoke (fn [_ _ _]
+                                 (response/error "LLM timeout" {:tokens 0 :duration-ms 5000}))
+                  agent/curate-implement-output mock-curator-error]
+      (let [ctx (-> (create-base-context)
+                    (assoc :phase-config {:phase :implement}))
+            interceptor (phase/get-phase-interceptor {:phase :implement})
+            enter-result ((:enter interceptor) ctx)
+            c (get-in enter-result [:phase :result :output :codex/consultation])]
+        (is (map? c) "consultation marker present on the failed result")
+        (is (contains? c :status))))))
 
 (deftest ^{:stratum 2} leave-implement-rejects-already-implemented-after-review-feedback-test
   (testing "already-implemented after review feedback fails closed instead of skipping"

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -985,6 +985,29 @@
         (is (= :agent-stalled (:phase/termination-reason reason)))
         (is (= 120000 (:stall/gap-duration-ms reason)))))))
 
+(deftest ^{:stratum 2} rate-limit-classification-survives-consultation-normalization-test
+  (testing "a specialized-agent failure whose scalar :output carries a
+            rate-limit message still classifies as rate-limited after
+            attach-consultation wraps the scalar under :agent/raw-output
+            (the round-2 review finding on #1825)"
+    (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
+                  agent/invoke (fn [_ _ _]
+                                 {:status :error
+                                  :output "HTTP 429 Too Many Requests — quota exhausted"
+                                  :error {:message nil}
+                                  :metrics {:tokens 0 :duration-ms 100}})
+                  agent/curate-implement-output mock-curator-error]
+      (let [ctx (-> (create-base-context)
+                    (assoc :phase-config {:phase :implement}))
+            interceptor (phase/get-phase-interceptor {:phase :implement})
+            enter-result ((:enter interceptor) ctx)
+            final-result ((:leave interceptor) enter-result)]
+        (is (= "HTTP 429 Too Many Requests — quota exhausted"
+               (get-in final-result [:phase :result :output :agent/raw-output]))
+            "scalar output preserved under :agent/raw-output")
+        (is (true? (get-in final-result [:phase :error :rate-limited?]))
+            "rate-limit classifier reads through the normalized shape")))))
+
 (use-fixtures :each
   (fn [f]
     (phase/reset-phase-loader!)


### PR DESCRIPTION
The bug Copilot caught on release (#1754) existed in both older attach sites: implement and plan only attached :codex/consultation when the result already had a map :output, which response/failure results do not — so failing phases (exactly where the gap instrument looks) recorded consultation nil, indistinguishable from an unconsulted run. Every gap-ledger row from the observational matrix carried this hole.

Guard becomes (map? result), creating :output when absent — same shape as the release fix. New test pins the failed-implement case; the two assertions that pinned 'output is nil' on nil-curator paths narrow to 'output carries exactly the consultation marker'.

T2 §6.2: repairs the instrument's :undelivered/:unheeded discrimination for failing phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)