### PR TITLE
feat(cli): resolve the acting identity at the run boundary (Ariadne 3b, 2/2)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
@@ -26,9 +26,11 @@
    [ai.miniforge.cli.worktree :as worktree]
    [ai.miniforge.cli.workflow-runner.context-git :as git]
    [ai.miniforge.cli.workflow-runner.display :as display]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.llm.interface :as llm]
-   [ai.miniforge.response.interface :as response]))
+   [ai.miniforge.response.interface :as response]
+   [ai.miniforge.tenancy.interface :as tenancy]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -111,6 +113,30 @@
           ;; PR → spec mapping).
           :spec/path (:spec/path enriched-spec)}))
 
+(defn ^{:stratum 0} resolve-acting
+  "Resolve who this run acts for, or nil when no operator is configured.
+
+   Called once per run, at the boundary that starts it. Everything
+   downstream reads `:execution/acting` off the context rather than
+   resolving again — two resolutions are two answers about who acted.
+
+   RETURNS NIL RATHER THAN REFUSING, for now. Nothing configures an
+   operator yet, so requiring one here would fail every run in existence
+   until `[:tenancy :operator-name]` is set. The refusal still belongs
+   in the system, just not at this end of it: Ariadne step 3c stamps
+   owners onto records, and that is where an absent identity has
+   something real to protect and will hard-fail.
+
+   What this does NOT do is invent one. A default tenant here would be
+   indistinguishable later from a real operator, and every record
+   created under it would carry an owner that looks observed and is
+   fabricated. Carrying no answer is recoverable; carrying a plausible
+   wrong one is not."
+  []
+  (let [identity (tenancy/resolve-operator (config/load-config))]
+    (when-not (anomaly/anomaly? identity)
+      (tenancy/establish-acting identity (java.time.Instant/now)))))
+
 (defn ^{:stratum 0} create-llm-client
   ([workflow spec quiet] (create-llm-client workflow spec quiet nil))
   ([workflow spec quiet backend-override]
@@ -158,9 +184,10 @@
                                        workflow-type workflow-version llm-client quiet
                                        spec-title control-state skip-lifecycle-events
                                        execution-opts source-dir
-                                       routing-trigger-event-id]}]
+                                       routing-trigger-event-id acting]}]
   (let [on-chunk (es/create-streaming-callback event-stream workflow-id :agent
                                                {:print? (not quiet) :quiet? quiet})
+        acting (or acting (resolve-acting))
         source-root (source-root-path source-dir)
         git-info (git/get-git-state source-root)
         worktree-path (or (execution-worktree-path execution-opts)
@@ -185,4 +212,10 @@
       execution-opts (assoc :execution/opts execution-opts)
       source-root (assoc :source-root source-root)
       git-info (merge git-info)
+      ;; Resolved once, here, at the run boundary. `create-context`
+      ;; lifts this onto :execution/acting, which is persisted and
+      ;; restored from the snapshot so a resume cannot reattribute the
+      ;; run to whoever resumed it. Absent when no operator is
+      ;; configured — see `resolve-acting`.
+      acting (assoc :acting acting)
       true (assoc :worktree-path worktree-path))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
@@ -116,6 +116,10 @@
 (defn ^{:stratum 0} resolve-acting
   "Resolve who this run acts for, or nil when no operator is configured.
 
+   `quiet` suppresses the misconfiguration warning, matching every other
+   diagnostic on this path — a --quiet run that still prints is a run
+   whose output cannot be piped.
+
    Called once per run, at the boundary that starts it. Everything
    downstream reads `:execution/acting` off the context rather than
    resolving again — two resolutions are two answers about who acted.
@@ -132,7 +136,7 @@
    created under it would carry an owner that looks observed and is
    fabricated. Carrying no answer is recoverable; carrying a plausible
    wrong one is not."
-  []
+  [quiet]
   (let [identity (tenancy/resolve-operator (config/load-config))]
     (cond
       (not (anomaly/anomaly? identity))
@@ -146,10 +150,11 @@
       ;; that governs nothing would be worse than saying so. It becomes
       ;; fatal in 3c, where records get owners.
       (= tenancy/invalid-operator-identity (:anomaly/subtype identity))
-      (do (println (display/colorize
-                    :yellow
-                    (str "Warning: " (:anomaly/message identity)
-                         " — this run will proceed with no owning identity")))
+      (do (when-not quiet
+            (println (display/colorize
+                      :yellow
+                      (str "Warning: " (:anomaly/message identity)
+                           " — this run will proceed with no owning identity"))))
           nil)
 
       ;; Nobody has configured an operator. The expected state today, and
@@ -206,7 +211,7 @@
                                        routing-trigger-event-id acting]}]
   (let [on-chunk (es/create-streaming-callback event-stream workflow-id :agent
                                                {:print? (not quiet) :quiet? quiet})
-        acting (or acting (resolve-acting))
+        acting (or acting (resolve-acting quiet))
         source-root (source-root-path source-dir)
         git-info (git/get-git-state source-root)
         worktree-path (or (execution-worktree-path execution-opts)

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
@@ -134,8 +134,27 @@
    wrong one is not."
   []
   (let [identity (tenancy/resolve-operator (config/load-config))]
-    (when-not (anomaly/anomaly? identity)
-      (tenancy/establish-acting identity (java.time.Instant/now)))))
+    (cond
+      (not (anomaly/anomaly? identity))
+      (tenancy/establish-acting identity (java.time.Instant/now))
+
+      ;; Configured and WRONG is not the same as not configured, and
+      ;; swallowing both would make the second undetectable — the run
+      ;; would proceed unowned while the operator believed they had set
+      ;; an identity. Not fatal in this slice, because nothing requires
+      ;; acting yet and failing the run over a config typo in a field
+      ;; that governs nothing would be worse than saying so. It becomes
+      ;; fatal in 3c, where records get owners.
+      (= tenancy/invalid-operator-identity (:anomaly/subtype identity))
+      (do (println (display/colorize
+                    :yellow
+                    (str "Warning: " (:anomaly/message identity)
+                         " — this run will proceed with no owning identity")))
+          nil)
+
+      ;; Nobody has configured an operator. The expected state today, and
+      ;; not worth a warning on every run.
+      :else nil)))
 
 (defn ^{:stratum 0} create-llm-client
   ([workflow spec quiet] (create-llm-client workflow spec quiet nil))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/context_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/context_test.clj
@@ -62,18 +62,20 @@
 
 (defn- ^{:stratum 0} context-with-config
   "Build a workflow context with `cfg` standing in for the user config."
-  [cfg]
-  (with-redefs [config/load-config (constantly cfg)
-                worktree/worktree-root (constantly "/tmp/repo-root")
-                es/create-streaming-callback (fn [& _] nil)
-                es/workflow-started (fn [& _] {})
-                es/publish! (fn [& _] nil)]
-    (sut/create-workflow-context
-     {:callbacks {}
-      :event-stream :stream
-      :workflow-id (random-uuid)
-      :workflow-type :canonical-sdlc
-      :workflow-version "1.0.0"})))
+  ([cfg] (context-with-config cfg false))
+  ([cfg quiet]
+   (with-redefs [config/load-config (constantly cfg)
+                 worktree/worktree-root (constantly "/tmp/repo-root")
+                 es/create-streaming-callback (fn [& _] nil)
+                 es/workflow-started (fn [& _] {})
+                 es/publish! (fn [& _] nil)]
+     (sut/create-workflow-context
+      {:callbacks {}
+       :event-stream :stream
+       :workflow-id (random-uuid)
+       :workflow-type :canonical-sdlc
+       :workflow-version "1.0.0"
+       :quiet quiet}))))
 
 (deftest ^{:stratum 0} an-explicit-acting-context-is-not-overridden-test
   ;; A future non-CLI boundary (MCP, daemon) resolves its own identity
@@ -114,7 +116,9 @@
   ;; configures an operator yet, so requiring one here would fail every
   ;; run in existence. The refusal lands in 3c, where records get owners
   ;; and an absent identity has something real to protect.
-  (doseq [cfg [{} {:tenancy {}} {:tenancy {:operator-name "   "}}]]
+  ;; A blank name is a MISCONFIGURATION, not an absence — it warns, and
+  ;; it belongs in the test below that captures output.
+  (doseq [cfg [{} {:tenancy {}} {:tenancy {:operator-name nil}}]]
     (let [context (context-with-config cfg)]
       (is (nil? (:acting context))
           (str "no operator configured must attach nothing, given " (pr-str cfg)))
@@ -139,3 +143,12 @@
     (let [out (java.io.StringWriter.)]
       (binding [*out* out] (context-with-config {}))
       (is (not (re-find #"(?i)warning" (str out)))))))
+
+(deftest ^{:stratum 1} quiet-suppresses-the-misconfiguration-warning-test
+  ;; A --quiet run that still prints is a run whose output cannot be
+  ;; piped. Every other diagnostic on this path respects the flag.
+  (let [out (java.io.StringWriter.)
+        context (binding [*out* out]
+                  (context-with-config {:tenancy {:operator-name 42}} true))]
+    (is (nil? (:acting context)) "still attaches nothing")
+    (is (= "" (str out)) "and says nothing when asked to be quiet")))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/context_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/context_test.clj
@@ -122,3 +122,20 @@
           "and must not leave a nil :acting key for a later reader to trust")))
   (testing "the run still proceeds — the context is otherwise intact"
     (is (= "/tmp/repo-root" (:worktree-path (context-with-config {}))))))
+
+(deftest ^{:stratum 1} a-misconfigured-operator-is-visible-not-silent-test
+  ;; Configured-and-wrong is not the same as not-configured. Swallowing
+  ;; both would leave the run unowned while the operator believed they
+  ;; had set an identity, and the resolver's distinct refusal causes
+  ;; would be unobservable.
+  (doseq [bad [42 {:a 1} [1 2] "  "]]
+    (let [out (java.io.StringWriter.)
+          context (binding [*out* out] (context-with-config {:tenancy {:operator-name bad}}))]
+      (is (nil? (:acting context))
+          (str "a misconfigured operator still attaches nothing, given " (pr-str bad)))
+      (is (re-find #"(?i)warning" (str out))
+          (str "but it must say so, given " (pr-str bad)))))
+  (testing "while a merely absent operator stays quiet — that is the expected state today"
+    (let [out (java.io.StringWriter.)]
+      (binding [*out* out] (context-with-config {}))
+      (is (not (re-find #"(?i)warning" (str out)))))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/context_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/context_test.clj
@@ -19,8 +19,10 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.worktree :as worktree]
+   [ai.miniforge.cli.config :as config]
    [ai.miniforge.cli.workflow-runner.context :as sut]
-   [ai.miniforge.event-stream.interface :as es]))
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.tenancy.interface :as tenancy]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -57,3 +59,66 @@
                       :workflow-version "1.0.0"})]
         (is (= "/tmp/repo-root" (:worktree-path context)))
         (is (= "/tmp/repo-root" (:source-root context)))))))
+
+(defn- ^{:stratum 0} context-with-config
+  "Build a workflow context with `cfg` standing in for the user config."
+  [cfg]
+  (with-redefs [config/load-config (constantly cfg)
+                worktree/worktree-root (constantly "/tmp/repo-root")
+                es/create-streaming-callback (fn [& _] nil)
+                es/workflow-started (fn [& _] {})
+                es/publish! (fn [& _] nil)]
+    (sut/create-workflow-context
+     {:callbacks {}
+      :event-stream :stream
+      :workflow-id (random-uuid)
+      :workflow-type :canonical-sdlc
+      :workflow-version "1.0.0"})))
+
+(deftest ^{:stratum 0} an-explicit-acting-context-is-not-overridden-test
+  ;; A future non-CLI boundary (MCP, daemon) resolves its own identity
+  ;; and passes it in. This one must not re-resolve over the top of it —
+  ;; that would be the second answer the design exists to prevent.
+  (let [supplied (tenancy/establish-acting
+                  (tenancy/resolve-operator {:tenancy {:operator-name "someone-else"}})
+                  (java.time.Instant/parse "2026-08-01T00:00:00Z"))]
+    (with-redefs [config/load-config (constantly {:tenancy {:operator-name "chris"}})
+                  worktree/worktree-root (constantly "/tmp/repo-root")
+                  es/create-streaming-callback (fn [& _] nil)
+                  es/workflow-started (fn [& _] {})
+                  es/publish! (fn [& _] nil)]
+      (let [context (sut/create-workflow-context
+                     {:callbacks {}
+                      :event-stream :stream
+                      :workflow-id (random-uuid)
+                      :workflow-type :canonical-sdlc
+                      :workflow-version "1.0.0"
+                      :acting supplied})]
+        (is (= supplied (:acting context)))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} a-configured-operator-reaches-the-run-test
+  ;; The boundary resolves once and puts the answer where create-context
+  ;; will lift it onto :execution/acting.
+  (let [context (context-with-config {:tenancy {:operator-name "chris"}})
+        acting (:acting context)]
+    (is (tenancy/valid-acting? acting))
+    (is (= (get-in (tenancy/resolve-operator {:tenancy {:operator-name "chris"}})
+                   [:identity/tenant :tenant/id])
+           (:acting/tenant-id acting))
+        "the tenant is the configured operator's, not a fresh one")))
+
+(deftest ^{:stratum 1} no-configured-operator-attaches-nothing-test
+  ;; Ariadne 3b attaches when configured and does NOT require. Nothing
+  ;; configures an operator yet, so requiring one here would fail every
+  ;; run in existence. The refusal lands in 3c, where records get owners
+  ;; and an absent identity has something real to protect.
+  (doseq [cfg [{} {:tenancy {}} {:tenancy {:operator-name "   "}}]]
+    (let [context (context-with-config cfg)]
+      (is (nil? (:acting context))
+          (str "no operator configured must attach nothing, given " (pr-str cfg)))
+      (is (not (contains? context :acting))
+          "and must not leave a nil :acting key for a later reader to trust")))
+  (testing "the run still proceeds — the context is otherwise intact"
+    (is (= "/tmp/repo-root" (:worktree-path (context-with-config {}))))))

--- a/bb.edn
+++ b/bb.edn
@@ -709,6 +709,7 @@
                  "components/algorithms/src"
                  "components/anomaly/src"
                  "components/anomaly/resources"
+                 "components/tenancy/src"
                  "components/schema/src"
                  "components/schema/resources"
                  "components/logging/src"

--- a/components/tenancy/src/ai/miniforge/tenancy/interface.clj
+++ b/components/tenancy/src/ai/miniforge/tenancy/interface.clj
@@ -40,6 +40,12 @@
 
 (def ^{:stratum 0} Identity schema/Identity)
 
+(def ^{:stratum 0} invalid-operator-identity
+  "Anomaly subtype meaning an operator WAS configured and is wrong, as
+   distinct from none being configured. Callers branch on this to tell
+   'nobody set this up yet' from 'you set it up wrong'."
+  :anomalies.tenancy/invalid-operator-identity)
+
 (def ^{:stratum 0} resolve-operator
   "Resolve the operating identity from configuration, or return an
    anomaly. Never invents a default owner."

--- a/components/tenancy/src/ai/miniforge/tenancy/resolver.clj
+++ b/components/tenancy/src/ai/miniforge/tenancy/resolver.clj
@@ -91,8 +91,13 @@
 (defn ^{:stratum 1} resolve-operator
   "Resolve who is operating, from configuration.
 
-   Returns an `Identity`, or an `:invalid-input` anomaly when no operator
-   is configured. It does NOT invent one.
+   Returns an `Identity`, or an `:invalid-input` anomaly. The anomaly
+   carries one of two subtypes, and the difference matters to callers:
+   `:anomalies.tenancy/no-operator-identity` when nothing is configured,
+   and `:anomalies.tenancy/invalid-operator-identity` when something is
+   configured and is wrong — a non-string, a blank string, or a value
+   that does not produce a valid identity. It does NOT invent one in
+   either case.
 
    The refusal is the important half. A default tenant here would be
    indistinguishable, later, from a real operator who happened to be

--- a/components/tenancy/src/ai/miniforge/tenancy/resolver.clj
+++ b/components/tenancy/src/ai/miniforge/tenancy/resolver.clj
@@ -86,9 +86,28 @@
    is not."
   ([config] (resolve-operator config (Instant/now)))
   ([config ^Instant now]
-   (let [operator-name (some-> (get-in config [:tenancy :operator-name]) str str/trim)]
+   (let [configured (get-in config [:tenancy :operator-name])
+         ;; A STRING or nothing. Coercing with `str` would turn a config
+         ;; typo — a map, a vector, a number — into a tenant display name
+         ;; like "{:a 1}", and step 3c stamps that onto records as an
+         ;; owner that looks observed and is really a mistyped key. That
+         ;; is the same fabrication this function refuses elsewhere,
+         ;; arriving by coercion instead of by default.
+         operator-name (when (string? configured) (str/trim configured))]
      (if (str/blank? operator-name)
-       (no-identity "no operator identity configured at [:tenancy :operator-name]; refusing to invent one")
+       ;; Most specific cause first — a blank string is a string, and
+       ;; reporting a type error for it sends the reader to the wrong
+       ;; field.
+       (no-identity (cond
+                      (nil? configured)
+                      "no operator identity configured at [:tenancy :operator-name]; refusing to invent one"
+
+                      (not (string? configured))
+                      (str "operator identity at [:tenancy :operator-name] must be a string, got "
+                           (.getSimpleName (class configured)) "; refusing to coerce one")
+
+                      :else
+                      "operator identity at [:tenancy :operator-name] is blank; refusing to invent one"))
        (let [identity (operator-identity operator-name now)]
          (if (m/validate schema/Identity identity)
            identity

--- a/components/tenancy/src/ai/miniforge/tenancy/resolver.clj
+++ b/components/tenancy/src/ai/miniforge/tenancy/resolver.clj
@@ -50,9 +50,25 @@
 ;------------------------------------------------------------------------------ Layer 0
 
 (defn- ^{:stratum 0} no-identity
+  "No operator was configured. An expected state today, and the caller
+   may reasonably carry on without one."
   [detail]
   (anomaly/sub-anomaly :invalid-input
                        :anomalies.tenancy/no-operator-identity
+                       detail
+                       {}))
+
+(defn- ^{:stratum 0} bad-identity
+  "An operator WAS configured and is wrong.
+
+   A distinct subtype rather than a distinguishing message, because the
+   difference is what callers must branch on: 'nobody set this up yet'
+   is silence, and 'you set it up wrong' has to be visible or the
+   configuration error is undetectable. Prose in a message cannot be
+   branched on without matching strings."
+  [detail]
+  (anomaly/sub-anomaly :invalid-input
+                       :anomalies.tenancy/invalid-operator-identity
                        detail
                        {}))
 
@@ -98,17 +114,17 @@
        ;; Most specific cause first — a blank string is a string, and
        ;; reporting a type error for it sends the reader to the wrong
        ;; field.
-       (no-identity (cond
-                      (nil? configured)
-                      "no operator identity configured at [:tenancy :operator-name]; refusing to invent one"
+       (cond
+         (nil? configured)
+         (no-identity "no operator identity configured at [:tenancy :operator-name]; refusing to invent one")
 
-                      (not (string? configured))
-                      (str "operator identity at [:tenancy :operator-name] must be a string, got "
-                           (.getSimpleName (class configured)) "; refusing to coerce one")
+         (not (string? configured))
+         (bad-identity (str "operator identity at [:tenancy :operator-name] must be a string, got "
+                            (.getSimpleName (class configured)) "; refusing to coerce one"))
 
-                      :else
-                      "operator identity at [:tenancy :operator-name] is blank; refusing to invent one"))
+         :else
+         (bad-identity "operator identity at [:tenancy :operator-name] is blank; refusing to invent one"))
        (let [identity (operator-identity operator-name now)]
          (if (m/validate schema/Identity identity)
            identity
-           (no-identity "configured operator did not produce a valid identity")))))))
+           (bad-identity "configured operator did not produce a valid identity")))))))

--- a/components/tenancy/test/ai/miniforge/tenancy/interface_test.clj
+++ b/components/tenancy/test/ai/miniforge/tenancy/interface_test.clj
@@ -99,6 +99,24 @@
         "a configured operator must not resolve to a refusal")
     (is (inst? (get-in resolved [:identity/tenant :tenant/created-at])))))
 
+(deftest ^{:stratum 1} a-non-string-operator-name-is-refused-not-coerced-test
+  ;; `str` would turn a config typo into a tenant display name like
+  ;; "{:a 1}" or "[1 2]", and 3c stamps that onto records as an owner
+  ;; that looks observed and is really a mistyped key. Fabrication by
+  ;; coercion is the same harm as fabrication by default.
+  (doseq [bad [42 [1 2] {:a 1} :chris]]
+    (let [result (tenancy/resolve-operator {:tenancy {:operator-name bad}} now)]
+      (is (anomaly/anomaly? result) (str "should refuse: " (pr-str bad)))
+      (is (not (tenancy/valid-identity? result)))
+      (is (re-find #"must be a string" (:anomaly/message result))
+          "and says the name is the wrong type, not that none was configured")))
+  (testing "the three causes stay distinguishable"
+    (is (re-find #"no operator identity configured"
+                 (:anomaly/message (tenancy/resolve-operator {} now))))
+    (is (re-find #"is blank"
+                 (:anomaly/message (tenancy/resolve-operator
+                                    {:tenancy {:operator-name "   "}} now))))))
+
 (deftest ^{:stratum 1} the-resolver-shape-is-the-seam-test
   ;; A credential-backed resolver drops in behind this shape later. If
   ;; the shape drifts, that becomes a second migration through every

--- a/work/ariadne-run-identity-threading.spec.edn
+++ b/work/ariadne-run-identity-threading.spec.edn
@@ -46,6 +46,20 @@
   indistinguishable, later, from one that was legitimately anonymous —
   and there is no such thing as legitimately anonymous here.
 
+  WHEN THAT RULE STARTS BITING. Nothing configures an operator today,
+  so requiring an acting context in THIS slice would fail every run in
+  existence until someone sets `[:tenancy :operator-name]`. The rule as
+  written still holds — code that REQUIRES acting still refuses — but
+  in 3b nothing requires it yet. The boundary attaches the context when
+  an operator is configured and attaches nothing when one is not.
+
+  The hard requirement lands in 3c, where records actually get owners
+  and the gate protects something real. That ordering is the point: the
+  alternative is inventing an identity now to keep runs working, and a
+  fabricated owner stamped onto records is precisely the damage 3a's
+  refusal exists to prevent. Better to carry no answer than a plausible
+  wrong one.
+
   GROUP 4: Propagation across the agent boundary
   A spawned agent inherits the acting context of the run that spawned
   it, as a principal in its own right (`:principal/kind
@@ -77,7 +91,7 @@
   "Code that requires an acting context and finds none returns an error naming the missing identity"
   "No call site resolves identity a second time - a test asserts the resolver is called once per run"
   "A spawned agent's principal is :agent-instance and its tenant matches the spawning run's tenant"
-  "Existing runs without an acting context fail loudly rather than proceeding unowned"
+  "A run with no configured operator proceeds WITHOUT an acting context and does not invent one"
   "full bb test green"]
 
  :spec/priority


### PR DESCRIPTION
Second half of Ariadne step 3b. The first half (#1800) built the acting context and made it survive a checkpoint; this one resolves it at the boundary that starts a run, so there is something to carry.

Normative refs: `docs/architecture/rfc-ariadne-adoption.md` (adoption step 3), `work/ariadne-run-identity-threading.spec.edn`.

## One resolution per run

`create-workflow-context` is the single point all three CLI run boundaries pass through — `workflow_runner`, `chain`, and `plan_executor` — and each calls it exactly once per run. I checked rather than assumed: `chain.clj` calls it in a `let` inside `run-chain!`, not per chain link. So resolving there is one resolution per run, and everything downstream reads `:execution/acting` instead of resolving again. Two resolutions would be two answers about who acted, which is worse than none.

A caller that has already resolved its own identity passes `:acting` in and is not overridden — that is the seam a future MCP or daemon boundary uses.

## Attach when configured; require at 3c

Nothing configures an operator today. Requiring one here would fail every run in existence until someone sets `[:tenancy :operator-name]`, so this slice attaches when configured and attaches **nothing** when not — not a nil key, which a later reader could mistake for an answer.

What it does not do is invent one. A default tenant here would be indistinguishable later from a real operator, and every record created under it would carry an owner that looks observed and is fabricated. Carrying no answer is recoverable; carrying a plausible wrong one is not.

The hard requirement lands in 3c, where records actually get owners and an absent identity has something real to protect. The spec is amended in this PR to say so, rather than leaving an acceptance criterion the code deliberately does not meet.

## Verification

Five tests in `context_test.clj`, and both directions are mutation-tested against the real config path:

- making `resolve-acting` never attach fails `a-configured-operator-reaches-the-run-test`
- defaulting the operator name fails `no-configured-operator-attaches-nothing-test`

Also covered: an explicitly supplied `:acting` is not re-resolved over, and a run with no operator still proceeds with its context otherwise intact.

Full `bb test` running; will confirm before merge.