### PR TITLE
feat(deliberation-workspace): apply validated transactions

### DIFF
--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/commit.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/commit.clj
@@ -53,22 +53,33 @@
             workspace
             (get operation :links {}))))
 
-(defn- ^{:stratum 0} record-challenge [workspace operation context version]
+(defn- ^{:stratum 0} record-challenge
+  "Record one open challenge per target for the §3.5 anti-livelock cap.
+
+   The ordinal keeps two challenges on the same target inside one commit
+   from colliding. Overwriting would undercount open challenges, which is
+   exactly what the cap reads.
+
+   Ordinals are handed out over SORTED targets from a single start count
+   read before the reduce. `touched-ids` returns a set, so counting inside
+   the reduce would tie each id to set iteration order: the same
+   transaction could rebuild different challenge ids on a different run,
+   and an id that does not follow from the log is not reconstructible
+   from it."
+  [workspace operation context version]
   (if (= :challenge (:op operation))
-    (reduce (fn [ws id]
-              ;; The ordinal keeps two challenges on the same target inside one
-              ;; commit from colliding. Overwriting would undercount open
-              ;; challenges, which is exactly what the §3.5 cap reads.
-              (let [ordinal (count (get ws :workspace/challenges {}))
-                    challenge-id (str "challenge-" version "-" ordinal "-" id)]
-                (assoc-in ws [:workspace/challenges challenge-id]
-                          {:challenge/id challenge-id
-                           :challenge/role (:role context)
-                           :challenge/target id
-                           :challenge/status :open
-                           :challenge/version version})))
-            workspace
-            (tx/touched-ids operation))
+    (let [start (count (get workspace :workspace/challenges {}))]
+      (reduce (fn [ws [ordinal id]]
+                (let [challenge-id (str "challenge-" version "-"
+                                        (+ start ordinal) "-" id)]
+                  (assoc-in ws [:workspace/challenges challenge-id]
+                            {:challenge/id challenge-id
+                             :challenge/role (:role context)
+                             :challenge/target id
+                             :challenge/status :open
+                             :challenge/version version})))
+              workspace
+              (map-indexed vector (sort (tx/touched-ids operation)))))
     workspace))
 
 (defn- ^{:stratum 0} insert-created

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/commit.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/commit.clj
@@ -1,0 +1,115 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.deliberation-workspace.commit
+  "Applying a validated transaction to the workspace (N14 §3) and deriving
+   conflicts (§2.5).
+
+   Status effects are derived from the operation, never from agent-supplied
+   data: an activation chooses which operation to propose, and the engine
+   decides what that operation does. Otherwise a transaction could name
+   `:challenge` and carry `:accepted`."
+  (:require
+   [ai.miniforge.deliberation-workspace.conflict :as conflict]
+   [ai.miniforge.deliberation-workspace.object :as object]
+   [ai.miniforge.deliberation-workspace.transaction :as tx]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} apply-links [workspace operation]
+  (reduce (fn [ws [edge targets]]
+            (reduce (fn [w id]
+                      (update-in w [:workspace/objects id]
+                                 object/add-link edge (:source operation)))
+                    ws
+                    targets))
+          workspace
+          (get operation :links {})))
+
+(defn- ^{:stratum 0} record-challenge [workspace operation context version]
+  (if (= :challenge (:op operation))
+    (reduce (fn [ws id]
+              (let [challenge-id (str "challenge-" version "-" id)]
+                (assoc-in ws [:workspace/challenges challenge-id]
+                          {:challenge/id challenge-id
+                           :challenge/role (:role context)
+                           :challenge/target id
+                           :challenge/status :open
+                           :challenge/version version})))
+            workspace
+            (tx/touched-ids operation))
+    workspace))
+
+(defn- ^{:stratum 0} insert-created
+  "Insert the objects `operation` creates, stamping provenance from the
+   transaction rather than trusting the activation's own report of it."
+  [workspace operation {:keys [role activation version]}]
+  (reduce (fn [ws spec]
+            (let [created (object/new-object
+                           (assoc spec :role role :activation activation
+                                  :version version))]
+              (assoc-in ws [:workspace/objects (:object/id created)] created)))
+          workspace
+          (get operation :creates [])))
+
+(defn- ^{:stratum 0} apply-status
+  "Impose the operation's status on its targets and advance their staleness
+   clock. A status illegal for the target's type is skipped; the object is
+   still touched, so the clock stays honest."
+  [workspace operation version]
+  (let [status (if (= :close-goal (:op operation))
+                 (tx/goal-outcomes (:outcome operation))
+                 (get tx/status-effect (:op operation)))]
+    (reduce (fn [ws id]
+              (let [current (get-in ws [:workspace/objects id])]
+                (if (and status (object/legal-status? (:object/type current) status))
+                  (update-in ws [:workspace/objects id]
+                             #(-> % (assoc :object/status status)
+                                  (object/touch version)))
+                  (update-in ws [:workspace/objects id] object/touch version))))
+            workspace
+            (tx/touched-ids operation))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} apply-operation [workspace operation context]
+  (let [version (:version context)]
+    (-> workspace
+        (insert-created operation context)
+        (apply-status operation version)
+        (apply-links operation)
+        (record-challenge operation context version))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} commit
+  "Apply a validated transaction and advance the workspace version.
+
+   The version increments once per committed transaction — it is the clock
+   every basis check and staleness measure reads, so it must move exactly
+   with the log, never with wall time."
+  [workspace transaction]
+  (let [version (inc (get workspace :workspace/version 0))
+        context {:role (:tx/role transaction)
+                 :activation (:tx/activation transaction)
+                 :version version}]
+    (-> (reduce #(apply-operation %1 %2 context)
+                workspace
+                (:tx/operations transaction))
+        (conflict/derive-conflicts version)
+        (assoc :workspace/version version)
+        (update :workspace/log (fnil conj []) transaction))))

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/commit.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/commit.clj
@@ -30,20 +30,37 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(defn- ^{:stratum 0} apply-links [workspace operation]
-  (reduce (fn [ws [edge targets]]
-            (reduce (fn [w id]
-                      (update-in w [:workspace/objects id]
-                                 object/add-link edge (:source operation)))
-                    ws
-                    targets))
-          workspace
-          (get operation :links {})))
+(defn- ^{:stratum 0} apply-links
+  "Add the operation's edges to the objects it declared as targets.
+
+   Edges are written onto the DECLARED targets and point at the
+   destinations in `:links`. Writing onto the destinations instead would
+   mutate objects the validator never saw: `touched-ids` reads `:targets`
+   only, so target-existence, staleness, and terminal checks would all be
+   bypassed for anything reachable through `:links`."
+  [workspace operation]
+  (let [targets (tx/touched-ids operation)
+        known (get workspace :workspace/objects {})]
+    (reduce (fn [ws [edge destinations]]
+              (reduce (fn [w target-id]
+                        (reduce (fn [acc destination]
+                                  (update-in acc [:workspace/objects target-id]
+                                             object/add-link edge destination))
+                                w
+                                destinations))
+                      ws
+                      (filter known targets)))
+            workspace
+            (get operation :links {}))))
 
 (defn- ^{:stratum 0} record-challenge [workspace operation context version]
   (if (= :challenge (:op operation))
     (reduce (fn [ws id]
-              (let [challenge-id (str "challenge-" version "-" id)]
+              ;; The ordinal keeps two challenges on the same target inside one
+              ;; commit from colliding. Overwriting would undercount open
+              ;; challenges, which is exactly what the §3.5 cap reads.
+              (let [ordinal (count (get ws :workspace/challenges {}))
+                    challenge-id (str "challenge-" version "-" ordinal "-" id)]
                 (assoc-in ws [:workspace/challenges challenge-id]
                           {:challenge/id challenge-id
                            :challenge/role (:role context)

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/transaction.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/transaction.clj
@@ -84,6 +84,25 @@
    :add-constraint #{:interpreter}
    :retire-question #{:meta-watchdog}})
 
+(def ^{:stratum 0} status-effect
+  "Status an operation imposes on the objects it targets (N14 §2.3).
+   Operations absent from this table do not move target status.
+
+   The engine reads the effect from the operation rather than from the
+   transaction payload: an activation chooses which operation to propose,
+   and this table decides what that operation does."
+  {:accept-decision :accepted
+   :reject-decision :rejected
+   :answer-question :answered
+   :retire-question :retired
+   :record-experiment-result :completed
+   :invalidate-artifact :superseded
+   :challenge :contested})
+
+(def ^{:stratum 0} goal-outcomes
+  "Outcomes `close-goal` may impose (N14 §2.3)."
+  #{:accepted :rejected})
+
 (def ^{:stratum 0} ^:private universal-operations
   "Operations every role may propose (N14 §5.3, final clause)."
   #{:assert-claim :add-question :declare-blocked})

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/commit_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/commit_test.clj
@@ -35,9 +35,16 @@
    :workspace/objects (into {} (map (juxt :object/id identity)) objects)
    :workspace/log []})
 
-(defn- ^{:stratum 0} transact [ws role & operations]
-  (commit/commit ws (tx/new-transaction {:role role :activation "act-9"
-                                         :basis 5 :operations operations})))
+(defn- ^{:stratum 0} transact
+  "Commit `operations` against `ws`, declaring the basis the workspace is
+   actually at. `commit` never reads the basis — validation does — but a
+   hardcoded one goes stale the moment a test commits twice, and would
+   read as a stale-basis scenario to anyone adding a non-additive op here."
+  [ws role & operations]
+  (commit/commit ws (tx/new-transaction
+                     {:role role :activation "act-9"
+                      :basis (get ws :workspace/version 0)
+                      :operations operations})))
 
 (defn- ^{:stratum 0} object-at [ws id]
   (get-in ws [:workspace/objects id]))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/commit_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/commit_test.clj
@@ -131,3 +131,24 @@
                        {:op :challenge :targets #{"claim-1"} :evidence #{"e-1"}}
                        {:op :challenge :targets #{"claim-1"} :evidence #{"e-2"}})]
       (is (= 2 (count (:workspace/challenges ws)))))))
+
+(deftest ^{:stratum 1} challenge-ids-follow-sorted-targets-not-set-order
+  (testing "an id the log cannot rebuild is not reconstructible from the log"
+    (let [ws (transact (workspace (obj "claim-1" :claim)
+                                  (obj "claim-2" :claim)
+                                  (obj "claim-3" :claim))
+                       :skeptic
+                       {:op :challenge :targets #{"claim-1" "claim-2" "claim-3"}})]
+      (is (= {"claim-1" "challenge-6-0-claim-1"
+              "claim-2" "challenge-6-1-claim-2"
+              "claim-3" "challenge-6-2-claim-3"}
+             (into {} (map (juxt :challenge/target :challenge/id))
+                   (vals (:workspace/challenges ws))))
+          "targets iterate out of order as a set, so ordinals must come from sort")))
+  (testing "a second challenge operation counts on from the first"
+    (let [ws (transact (workspace (obj "claim-1" :claim) (obj "claim-2" :claim))
+                       :skeptic
+                       {:op :challenge :targets #{"claim-1"}}
+                       {:op :challenge :targets #{"claim-2"}})]
+      (is (= #{"challenge-6-0-claim-1" "challenge-6-1-claim-2"}
+             (set (keys (:workspace/challenges ws))))))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/commit_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/commit_test.clj
@@ -105,3 +105,29 @@
     (is (= :skeptic (:challenge/role recorded)))
     (is (= "claim-1" (:challenge/target recorded)))
     (is (= :open (:challenge/status recorded)))))
+
+(deftest ^{:stratum 1} links-are-written-onto-declared-targets-only
+  (testing "an undeclared destination is not mutated"
+    (let [ws (transact (workspace (obj "claim-1" :claim) (obj "evidence-1" :evidence))
+                       :proposer
+                       {:op :attach-evidence :targets #{"claim-1"}
+                        :links {:supports #{"evidence-1"}}})]
+      (is (= #{"evidence-1"}
+             (object/linked (object-at ws "claim-1") :supports))
+          "the declared target carries the edge")
+      (is (= #{} (object/linked (object-at ws "evidence-1") :supports))
+          "the destination was never declared, so validation never saw it"))))
+
+(deftest ^{:stratum 1} links-to-an-unknown-target-do-not-create-objects
+  (let [ws (transact (workspace (obj "claim-1" :claim)) :proposer
+                     {:op :attach-evidence :targets #{"claim-1"}
+                      :links {:supports #{"evidence-404"}}})]
+    (is (nil? (object-at ws "evidence-404")))
+    (is (= #{"evidence-404"} (object/linked (object-at ws "claim-1") :supports)))))
+
+(deftest ^{:stratum 1} two-challenges-on-one-target-in-one-commit-both-record
+  (testing "collapsing them would undercount the anti-livelock cap"
+    (let [ws (transact (workspace (obj "claim-1" :claim)) :skeptic
+                       {:op :challenge :targets #{"claim-1"} :evidence #{"e-1"}}
+                       {:op :challenge :targets #{"claim-1"} :evidence #{"e-2"}})]
+      (is (= 2 (count (:workspace/challenges ws)))))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/commit_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/commit_test.clj
@@ -1,0 +1,107 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.deliberation-workspace.commit-test
+  (:require
+   [ai.miniforge.deliberation-workspace.commit :as commit]
+   [ai.miniforge.deliberation-workspace.object :as object]
+   [ai.miniforge.deliberation-workspace.transaction :as tx]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} obj [id type & {:keys [links status]}]
+  (cond-> (object/new-object {:id id :type type :statement (str "statement " id)
+                              :role :proposer :activation "act-1" :version 1
+                              :links links})
+    status (assoc :object/status status)))
+
+(defn- ^{:stratum 0} workspace [& objects]
+  {:workspace/version 5
+   :workspace/objects (into {} (map (juxt :object/id identity)) objects)
+   :workspace/log []})
+
+(defn- ^{:stratum 0} transact [ws role & operations]
+  (commit/commit ws (tx/new-transaction {:role role :activation "act-9"
+                                         :basis 5 :operations operations})))
+
+(defn- ^{:stratum 0} object-at [ws id]
+  (get-in ws [:workspace/objects id]))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} committing-advances-the-version-once-per-transaction
+  (let [ws (transact (workspace) :proposer {:op :add-question})]
+    (is (= 6 (:workspace/version ws)))
+    (is (= 1 (count (:workspace/log ws))))
+    (is (= 7 (:workspace/version (transact ws :proposer {:op :add-question}))))))
+
+(deftest ^{:stratum 1} created-objects-are-stamped-by-the-engine
+  (let [ws (transact (workspace) :skeptic
+                     {:op :assert-claim
+                      :creates [{:id "claim-1" :type :claim
+                                 :statement "the invariant holds"
+                                 :role :synthesizer :version 999}]})
+        created (object-at ws "claim-1")]
+    (testing "provenance comes from the transaction, not the activation's claim"
+      (is (= :skeptic (:object/role created)))
+      (is (= 6 (:object/version created)))
+      (is (= "act-9" (:object/activation created))))))
+
+(deftest ^{:stratum 1} status-effects-are-derived-from-the-operation
+  (testing "accepting a decision moves it to :accepted"
+    (let [ws (transact (workspace (obj "decision-1" :decision)) :synthesizer
+                       {:op :accept-decision :targets #{"decision-1"}})]
+      (is (= :accepted (:object/status (object-at ws "decision-1"))))))
+  (testing "a challenge contests its target"
+    (let [ws (transact (workspace (obj "claim-1" :claim)) :skeptic
+                       {:op :challenge :targets #{"claim-1"}})]
+      (is (= :contested (:object/status (object-at ws "claim-1"))))))
+  (testing "agent-supplied status is ignored — the operation decides"
+    (let [ws (transact (workspace (obj "claim-1" :claim)) :skeptic
+                       {:op :challenge :targets #{"claim-1"}
+                        :status :accepted})]
+      (is (= :contested (:object/status (object-at ws "claim-1")))))))
+
+(deftest ^{:stratum 1} an-illegal-status-for-the-type-is-not-applied
+  (testing "a question cannot be driven into a deliberative status"
+    (let [ws (transact (workspace (obj "question-1" :question)) :synthesizer
+                       {:op :accept-decision :targets #{"question-1"}})]
+      (is (= :open (:object/status (object-at ws "question-1")))))))
+
+(deftest ^{:stratum 1} closing-a-goal-requires-a-legal-outcome
+  (testing "a declared outcome closes the goal"
+    (let [ws (transact (workspace (obj "goal-1" :goal)) :synthesizer
+                       {:op :close-goal :targets #{"goal-1"} :outcome :accepted})]
+      (is (= :accepted (:object/status (object-at ws "goal-1"))))))
+  (testing "an outcome outside the closed set leaves the goal open"
+    (let [ws (transact (workspace (obj "goal-1" :goal)) :synthesizer
+                       {:op :close-goal :targets #{"goal-1"} :outcome :maybe})]
+      (is (= :open (:object/status (object-at ws "goal-1")))))))
+
+(deftest ^{:stratum 1} every-touched-object-advances-the-staleness-clock
+  (let [ws (transact (workspace (obj "claim-1" :claim)) :proposer
+                     {:op :attach-evidence :targets #{"claim-1"}})]
+    (is (= 6 (:object/touched-at (object-at ws "claim-1"))))))
+
+(deftest ^{:stratum 1} challenges-are-recorded-for-the-anti-livelock-cap
+  (let [ws (transact (workspace (obj "claim-1" :claim)) :skeptic
+                     {:op :challenge :targets #{"claim-1"}})
+        recorded (first (vals (:workspace/challenges ws)))]
+    (is (= :skeptic (:challenge/role recorded)))
+    (is (= "claim-1" (:challenge/target recorded)))
+    (is (= :open (:challenge/status recorded)))))


### PR DESCRIPTION
Ninth slice of the **N14 Stage 0 pilot**. Stacked on the conflict PR.

## What this adds

`commit` applies a validated transaction and advances the workspace version.

Two properties matter more than the mechanics:

1. **The engine decides what an operation does.** Status effects are read
   from the `status-effect` table keyed by operation — never from the
   transaction payload. An activation chooses *which* operation to propose;
   it does not get to say what that operation means. Without this a
   transaction could name `:challenge` and carry `:accepted`. Tested
   directly by committing a challenge that supplies `:status :accepted` and
   asserting the target lands `:contested`.
2. **Provenance is stamped, not reported.** Created objects take the
   transaction's role, activation, and version, overwriting whatever the
   activation claimed about itself. A role cannot attribute its own object
   to another role — which matters because the ablation's visible set is
   computed from `:object/role`.

A status illegal for the target's type is skipped, but the object is still
touched so the staleness clock stays honest.

The version increments exactly once per committed transaction: it is the
clock that basis checks and staleness measures read, so it must track the
log rather than wall time.

## Placement note

`status-effect` and `goal-outcomes` live in `transaction` beside
`operation-class` — all three answer *what an operation is*, as distinct from
how the workspace applies it. That also keeps this namespace within the
SL003 layer budget.

## Testing

7 tests / 16 assertions covering version advance, engine stamping, each
status effect, the ignored agent-supplied status, illegal-status-for-type,
goal outcome validation, the staleness clock, and challenge recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)