### PR TITLE
feat(deliberation-workspace): engine-derived conflicts

### DIFF
--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/conflict.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/conflict.clj
@@ -27,19 +27,27 @@
 ;------------------------------------------------------------------------------ Layer 0
 
 (defn ^{:stratum 0} derive-conflicts
-  "N14 §2.5: a conflict object is derived for every pair of live claims
-   linked `contradicts`. Conflicts are engine-derived, never proposed, and
-   are closed by resolving a participant rather than by deletion."
+  "N14 §2.5: a conflict object is derived for every pair of live objects
+   linked `contradicts` — any non-terminal object that is not itself a
+   conflict, not only claims. Conflicts are engine-derived, never proposed,
+   and are closed by resolving a participant rather than by deletion.
+
+   Pairs are canonicalised into sorted id order and de-duplicated, so the
+   conflict a pair derives does not depend on which side happens to hold the
+   `contradicts` edge, and a symmetric pair that points both ways still
+   derives exactly one conflict."
   [workspace version]
   (let [objects (get workspace :workspace/objects {})
         contradictable? (fn [id]
                           (when-let [o (get objects id)]
                             (and (not (object/terminal? o))
                                  (not= :conflict (:object/type o)))))
-        pairs (for [[id o] (sort-by key objects)
-                    target (sort (object/linked o :contradicts))
-                    :when (and (contradictable? id) (contradictable? target))]
-                [id target])]
+        pairs (->> (for [[id o] objects
+                         target (object/linked o :contradicts)
+                         :when (and (contradictable? id) (contradictable? target))]
+                     (vec (sort [id target])))
+                   distinct
+                   sort)]
     (reduce (fn [ws [id target]]
               (let [conflict-id (str "conflict-" id "-" target)]
                 (if (get-in ws [:workspace/objects conflict-id])

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/conflict.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/conflict.clj
@@ -1,0 +1,54 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.deliberation-workspace.conflict
+  "Engine-derived conflicts (N14 §2.5).
+
+   Conflicts are never proposed by an activation and are never closed by
+   deletion — only by a transaction that resolves or supersedes one of the
+   participants."
+  (:require
+   [ai.miniforge.deliberation-workspace.object :as object]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} derive-conflicts
+  "N14 §2.5: a conflict object is derived for every pair of live claims
+   linked `contradicts`. Conflicts are engine-derived, never proposed, and
+   are closed by resolving a participant rather than by deletion."
+  [workspace version]
+  (let [objects (get workspace :workspace/objects {})
+        contradictable? (fn [id]
+                          (when-let [o (get objects id)]
+                            (and (not (object/terminal? o))
+                                 (not= :conflict (:object/type o)))))
+        pairs (for [[id o] (sort-by key objects)
+                    target (sort (object/linked o :contradicts))
+                    :when (and (contradictable? id) (contradictable? target))]
+                [id target])]
+    (reduce (fn [ws [id target]]
+              (let [conflict-id (str "conflict-" id "-" target)]
+                (if (get-in ws [:workspace/objects conflict-id])
+                  ws
+                  (assoc-in ws [:workspace/objects conflict-id]
+                            (object/new-object
+                             {:id conflict-id :type :conflict
+                              :statement (str "contradiction between " id " and " target)
+                              :role :engine :activation "derived" :version version
+                              :links {:contradicts #{id target}}})))))
+            workspace
+            pairs)))

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/conflict.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/conflict.clj
@@ -35,7 +35,13 @@
    Pairs are canonicalised into sorted id order and de-duplicated, so the
    conflict a pair derives does not depend on which side happens to hold the
    `contradicts` edge, and a symmetric pair that points both ways still
-   derives exactly one conflict."
+   derives exactly one conflict.
+
+   A conflict is a relation between two objects, so an object contradicting
+   its own id derives nothing. Admitting it would mint a `conflict-x-x` that
+   no transaction can resolve — nothing supersedes a participant without
+   superseding the other — and the §6.1 conflict tier would keep selecting
+   it for as long as the run lasts."
   [workspace version]
   (let [objects (get workspace :workspace/objects {})
         contradictable? (fn [id]
@@ -44,7 +50,9 @@
                                  (not= :conflict (:object/type o)))))
         pairs (->> (for [[id o] objects
                          target (object/linked o :contradicts)
-                         :when (and (contradictable? id) (contradictable? target))]
+                         :when (and (not= id target)
+                                    (contradictable? id)
+                                    (contradictable? target))]
                      (vec (sort [id target])))
                    distinct
                    sort)]

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/conflict_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/conflict_test.clj
@@ -1,0 +1,87 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.deliberation-workspace.conflict-test
+  (:require
+   [ai.miniforge.deliberation-workspace.conflict :as conflict]
+   [ai.miniforge.deliberation-workspace.object :as object]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} obj [id type & {:keys [links status]}]
+  (cond-> (object/new-object {:id id :type type :statement (str "statement " id)
+                              :role :proposer :activation "act-1" :version 1
+                              :links links})
+    status (assoc :object/status status)))
+
+(defn- ^{:stratum 0} workspace [& objects]
+  {:workspace/version 5
+   :workspace/objects (into {} (map (juxt :object/id identity)) objects)})
+
+(defn- ^{:stratum 0} conflicts-in [ws]
+  (filter #(= :conflict (:object/type %)) (vals (:workspace/objects ws))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} contradicting-claims-derive-a-conflict
+  (let [ws (conflict/derive-conflicts
+            (workspace (obj "claim-1" :claim :links {:contradicts #{"claim-2"}})
+                       (obj "claim-2" :claim))
+            6)
+        derived (first (conflicts-in ws))]
+    (is (= "conflict-claim-1-claim-2" (:object/id derived)))
+    (testing "conflicts are engine-derived, never proposed by a role"
+      (is (= :engine (:object/role derived))))
+    (testing "the conflict names both participants"
+      (is (= #{"claim-1" "claim-2"} (object/linked derived :contradicts))))))
+
+(deftest ^{:stratum 1} derivation-is-idempotent
+  (let [base (workspace (obj "claim-1" :claim :links {:contradicts #{"claim-2"}})
+                        (obj "claim-2" :claim))
+        twice (-> base (conflict/derive-conflicts 6) (conflict/derive-conflicts 7))]
+    (is (= 1 (count (conflicts-in twice))))))
+
+(deftest ^{:stratum 1} a-derived-conflict-does-not-breed
+  (testing "the conflict's own contradicts edges never derive further conflicts"
+    (let [ws (-> (workspace (obj "claim-1" :claim :links {:contradicts #{"claim-2"}})
+                            (obj "claim-2" :claim))
+                 (conflict/derive-conflicts 6)
+                 (conflict/derive-conflicts 7)
+                 (conflict/derive-conflicts 8))]
+      (is (= 1 (count (conflicts-in ws)))))))
+
+(deftest ^{:stratum 1} a-terminal-participant-produces-no-conflict
+  (let [ws (conflict/derive-conflicts
+            (workspace (obj "claim-1" :claim :links {:contradicts #{"claim-2"}})
+                       (obj "claim-2" :claim :status :superseded))
+            6)]
+    (is (empty? (conflicts-in ws)))))
+
+(deftest ^{:stratum 1} a-missing-participant-produces-no-conflict
+  (let [ws (conflict/derive-conflicts
+            (workspace (obj "claim-1" :claim :links {:contradicts #{"claim-404"}}))
+            6)]
+    (is (empty? (conflicts-in ws)))))
+
+(deftest ^{:stratum 1} derivation-is-deterministic
+  (let [objects [(obj "claim-2" :claim :links {:contradicts #{"claim-1"}})
+                 (obj "claim-1" :claim :links {:contradicts #{"claim-2"}})]
+        forward (conflict/derive-conflicts (apply workspace objects) 6)
+        reversed (conflict/derive-conflicts (apply workspace (reverse objects)) 6)]
+    (is (= (sort (map :object/id (conflicts-in forward)))
+           (sort (map :object/id (conflicts-in reversed)))))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/conflict_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/conflict_test.clj
@@ -85,3 +85,28 @@
         reversed (conflict/derive-conflicts (apply workspace (reverse objects)) 6)]
     (is (= (sort (map :object/id (conflicts-in forward)))
            (sort (map :object/id (conflicts-in reversed)))))))
+
+(deftest ^{:stratum 1} a-symmetric-pair-derives-exactly-one-conflict
+  (testing "both sides holding the edge is still one contradiction"
+    (let [ws (conflict/derive-conflicts
+              (workspace (obj "claim-1" :claim :links {:contradicts #{"claim-2"}})
+                         (obj "claim-2" :claim :links {:contradicts #{"claim-1"}}))
+              6)]
+      (is (= 1 (count (conflicts-in ws))))
+      (is (= "conflict-claim-1-claim-2"
+             (:object/id (first (conflicts-in ws))))))))
+
+(deftest ^{:stratum 1} the-conflict-id-is-canonical-whichever-side-holds-the-edge
+  (let [forward (conflict/derive-conflicts
+                 (workspace (obj "claim-1" :claim :links {:contradicts #{"claim-2"}})
+                            (obj "claim-2" :claim))
+                 6)
+        backward (conflict/derive-conflicts
+                  (workspace (obj "claim-1" :claim)
+                             (obj "claim-2" :claim :links {:contradicts #{"claim-1"}}))
+                  6)]
+    (is (= (map :object/id (conflicts-in forward))
+           (map :object/id (conflicts-in backward)))
+        "a directional id would make the same contradiction derive twice")
+    (is (= "conflict-claim-1-claim-2"
+           (:object/id (first (conflicts-in backward)))))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/conflict_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/conflict_test.clj
@@ -110,3 +110,19 @@
         "a directional id would make the same contradiction derive twice")
     (is (= "conflict-claim-1-claim-2"
            (:object/id (first (conflicts-in backward)))))))
+
+(deftest ^{:stratum 1} an-object-contradicting-itself-derives-no-conflict
+  (testing "a conflict is a relation between two objects"
+    (let [ws (conflict/derive-conflicts
+              (workspace (obj "claim-1" :claim :links {:contradicts #{"claim-1"}}))
+              6)]
+      (is (empty? (conflicts-in ws))
+          "conflict-claim-1-claim-1 has no second participant to resolve")))
+  (testing "a self-link does not suppress the real pair beside it"
+    (let [ws (conflict/derive-conflicts
+              (workspace (obj "claim-1" :claim
+                              :links {:contradicts #{"claim-1" "claim-2"}})
+                         (obj "claim-2" :claim))
+              6)]
+      (is (= ["conflict-claim-1-claim-2"]
+             (map :object/id (conflicts-in ws)))))))


### PR DESCRIPTION
Eighth slice of the **N14 Stage 0 pilot**. Stacked on
https://github.com/miniforge-ai/miniforge/pull/1838.

## What this adds

`derive-conflicts` implements §2.5: a conflict object is derived for every
pair of live objects linked `contradicts`. Conflicts are engine-derived —
never proposed by an activation — and are closed by resolving a participant
rather than by deletion.

Derivation is idempotent and deterministic: pairs are generated in sorted id
order, and re-deriving over an existing conflict is a no-op.

## The bug this slice already caught

A derived conflict carries `contradicts` edges to both participants. Without
excluding conflict objects from pair generation, the next derivation pass
treats those edges as a fresh contradiction and derives conflicts *about the
conflict* — one pass produced three objects instead of one, growing every
round. There is now a test that runs three passes and asserts the count stays
at one.

Left unfixed this would have been quietly fatal to G0: conflicts are the
scheduler's highest priority (§6.1), so a self-breeding conflict set would
starve every other trigger and the run would spend its whole budget
re-examining its own bookkeeping.

## Testing

6 tests / 8 assertions: derivation and its participants, idempotency, the
non-breeding property across three passes, terminal and missing participants,
and determinism across insertion order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)