### PR TITLE
fix(cli): address review findings deferred from the rule-210 split wave

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/etl/repo.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/etl/repo.clj
@@ -45,12 +45,14 @@
    Returns a schema/success or schema/failure result."
   [url]
   (try
-    (let [tmp-dir (str (System/getProperty "java.io.tmpdir") "/miniforge-etl-"
-                       (System/currentTimeMillis))
+    (let [tmp-dir (str (fs/path (System/getProperty "java.io.tmpdir")
+                                (str "miniforge-etl-" (random-uuid))))
           result  (process/sh "git" "clone" "--depth" "1" url tmp-dir)]
       (if (zero? (:exit result))
         (schema/success :path tmp-dir)
-        (schema/failure :path (str/trim (:err result)))))
+        (do
+          (try (fs/delete-tree tmp-dir) (catch Exception _ nil))
+          (schema/failure :path (str/trim (:err result))))))
     (catch Exception e
       (schema/failure :path (ex-message e)))))
 

--- a/bases/cli/src/ai/miniforge/cli/main/util.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/util.clj
@@ -23,7 +23,7 @@
    file (no same-file references), so the whole namespace is one real
    layer."
   (:require
-   [babashka.process :as process]
+   [babashka.fs :as fs]
    [ai.miniforge.cli.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -69,8 +69,7 @@
 (defn ^{:stratum 0} check-command
   "Check if a command is available."
   [cmd]
-  (let [{:keys [exit]} (process/sh "which" cmd)]
-    (zero? exit)))
+  (boolean (fs/which cmd)))
 
 (defn ^{:stratum 0} timestamp->epoch-ms
   [timestamp]

--- a/bases/cli/src/ai/miniforge/cli/tui/interaction.clj
+++ b/bases/cli/src/ai/miniforge/cli/tui/interaction.clj
@@ -64,7 +64,9 @@
 
 (defn ^{:stratum 0} nav-down [state]
   (let [max-idx (dec (count (:flat-items state)))]
-    (update state :selected-index #(min max-idx (inc %)))))
+    (if (neg? max-idx)
+      state
+      (update state :selected-index #(min max-idx (inc %))))))
 
 (defn ^{:stratum 0} get-selected-item [state]
   (get-in state [:flat-items (:selected-index state)]))

--- a/bases/cli/src/ai/miniforge/cli/tui/terminal.clj
+++ b/bases/cli/src/ai/miniforge/cli/tui/terminal.clj
@@ -70,9 +70,10 @@
   "Get terminal dimensions [width height]."
   []
   (try
-    (let [result (process/sh "stty" "size" :in (java.io.FileInputStream. "/dev/tty"))
-          [h w] (str/split (str/trim (:out result)) #" ")]
-      [(Integer/parseInt w) (Integer/parseInt h)])
+    (with-open [tty (java.io.FileInputStream. "/dev/tty")]
+      (let [result (process/sh "stty" "size" :in tty)
+            [h w] (str/split (str/trim (:out result)) #" ")]
+        [(Integer/parseInt w) (Integer/parseInt h)]))
     (catch Exception _
       [120 40])))  ; fallback
 

--- a/bases/cli/src/ai/miniforge/cli/web/components/pr_actions.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/components/pr_actions.clj
@@ -62,7 +62,7 @@
      :hx-swap "innerHTML"
      :hx-prompt (t :web-ui/reject-prompt)}
     (t :web-ui/reject-button)]
-   [:a.btn.btn-secondary {:href url :target "_blank"}
+   [:a.btn.btn-secondary {:href url :target "_blank" :rel "noopener noreferrer"}
     (t :web-ui/open-github-button)]])
 
 ;------------------------------------------------------------------------------ Layer 2


### PR DESCRIPTION
## Overview

Five Copilot review findings surfaced on the bases/cli rule-210 split PRs (#1818, #1819, #1820, #1821). Each was real but pre-existing behavior moved verbatim, so fixing it inside a pure-code-motion diff would have broken those PRs' review contract. All five were deferred with a commitment to an immediate follow-up — this is that follow-up.

## Changes

- `main/commands/etl/repo.clj` `git-clone-temp`: temp clone dir built with `fs/path` + `random-uuid` instead of string-concatenating `java.io.tmpdir` with a hard-coded `/` and `currentTimeMillis`; best-effort `fs/delete-tree` when `git clone` exits non-zero (from #1818)
- `web/components/pr_actions.clj`: `rel="noopener noreferrer"` added to the `target="_blank"` GitHub link, closing the reverse-tabnabbing vector (from #1819)
- `main/util.clj` `check-command`: `babashka.fs/which` replaces shelling out to `which` (portable, and Windows-correct via PATHEXT); the now-unused `babashka.process` require is dropped (from #1820)
- `tui/terminal.clj` `get-terminal-size`: `with-open` around the `/dev/tty` `FileInputStream`, closing the file-descriptor leak on repeated renders (from #1821)
- `tui/interaction.clj` `nav-down`: no-op when `:flat-items` is empty instead of setting `:selected-index` to -1 (from #1821)

## Testing

- `clj-kondo` clean on all five files
- Pre-commit smoke suite green (345 tests / 1301 assertions + GraalVM set)
- Existing etl tests mock `git-clone-temp` at the var level and are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)