### PR TITLE
docs(pull-requests): correct the effect-grant anomalies record

### DIFF
--- a/docs/pull-requests/2026-08-05-codex-standards-effect-grant-anomalies.md
+++ b/docs/pull-requests/2026-08-05-codex-standards-effect-grant-anomalies.md
@@ -40,10 +40,17 @@ section, not the title, as the description of what changed.
 The branch originally carried the fix the commit title names: six files
 returning serialization and validation failures as anomaly values before
 any write, across `effect-transaction` and `execution-grant`. A 2026-08-07
-rebase dropped them. They patched `store/write!`, which #1705 (`e67c640`)
-had already removed when it split `store.clj` into `persistence.clj` and
-`codec.clj`; every production file conflicted, and the conflicts were
-resolved by discarding the changes rather than porting them.
+rebase dropped them. They patched `store/write!`, a function the durable
+store no longer has: `store.clj` delegates to `persistence.clj` and
+`codec.clj` instead. Every production file conflicted, and the conflicts
+were resolved by discarding the changes rather than porting them.
+
+The commit that performed that split is not identifiable from the current
+history. The earliest commit in this repository (`e67c640`, 2026-08-07) is
+a root commit with no parents, and it already contains the split layout,
+so the restructure predates everything now visible. `git log` on these
+paths reports `e67c640` only because history stops there — that is
+truncation, not authorship.
 
 No follow-up is required. `main` reaches the same guarantees by another
 route:
@@ -79,10 +86,12 @@ No migration or rollout is needed.
 - Base Branch: `main`
 - Depends On: none
 - Merged As: `3d2361e4`
-- Context: #1705 (`e67c640`) restructured the durable effect boundary and
-  supplies the anomaly contract this branch set out to add
+- Context: the durable effect boundary on `main` already supplies the
+  anomaly contract this branch set out to add; see
+  [What did not land](#what-did-not-land)
 
 ## Checklist
 
 - [x] Pre-commit checks passed
-- [ ] Audit gap fixed — closed by #1705, not by this commit
+- [ ] Audit gap fixed — the guarantees hold on `main` today, but not
+      because of this commit

--- a/docs/pull-requests/2026-08-05-codex-standards-effect-grant-anomalies.md
+++ b/docs/pull-requests/2026-08-05-codex-standards-effect-grant-anomalies.md
@@ -3,21 +3,71 @@
   Author: Christopher Lester (christopher@miniforge.ai)
   Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 -->
-# fix: return anomalies from durable effect boundaries
+# test: cover anomaly propagation through the effect lifecycle
 
 ## Overview
 
-Moves effect-transaction and execution-grant persistence validation failures onto the anomaly value path.
+Adds one regression test proving that `record/propose!` and
+`record/advance!` return a store write failure unchanged instead of
+reporting success. No production code changed.
+
+This document originally described a broader fix. That fix did not land —
+see [What did not land](#what-did-not-land) — and the document has been
+corrected to describe the commit that did.
 
 ## Changes in Detail
 
-- Reject unsupported timestamps before writing.
-- Propagate persistence anomalies to callers.
-- Update focused tests for the returned anomaly contract.
+Merged as `3d2361e4` ("fix: return anomalies from durable effect
+boundaries (#1672)", 2026-08-11), which squash-merged two files:
+
+| File | Change |
+|------|--------|
+| `components/effect-transaction/test/ai/miniforge/effect_transaction/store_test.clj` | Adds `lifecycle-writes-propagate-store-anomalies-test` (stratum 2). |
+| `docs/pull-requests/2026-08-05-codex-standards-effect-grant-anomalies.md` | This document. |
+
+The test redefines `store/create!` and `store/transition!` to return an
+`:unavailable` anomaly, then asserts both lifecycle entry points return
+that value unchanged. It guards against reintroducing a
+`(do (store/create! dir t) t)` shape, which discards the store's return
+value and reports success on a failed write.
+
+The commit title names a fix the merged diff does not contain. The title
+is preserved here as the durable identifier for `3d2361e4`; treat this
+section, not the title, as the description of what changed.
+
+## What did not land
+
+The branch originally carried the fix the commit title names: six files
+returning serialization and validation failures as anomaly values before
+any write, across `effect-transaction` and `execution-grant`. A 2026-08-07
+rebase dropped them. They patched `store/write!`, which #1705 (`e67c640`)
+had already removed when it split `store.clj` into `persistence.clj` and
+`codec.clj`; every production file conflicted, and the conflicts were
+resolved by discarding the changes rather than porting them.
+
+No follow-up is required. `main` reaches the same guarantees by another
+route:
+
+- `record/propose!` and `record/advance!` validate against
+  `schema/EffectTransaction` before writing, and return `store/create!` /
+  `store/transition!` in tail position, so persistence anomalies reach
+  callers.
+- `persistence/persist!` wraps serialization in `try`/`catch`, and
+  `pr-str` is evaluated before `spit`, so a rejected record never reaches
+  disk.
+- `interface/record-breach!` validates `schema/Breach`, and
+  `interface/revoke-for-cause!` validates
+  `[ExecutionGrant BreachObservation inst?]`, which makes the breach
+  record built from those arguments valid by construction.
+
+Coverage for the execution-grant half already exists in
+`breach_test.clj`: `malformed-breach-is-refused-test`,
+`storage-failures-are-returned-as-data-test`, and
+`both-inst-types-round-trip-test`.
 
 ## Testing Plan
 
-- Focused effect-transaction and execution-grant tests
+- Focused `effect-transaction` tests
 - Normal pre-commit validation
 
 ## Deployment Plan
@@ -28,8 +78,11 @@ No migration or rollout is needed.
 
 - Base Branch: `main`
 - Depends On: none
+- Merged As: `3d2361e4`
+- Context: #1705 (`e67c640`) restructured the durable effect boundary and
+  supplies the anomaly contract this branch set out to add
 
 ## Checklist
 
-- [x] Audit gap fixed
 - [x] Pre-commit checks passed
+- [ ] Audit gap fixed — closed by #1705, not by this commit

--- a/docs/pull-requests/2026-08-05-codex-standards-effect-grant-anomalies.md
+++ b/docs/pull-requests/2026-08-05-codex-standards-effect-grant-anomalies.md
@@ -41,9 +41,11 @@ The branch originally carried the fix the commit title names: six files
 returning serialization and validation failures as anomaly values before
 any write, across `effect-transaction` and `execution-grant`. A 2026-08-07
 rebase dropped them. They patched `store/write!`, a function the durable
-store no longer has: `store.clj` delegates to `persistence.clj` and
-`codec.clj` instead. Every production file conflicted, and the conflicts
-were resolved by discarding the changes rather than porting them.
+store no longer has. `store.clj` now delegates to `persistence.clj`, which
+owns the file, lock, and link handling and in turn calls `codec.clj` at the
+EDN boundary; `store.clj` does not reference the codec itself. Every
+production file conflicted, and the conflicts were resolved by discarding
+the changes rather than porting them.
 
 The commit that performed that split is not identifiable from the current
 history. The earliest commit in this repository (`e67c640`, 2026-08-07) is


### PR DESCRIPTION
## Summary

- Corrects `docs/pull-requests/2026-08-05-codex-standards-effect-grant-anomalies.md`, which describes a six-file fix that never landed while the commit it documents is a single test.
- Records what was dropped, why, and where `main` supplies the same guarantees.
- Docs only. No code changes.

## Motivation

`3d2361e4` ("fix: return anomalies from durable effect boundaries (#1672)", 2026-08-11) merged two files: one regression test and this doc. The doc claims "Reject unsupported timestamps before writing", lists execution-grant breach history under **Strata affected**, and ticks "Audit gap fixed" — none of which that commit does.

The branch did originally carry the fix. A 2026-08-07 rebase dropped it: it patched `store/write!`, a function the durable store no longer has. `store.clj` delegates to `persistence.clj`, which owns the file, lock, and link handling and in turn calls `codec.clj` at the EDN boundary. Every production file conflicted, and the conflicts were resolved by discarding the changes rather than porting them. The reduced two-file version then merged with the original doc intact.

Since `docs/pull-requests/` is the provenance trail for this repo, the record currently attributes a durable-boundary fix to a commit that contains a test. That is the whole of what this PR fixes.

## Changes

| File/Area | Change |
|-----------|--------|
| `docs/pull-requests/2026-08-05-codex-standards-effect-grant-anomalies.md` | Retitled to `test: cover anomaly propagation through the effect lifecycle`. Describes the merged two-file diff, adds a **What did not land** section covering the dropped fix and the rebase that dropped it, notes that the commit title names a fix the diff lacks, and unticks "Audit gap fixed" with the reason. |

## Testing

- [x] Docs-only change; no code paths touched.
- [x] Every claim verified against the repo: `3d2361e4` is an ancestor of `main` and its diff is the two files named; the test is live at `store_test.clj:190`; `record/propose!` and `record/advance!` return `store/create!` / `store/transition!` in tail position; `persistence/persist!` evaluates `pr-str` before `spit`; `interface/record-breach!` validates `schema/Breach` and `interface/revoke-for-cause!` validates `[ExecutionGrant BreachObservation inst?]`; `breach_test.clj` carries the three named tests.
- [x] Header matches the convention in sibling docs.

## Review history

Two errors in the first revision, both caught in review and both fixed:

**`c6cb96e`** — removes an unsupported attribution that credited the durable-store split to #1705 (`e67c640`). That does not hold: `e67c640` is a **root commit** with no parents (`git log -1 --format=%P e67c640` is empty), and it carries the entire repository tree. It contains `persistence.clj` and `codec.clj` as part of that initial tree rather than as a change it made. `git log -- <path>` named it only because the repository's visible history stops there — truncation, not authorship. The split predates everything now visible, so no commit in this history can be credited with it, and the doc now says so explicitly instead of naming one.

**`2db1e8d`** — states the real delegation chain. The doc had said `store.clj` delegates to `persistence.clj` *and* `codec.clj`, implying two direct dependencies. `store.clj` requires only `persistence` (`grep -c codec store.clj` → 0); `persistence.clj` is what requires and calls the codec, at lines 22, 104, and 113. This PR description has been corrected to match.

## Checklist

### Required

- [x] All tests pass (`bb test`) — n/a, no code changed
- [x] Pre-commit validation passes (no `--no-verify`)
- [x] No commented-out tests
- [x] No giant functions
- [x] Functions are small and composable
- [x] New behavior has tests — n/a, no new behavior

### Best Practices

- [x] Code follows development guidelines
- [x] Linting passes (`bb lint:clj:all`) — n/a, no Clojure changed
- [x] README/docs updated if needed
- [x] PR doc created in `docs/pull-requests/YYYY-MM-DD-branch-name.md` — this PR *is* the doc correction; no second doc added, since a new record describing a one-file doc fix would add noise to the same trail it repairs
- [x] Focused PR (single concern)

## Related

- Related to #1672 (closed; content already merged as `3d2361e4`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxt5dHz3fqRBnno6gxHBG