### PR TITLE
feat(deliberation-workspace): the Stage 0 run loop

### DIFF
--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/run.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/run.clj
@@ -47,6 +47,17 @@
 (defn- ^{:stratum 0} note-activation [workspace role]
   (assoc-in workspace [:workspace/last-seen role] (:workspace/version workspace)))
 
+(defn- ^{:stratum 0} stages-of
+  "The validation chain for this run.
+
+   Defaulting to an empty chain would let a caller who forgot to populate
+   :workspace/stages commit unknown operations, unknown targets, and stale
+   writes without a single check running — silently, and looking healthy in
+   the event log. The concurrency stages are the floor."
+  [workspace]
+  (let [stages (get workspace :workspace/stages)]
+    (if (seq stages) stages validation/concurrency-stages)))
+
 (defn- ^{:stratum 0} count-quiet
   "Track consecutive transactions that added no new object, which is what
    the §7 quiescence rule measures. Takes the committed workspace first so
@@ -67,25 +78,27 @@
    `activate` receives {:role :projection :workspace} and returns a
    transaction, or nil to pass."
   [workspace activate]
-  (let [{:activation/keys [role reason]} (scheduler/next-activation workspace)
-        visibility (get workspace :workspace/visibility :full)
-        rendered (projection/project workspace role
-                                     {:visibility visibility
-                                      :since (last-seen workspace role)})
-        proposed (activate {:role role :projection rendered :workspace workspace})
-        spent (-> workspace spend (note-activation role)
-                  (record-event {:event :activation/completed
-                                 :role role :reason reason}))]
-    (if (nil? proposed)
-      (record-event spent {:event :transaction/passed :role role})
-      (if-let [rejection (validation/validate spent proposed
-                                              (get workspace :workspace/stages []))]
-        (record-event spent {:event :transaction/rejected
-                             :role role
-                             :reason (anomaly/subtype rejection)})
-        (-> (commit/commit spent proposed)
-            (count-quiet spent)
-            (record-event {:event :transaction/committed :role role}))))))
+  (if-let [{:activation/keys [role reason target]} (scheduler/next-activation workspace)]
+    (let [visibility (get workspace :workspace/visibility :full)
+          rendered (projection/project workspace role
+                                       {:visibility visibility
+                                        :since (last-seen workspace role)})
+          proposed (activate {:role role :projection rendered :workspace workspace})
+          spent (-> workspace spend (note-activation role)
+                    (record-event {:event :activation/completed
+                                   :role role :reason reason :target target}))]
+      (if (nil? proposed)
+        (record-event spent {:event :transaction/passed :role role})
+        (if-let [rejection (validation/validate spent proposed (stages-of workspace))]
+          (record-event spent {:event :transaction/rejected
+                               :role role
+                               :reason (anomaly/subtype rejection)})
+          (-> (commit/commit spent proposed)
+              (count-quiet spent)
+              (record-event {:event :transaction/committed :role role})))))
+    ;; Nothing eligible. Charging an activation that never ran would distort
+    ;; the N15 cost accounting; the deadlock rule closes the run instead.
+    (record-event workspace {:event :activation/none-eligible})))
 
 ;------------------------------------------------------------------------------ Layer 2
 

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/run.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/run.clj
@@ -59,9 +59,12 @@
     (if (seq stages) stages validation/concurrency-stages)))
 
 (defn- ^{:stratum 0} count-quiet
-  "Track consecutive transactions that added no new object, which is what
-   the §7 quiescence rule measures. Takes the committed workspace first so
-   it threads after `commit`."
+  "Track consecutive transactions that did not grow the object set, which
+   is what the §7 quiescence rule measures. The measure is the size of
+   `:workspace/objects`, not a scan for open objects: `new-object` gives
+   every created object a non-terminal initial status, so a transaction
+   grows the set exactly when it adds an object a role can still act on.
+   Takes the committed workspace first so it threads after `commit`."
   [committed previous]
   (let [object-count (fn [ws] (count (get ws :workspace/objects {})))]
     (if (> (object-count committed) (object-count previous))

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/run.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/run.clj
@@ -1,0 +1,106 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.deliberation-workspace.run
+  "The N14 Stage 0 run loop: schedule, project, activate, validate, commit,
+   repeat until a closing rule fires.
+
+   The activation function is injected. Every LLM call in a real run happens
+   behind it, so the whole loop is exercised deterministically in tests with
+   a function that returns canned transactions."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.deliberation-workspace.commit :as commit]
+   [ai.miniforge.deliberation-workspace.projection :as projection]
+   [ai.miniforge.deliberation-workspace.scheduler :as scheduler]
+   [ai.miniforge.deliberation-workspace.termination :as termination]
+   [ai.miniforge.deliberation-workspace.validation :as validation]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} spend [workspace]
+  (update-in workspace [:workspace/spent :activations] (fnil inc 0)))
+
+(defn- ^{:stratum 0} record-event [workspace event]
+  (update workspace :workspace/events (fnil conj []) event))
+
+(defn- ^{:stratum 0} last-seen
+  "The workspace version at `role`'s previous activation — the `since` the
+   projection's delta is computed from."
+  [workspace role]
+  (get-in workspace [:workspace/last-seen role] 0))
+
+(defn- ^{:stratum 0} note-activation [workspace role]
+  (assoc-in workspace [:workspace/last-seen role] (:workspace/version workspace)))
+
+(defn- ^{:stratum 0} count-quiet
+  "Track consecutive transactions that added no new object, which is what
+   the §7 quiescence rule measures. Takes the committed workspace first so
+   it threads after `commit`."
+  [committed previous]
+  (let [object-count (fn [ws] (count (get ws :workspace/objects {})))]
+    (if (> (object-count committed) (object-count previous))
+      (assoc committed :workspace/quiet-rounds 0)
+      (update committed :workspace/quiet-rounds (fnil inc 0)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} step
+  "Run one activation. Returns the workspace after the attempt, whether the
+   transaction committed or was rejected — a rejection still costs budget,
+   because the activation ran.
+
+   `activate` receives {:role :projection :workspace} and returns a
+   transaction, or nil to pass."
+  [workspace activate]
+  (let [{:activation/keys [role reason]} (scheduler/next-activation workspace)
+        visibility (get workspace :workspace/visibility :full)
+        rendered (projection/project workspace role
+                                     {:visibility visibility
+                                      :since (last-seen workspace role)})
+        proposed (activate {:role role :projection rendered :workspace workspace})
+        spent (-> workspace spend (note-activation role)
+                  (record-event {:event :activation/completed
+                                 :role role :reason reason}))]
+    (if (nil? proposed)
+      (record-event spent {:event :transaction/passed :role role})
+      (if-let [rejection (validation/validate spent proposed
+                                              (get workspace :workspace/stages []))]
+        (record-event spent {:event :transaction/rejected
+                             :role role
+                             :reason (anomaly/subtype rejection)})
+        (-> (commit/commit spent proposed)
+            (count-quiet spent)
+            (record-event {:event :transaction/committed :role role}))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} run
+  "Drive the loop until a §7 closing rule fires, then return the closed
+   workspace with its termination record attached.
+
+   `max-steps` is a harness backstop, not a spec rule: budgets and closing
+   rules should end a run first, and a run that hits this bound is a defect
+   worth surfacing rather than a normal ending."
+  [workspace activate {:keys [max-steps] :or {max-steps 1000}}]
+  (loop [ws workspace
+         steps 0]
+    (if-let [closing (termination/closing-rule ws)]
+      (assoc ws :workspace/termination closing)
+      (if (>= steps max-steps)
+        (assoc ws :workspace/termination {:termination/rule :step-bound-exceeded})
+        (recur (step ws activate) (inc steps))))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
@@ -1,0 +1,117 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.deliberation-workspace.run-test
+  (:require
+   [ai.miniforge.deliberation-workspace.guards :as guards]
+   [ai.miniforge.deliberation-workspace.object :as object]
+   [ai.miniforge.deliberation-workspace.run :as run]
+   [ai.miniforge.deliberation-workspace.transaction :as tx]
+   [ai.miniforge.deliberation-workspace.validation :as validation]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private stages
+  (into validation/concurrency-stages guards/guard-stages))
+
+(defn- ^{:stratum 0} goal [id]
+  (object/new-object {:id id :type :goal :statement "ship the thing"
+                      :role :interpreter :activation "act-0" :version 1}))
+
+(defn- ^{:stratum 0} passes [_] nil)
+
+(defn- ^{:stratum 0} events-of [ws kind]
+  (filter #(= kind (:event %)) (:workspace/events ws)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} workspace [& {:as extra}]
+  (merge {:workspace/version 1
+          :workspace/objects {"goal-1" (goal "goal-1")}
+          :workspace/roles [:proposer :skeptic :synthesizer]
+          :workspace/eligibility {}
+          :workspace/stages stages
+          :workspace/log []
+          :workspace/budget {:activations 3}}
+         extra))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} a-run-closes-on-budget-and-forces-synthesis
+  (let [closed (run/run (workspace) passes {})]
+    (is (= :budget-boundary (get-in closed [:workspace/termination :termination/rule])))
+    (is (get-in closed [:workspace/termination :termination/forced-synthesis]))
+    (is (= 3 (get-in closed [:workspace/spent :activations])))))
+
+(deftest ^{:stratum 2} a-run-closes-as-success-when-every-goal-is-terminal
+  (let [ws (workspace :workspace/objects
+                      {"goal-1" (assoc (goal "goal-1") :object/status :accepted)})]
+    (is (= :success (get-in (run/run ws passes {})
+                            [:workspace/termination :termination/rule])))))
+
+(deftest ^{:stratum 2} a-passing-activation-still-costs-budget
+  (testing "an activation that proposes nothing has still run"
+    (let [after (run/step (workspace) passes)]
+      (is (= 1 (get-in after [:workspace/spent :activations])))
+      (is (= 1 (count (events-of after :transaction/passed)))))))
+
+(deftest ^{:stratum 2} a-committed-transaction-advances-the-version
+  (let [activate (fn [{:keys [role]}]
+                   (tx/new-transaction
+                    {:role role :activation "act-1" :basis 1
+                     :operations [{:op :assert-claim
+                                   :creates [{:id "claim-1" :type :claim
+                                              :statement "a claim"}]}]}))
+        after (run/step (workspace) activate)]
+    (is (= 2 (:workspace/version after)))
+    (is (some? (get-in after [:workspace/objects "claim-1"])))
+    (is (= 1 (count (events-of after :transaction/committed))))))
+
+(deftest ^{:stratum 2} a-rejected-transaction-is-logged-with-its-reason
+  (let [activate (fn [{:keys [role]}]
+                   (tx/new-transaction
+                    {:role role :activation "act-1" :basis 1
+                     :operations [{:op :not-an-operation}]}))
+        after (run/step (workspace) activate)]
+    (testing "the workspace does not advance"
+      (is (= 1 (:workspace/version after))))
+    (testing "but the activation is charged and the reason recorded"
+      (is (= 1 (get-in after [:workspace/spent :activations])))
+      (is (= :anomalies.deliberation/unknown-operation
+             (:reason (first (events-of after :transaction/rejected))))))))
+
+(deftest ^{:stratum 2} the-ablation-setting-reaches-the-projection
+  (let [seen (atom nil)
+        activate (fn [{:keys [projection]}] (reset! seen projection) nil)]
+    (run/step (workspace :workspace/visibility :none) activate)
+    (is (= :none (:projection/visibility @seen)))))
+
+(deftest ^{:stratum 2} each-role-sees-a-delta-from-its-own-last-activation
+  (let [seen (atom [])
+        activate (fn [{:keys [role projection]}]
+                   (swap! seen conj [role (:projection/version projection)])
+                   nil)]
+    (run/run (workspace) activate {})
+    (testing "every activation renders at the current version"
+      (is (= 3 (count @seen))))))
+
+(deftest ^{:stratum 2} the-step-bound-is-a-defect-signal-not-a-normal-ending
+  (let [endless (workspace :workspace/budget {} :workspace/quiescence-rounds 10000)
+        closed (run/run endless passes {:max-steps 5})]
+    (is (= :step-bound-exceeded
+           (get-in closed [:workspace/termination :termination/rule])))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
@@ -112,8 +112,8 @@
                      :operations [{:op :assert-claim
                                    :creates [{:id (str "claim-" (:workspace/version workspace))
                                               :type :claim :statement "a claim"}]}]}))
-        by-role (do (run/run (workspace :workspace/budget {:activations 4}) activate {})
-                    (group-by :role @seen))
+        _ (run/run (workspace :workspace/budget {:activations 4}) activate {})
+        by-role (group-by :role @seen)
         proposals (get by-role :proposer)]
     (testing "round-robin brings the first role back for a second activation"
       (is (= [:proposer :skeptic :synthesizer :proposer] (mapv :role @seen))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
@@ -115,3 +115,37 @@
         closed (run/run endless passes {:max-steps 5})]
     (is (= :step-bound-exceeded
            (get-in closed [:workspace/termination :termination/rule])))))
+
+(deftest ^{:stratum 2} missing-stages-fall-back-to-validation-not-to-nothing
+  (testing "an empty chain would commit anything the activation proposed"
+    (let [ws (dissoc (workspace) :workspace/stages)
+          activate (fn [{:keys [role]}]
+                     (tx/new-transaction {:role role :activation "act-1" :basis 1
+                                          :operations [{:op :not-an-operation}]}))
+          after (run/step ws activate)]
+      (is (= 1 (:workspace/version after)) "nothing may commit unvalidated")
+      (is (= :anomalies.deliberation/unknown-operation
+             (:reason (first (events-of after :transaction/rejected))))))))
+
+(deftest ^{:stratum 2} an-uneligible-workspace-does-not-charge-an-activation
+  (testing "no role to run means no activation ran"
+    (let [ws (workspace :workspace/roles [] :workspace/eligibility {})
+          called (atom false)
+          activate (fn [_] (reset! called true) nil)
+          after (run/step ws activate)]
+      (is (false? @called) "activate must not be invoked with a nil role")
+      (is (nil? (get-in after [:workspace/spent :activations])))
+      (is (= 1 (count (events-of after :activation/none-eligible)))))))
+
+(deftest ^{:stratum 2} the-activation-event-records-what-triggered-it
+  (let [conflict (object/new-object {:id "conflict-1" :type :conflict
+                                     :statement "a contradiction"
+                                     :role :engine :activation "derived"
+                                     :version 1})
+        ws (-> (workspace)
+               (assoc-in [:workspace/objects "conflict-1"] conflict)
+               (assoc :workspace/eligibility {:conflict [:skeptic]}))
+        after (run/step ws passes)
+        event (first (events-of after :activation/completed))]
+    (is (= :conflict (:reason event)))
+    (is (= "conflict-1" (:target event)) "the trigger must be auditable")))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
@@ -103,12 +103,17 @@
 
 (deftest ^{:stratum 2} each-role-sees-a-delta-from-its-own-last-activation
   (let [seen (atom [])
+        ;; This test runs four activations, so the basis has to come from the
+        ;; projection each one was actually rendered from — that is what the
+        ;; §3.1 contract means by basis. A constant would be right only for
+        ;; the first activation.
         activate (fn [{:keys [role projection workspace]}]
                    (swap! seen conj
                           {:role role
                            :delta (set (map :object/id (:projection/delta projection)))})
                    (tx/new-transaction
-                    {:role role :activation "act-1" :basis 1
+                    {:role role :activation "act-1"
+                     :basis (:projection/version projection)
                      :operations [{:op :assert-claim
                                    :creates [{:id (str "claim-" (:workspace/version workspace))
                                               :type :claim :statement "a claim"}]}]}))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
@@ -103,12 +103,27 @@
 
 (deftest ^{:stratum 2} each-role-sees-a-delta-from-its-own-last-activation
   (let [seen (atom [])
-        activate (fn [{:keys [role projection]}]
-                   (swap! seen conj [role (:projection/version projection)])
-                   nil)]
-    (run/run (workspace) activate {})
-    (testing "every activation renders at the current version"
-      (is (= 3 (count @seen))))))
+        activate (fn [{:keys [role projection workspace]}]
+                   (swap! seen conj
+                          {:role role
+                           :delta (set (map :object/id (:projection/delta projection)))})
+                   (tx/new-transaction
+                    {:role role :activation "act-1" :basis 1
+                     :operations [{:op :assert-claim
+                                   :creates [{:id (str "claim-" (:workspace/version workspace))
+                                              :type :claim :statement "a claim"}]}]}))
+        by-role (do (run/run (workspace :workspace/budget {:activations 4}) activate {})
+                    (group-by :role @seen))
+        proposals (get by-role :proposer)]
+    (testing "round-robin brings the first role back for a second activation"
+      (is (= [:proposer :skeptic :synthesizer :proposer] (mapv :role @seen))))
+    (testing "a role's first activation has seen nothing, so the delta is everything"
+      (is (= #{"goal-1"} (:delta (first proposals)))))
+    (testing "the second delta starts at that role's own last activation"
+      (is (= #{"claim-1" "claim-2" "claim-3"} (:delta (second proposals)))
+          "goal-1 has not moved since the proposer last ran, so it is not in the delta"))
+    (testing "a role that ran more recently sees a shorter delta than one that has not"
+      (is (= #{"goal-1" "claim-1"} (:delta (first (get by-role :skeptic))))))))
 
 (deftest ^{:stratum 2} the-step-bound-is-a-defect-signal-not-a-normal-ending
   (let [endless (workspace :workspace/budget {} :workspace/quiescence-rounds 10000)
@@ -127,7 +142,7 @@
       (is (= :anomalies.deliberation/unknown-operation
              (:reason (first (events-of after :transaction/rejected))))))))
 
-(deftest ^{:stratum 2} an-uneligible-workspace-does-not-charge-an-activation
+(deftest ^{:stratum 2} an-ineligible-workspace-does-not-charge-an-activation
   (testing "no role to run means no activation ran"
     (let [ws (workspace :workspace/roles [] :workspace/eligibility {})
           called (atom false)


### PR DESCRIPTION
Tenth and final structural slice of the **N14 Stage 0 pilot**. Stacked on
https://github.com/miniforge-ai/miniforge/pull/1840.

With this the pilot is a working loop: schedule → project → activate →
validate → commit, until a §7 closing rule fires.

## The injected activation seam

`activate` is a function the caller supplies. Every LLM call in a real run
sits behind it, which is what lets the entire loop — scheduling, ablation,
validation, commit, termination — run deterministically in tests against
canned transactions. All 8 tests here exercise the real loop; none of them
mock the workspace.

## Two decisions worth flagging

1. **A rejected transaction still costs budget.** The activation ran. Charging
   only successes would let a role churn invalid proposals for free, and under
   a fixed activation budget that would quietly distort the N15 cost
   accounting. Rejections are recorded with their anomaly subtype so the run
   record says *why*, per §3.4.
2. **`max-steps` closes with its own rule.** It is a harness backstop, not a
   spec closing rule — budgets and §7 should end a run first. A run that hits
   the bound is a defect, so it terminates as `:step-bound-exceeded` rather
   than masquerading as quiescence.

## Bug this slice caught

`count-quiet` was threaded as `(-> (commit …) (count-quiet spent))`, so its
`[before after]` parameter order meant it returned the *pre-commit*
workspace — silently discarding every commit while still logging
`:transaction/committed`. The version never advanced and no object was ever
created. Caught by the test asserting the version advances; parameters are
now ordered to thread correctly.

That failure mode is worth naming: the run would have looked healthy in its
event log while producing an empty workspace, and every G0 result would have
been a null.

## Testing

8 tests / 15 assertions: budget closure with forced synthesis, success
closure, pass-still-costs-budget, commit advancing the version, rejection
logging with subtype, the ablation setting reaching the projection, and the
step bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)