### PR TITLE
fix(loop): correct :require-docstrings comment and add policy-gate tests

### DIFF
--- a/components/loop/src/ai/miniforge/loop/gates.clj
+++ b/components/loop/src/ai/miniforge/loop/gates.clj
@@ -300,10 +300,14 @@
                           acc)
 
                         ;; Require docstrings
+                        ;; Matches (defn name [...]) with NO string literal between
+                        ;; the function name and the arg vector.  The negative
+                        ;; lookahead (?!") explicitly excludes (defn name "doc" [...])
+                        ;; so documented functions are never flagged.
                         :require-docstrings
                         (if (and (string? content)
                                  (#{:code} artifact-type)
-                                 (re-find #"\(defn\s+\S+\s+\[" content))
+                                 (re-find #"\(defn\s+\S+\s+(?!\")\[" content))
                           (conj acc (make-error :missing-docstring
                                                 (messages/t :gate/missing-docstring)))
                           acc)

--- a/components/loop/src/ai/miniforge/loop/gates.clj
+++ b/components/loop/src/ai/miniforge/loop/gates.clj
@@ -300,14 +300,14 @@
                           acc)
 
                         ;; Require docstrings
-                        ;; Matches (defn name [...]) with NO string literal between
-                        ;; the function name and the arg vector.  The negative
-                        ;; lookahead (?!") explicitly excludes (defn name "doc" [...])
-                        ;; so documented functions are never flagged.
+                        ;; Matches (defn name [...]) where the arg vector immediately
+                        ;; follows the function name (whitespace only).  A docstring
+                        ;; literal between the name and the vector breaks \s+\[, so
+                        ;; documented functions are never flagged.
                         :require-docstrings
                         (if (and (string? content)
                                  (#{:code} artifact-type)
-                                 (re-find #"\(defn\s+\S+\s+(?!\")\[" content))
+                                 (re-find #"\(defn\s+\S+\s+\[" content))
                           (conj acc (make-error :missing-docstring
                                                 (messages/t :gate/missing-docstring)))
                           acc)

--- a/components/loop/test/ai/miniforge/loop/gates_test.clj
+++ b/components/loop/test/ai/miniforge/loop/gates_test.clj
@@ -183,7 +183,32 @@
                                 :artifact/content "; TODO: fix this later\n(defn x [] :ok)"}
             result (gates/check todo-gate artifact-with-todo {})]
         (is (not (:gate/passed? result)))
-        (is (= :todo-found (:code (first (:gate/errors result)))))))))
+        (is (= :todo-found (:code (first (:gate/errors result)))))))
+
+    (testing "require-docstrings policy flags functions without docstrings"
+      (let [doc-gate (gates/policy-gate :docs {:policies [:require-docstrings]})
+            artifact-no-doc {:artifact/id (random-uuid)
+                             :artifact/type :code
+                             :artifact/content "(defn undocumented [x] (* x 2))"}
+            result (gates/check doc-gate artifact-no-doc {})]
+        (is (not (:gate/passed? result)))
+        (is (= :missing-docstring (:code (first (:gate/errors result)))))))
+
+    (testing "require-docstrings policy passes for functions with docstrings"
+      (let [doc-gate (gates/policy-gate :docs {:policies [:require-docstrings]})
+            artifact-with-doc {:artifact/id (random-uuid)
+                               :artifact/type :code
+                               :artifact/content "(defn documented \"Doubles x.\" [x] (* x 2))"}
+            result (gates/check doc-gate artifact-with-doc {})]
+        (is (:gate/passed? result))))
+
+    (testing "require-docstrings policy passes for multiline functions with docstrings"
+      (let [doc-gate (gates/policy-gate :docs {:policies [:require-docstrings]})
+            artifact-multiline-doc {:artifact/id (random-uuid)
+                                    :artifact/type :code
+                                    :artifact/content "(defn documented\n  \"Doubles x.\"\n  [x]\n  (* x 2))"}
+            result (gates/check doc-gate artifact-multiline-doc {})]
+        (is (:gate/passed? result))))))
 
 (deftest ^{:stratum 1} test-gate-test
   (testing "test gate with no test-fn passes with warning"


### PR DESCRIPTION
## Problem

The `:require-docstrings` branch in `PolicyGate/check` had a misleading comment and lacked test coverage for the documented-function case. The regex itself was always correct, but the absence of tests left the intent implicit and the comment was inaccurate.

A code-review pass (Copilot, PR #1831) confirmed that the `\s+\[` pattern already excludes documented functions by construction: `\[` requires `[` immediately, so any docstring literal between the function name and the arg vector breaks the match without any additional guard.

## Fix

`components/loop/src/ai/miniforge/loop/gates.clj` — rewrite the comment to accurately describe the mechanism:

```clojure
;; before
;; Require docstrings
:require-docstrings
(if (and (string? content)
         (#{:code} artifact-type)
         (re-find #"\(defn\s+\S+\s+\[" content))
  ...)

;; after — comment clarified; regex unchanged
;; Matches (defn name [...]) where the arg vector immediately
;; follows the function name (whitespace only).  A docstring
;; literal between the name and the vector breaks \s+\[, so
;; documented functions are never flagged.
:require-docstrings
(if (and (string? content)
         (#{:code} artifact-type)
         (re-find #"\(defn\s+\S+\s+\[" content))
  ...)
```

| Form | Result |
|------|--------|
| `(defn foo [x] ...)` | matches → `:missing-docstring` error (correct) |
| `(defn foo "doc" [x] ...)` | no match → passes (correct) |
| `(defn foo\n  "doc"\n  [x] ...)` | no match → passes (correct) |

## Tests

Three new cases added to `policy-gate-test` in `gates_test.clj`:

1. **Function without docstring** → gate fails with `:missing-docstring`
2. **Function with inline docstring** → gate passes
3. **Function with multiline docstring** → gate passes

## Checklist

- [x] Single-stratum change (`components/loop` only)
- [x] No new files (Apache-2.0 header not required)
- [x] Existing tests unchanged; three new cases added
- [x] Regex behaviour unchanged from `main`; comment corrected

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhFydG1tZ1N8WyS93NkdUq)_