### PR TITLE
feat(deliberation-workspace): N14 termination rules

### DIFF
--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/termination.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/termination.clj
@@ -1,0 +1,74 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.deliberation-workspace.termination
+  "The N14 §7 closing rules: success, budget boundary, quiescence, deadlock."
+  (:require
+   [ai.miniforge.deliberation-workspace.object :as object]
+   [ai.miniforge.deliberation-workspace.scheduler :as scheduler]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} default-quiescence-rounds
+  "Consecutive committed transactions producing no new open objects before
+   the run is quiescent (N14 §7)."
+  3)
+
+(defn- ^{:stratum 0} goals-terminal? [workspace]
+  (let [goals (->> (get workspace :workspace/objects {})
+                   vals
+                   (filter #(= :goal (:object/type %))))]
+    (and (seq goals) (every? object/terminal? goals))))
+
+(defn- ^{:stratum 0} exhausted-budget
+  "The budget dimension that ran out, or nil while the run can still spend."
+  [workspace]
+  (let [{:keys [activations cost]} (get workspace :workspace/budget {})
+        spent (get workspace :workspace/spent {})]
+    (cond
+      (and activations (>= (get spent :activations 0) activations)) :activations
+      (and cost (>= (get spent :cost 0) cost)) :cost)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} quiescent? [workspace]
+  (>= (get workspace :workspace/quiet-rounds 0)
+      (get workspace :workspace/quiescence-rounds default-quiescence-rounds)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} closing-rule
+  "The §7 rule that fires, or nil while the run continues.
+
+   Order matters: success is checked before budget so a run that completes
+   on its last permitted activation closes as a success, not an exhaustion."
+  [workspace]
+  (let [exhausted (exhausted-budget workspace)]
+    (cond
+      (goals-terminal? workspace)
+      {:termination/rule :success}
+
+      exhausted
+      {:termination/rule :budget-boundary
+       :termination/detail exhausted
+       :termination/forced-synthesis true}
+
+      (quiescent? workspace)
+      {:termination/rule :quiescence}
+
+      (nil? (scheduler/next-activation workspace))
+      {:termination/rule :deadlock})))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/termination_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/termination_test.clj
@@ -19,7 +19,7 @@
   (:require
    [ai.miniforge.deliberation-workspace.object :as object]
    [ai.miniforge.deliberation-workspace.termination :as termination]
-   [clojure.test :refer [deftest is]]))
+   [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -64,3 +64,24 @@
 (deftest ^{:stratum 1} deadlock-closes-a-run-with-no-eligible-role
   (let [ws (workspace [(obj "goal-1" :goal)] :workspace/roles [])]
     (is (= :deadlock (:termination/rule (termination/closing-rule ws))))))
+
+(deftest ^{:stratum 1} cost-exhaustion-closes-the-run-the-same-way
+  (testing "the cost ceiling is a budget dimension like any other"
+    (let [ws (workspace [(obj "goal-1" :goal)]
+                        :workspace/budget {:cost 25.0}
+                        :workspace/spent {:cost 25.0})
+          result (termination/closing-rule ws)]
+      (is (= :budget-boundary (:termination/rule result)))
+      (is (= :cost (:termination/detail result)))
+      (is (:termination/forced-synthesis result))))
+  (testing "spend below the ceiling does not close the run"
+    (let [ws (workspace [(obj "goal-1" :goal)]
+                        :workspace/budget {:cost 25.0}
+                        :workspace/spent {:cost 24.0}
+                        :workspace/log [{:tx/role :proposer}])]
+      (is (nil? (termination/closing-rule ws)))))
+  (testing "activations are checked before cost, so the detail is unambiguous"
+    (let [ws (workspace [(obj "goal-1" :goal)]
+                        :workspace/budget {:activations 5 :cost 25.0}
+                        :workspace/spent {:activations 5 :cost 25.0})]
+      (is (= :activations (:termination/detail (termination/closing-rule ws)))))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/termination_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/termination_test.clj
@@ -1,0 +1,66 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.deliberation-workspace.termination-test
+  (:require
+   [ai.miniforge.deliberation-workspace.object :as object]
+   [ai.miniforge.deliberation-workspace.termination :as termination]
+   [clojure.test :refer [deftest is]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} obj [id type & {:keys [status]}]
+  (cond-> (object/new-object {:id id :type type :statement (str "statement " id)
+                              :role :proposer :activation "act-1" :version 1})
+    status (assoc :object/status status)))
+
+(defn- ^{:stratum 0} workspace [objects & {:as extra}]
+  (merge {:workspace/version 10
+          :workspace/objects (into {} (map (juxt :object/id identity)) objects)
+          :workspace/roles [:proposer :skeptic :synthesizer]
+          :workspace/eligibility {}
+          :workspace/log []}
+         extra))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} success-closes-before-budget-exhaustion
+  (let [ws (workspace [(obj "goal-1" :goal :status :accepted)]
+                      :workspace/budget {:activations 5}
+                      :workspace/spent {:activations 5})]
+    (is (= :success (:termination/rule (termination/closing-rule ws))))))
+
+(deftest ^{:stratum 1} budget-exhaustion-forces-a-synthesis
+  (let [ws (workspace [(obj "goal-1" :goal)]
+                      :workspace/budget {:activations 5}
+                      :workspace/spent {:activations 5})
+        result (termination/closing-rule ws)]
+    (is (= :budget-boundary (:termination/rule result)))
+    (is (= :activations (:termination/detail result)))
+    (is (:termination/forced-synthesis result))))
+
+(deftest ^{:stratum 1} quiescence-closes-a-run-that-stopped-producing
+  (let [ws (workspace [(obj "goal-1" :goal)] :workspace/quiet-rounds 3)]
+    (is (= :quiescence (:termination/rule (termination/closing-rule ws))))))
+
+(deftest ^{:stratum 1} a-live-run-does-not-terminate
+  (let [ws (workspace [(obj "goal-1" :goal)] :workspace/log [{:tx/role :proposer}])]
+    (is (nil? (termination/closing-rule ws)))))
+
+(deftest ^{:stratum 1} deadlock-closes-a-run-with-no-eligible-role
+  (let [ws (workspace [(obj "goal-1" :goal)] :workspace/roles [])]
+    (is (= :deadlock (:termination/rule (termination/closing-rule ws))))))


### PR DESCRIPTION
Seventh slice of the **N14 Stage 0 pilot**. Stacked on the scheduler PR.

## What this adds

`closing-rule` returns the §7 rule that fires, or nil while the run
continues:

1. **success** — every goal terminal
2. **budget boundary** — activations or cost exhausted; carries
   `:termination/forced-synthesis` so the run loop knows to spend the
   reserved closure allowance (§6.3) on a final synthesizer activation
3. **quiescence** — consecutive transactions producing nothing new
4. **deadlock** — no eligible role remains

## Why the order is fixed

Success is checked **before** budget exhaustion. A run that completes its
last goal on its last permitted activation should close as a success, not an
exhaustion — otherwise the N15 harness would score a completed run as a
budget failure and the success metric would under-report exactly at the
tier boundary, where the interesting comparisons live.

## Testing

5 tests / 7 assertions covering each rule and the success-beats-exhaustion
ordering, plus the negative case that a live run returns nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)