### PR TITLE
refactor(evidence-bundle): split collector.clj under the layer budget

### DIFF
--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
@@ -31,6 +31,7 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
+;; Intent Collection
 (defn ^{:stratum 0} extract-intent
   [workflow-spec]
   {:intent/type (get workflow-spec :intent/type :update)
@@ -42,7 +43,7 @@
    :intent/declared-at (java.time.Instant/now)
    :intent/author (get workflow-spec :author "system")})
 
-;; Compliance Defaults and Overrides
+;; Access Log
 (defn ^{:stratum 0} append-access-log-entry
   "Append an access log entry to the bundle's :evidence/access-log.
    Stamps :access-log/timestamp on the entry when absent.
@@ -56,7 +57,7 @@
             (fn [access-log]
               (conj (vec (or access-log [])) stamped)))))
 
-;; Phase Evidence Collection
+;; Workflow Integration Helpers
 (defn ^{:stratum 0} should-create-bundle?
   "Check if evidence bundle should be created for workflow.
    Always create bundle at completion, even on failure (per N6 spec)."

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
@@ -16,36 +16,21 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.evidence-bundle.collector
-  "Utilities for collecting evidence during workflow execution.
-   Provides helpers for gathering phase results, artifacts, and metadata."
+  "Assembling an evidence bundle from workflow state.\n\n   The pieces it assembles live in sibling namespaces; this one is the\n   order they go together in."
   (:require
-   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.artifact.interface :as artifact]
    [ai.miniforge.content-hash.interface :as content-hash]
+   [ai.miniforge.evidence-bundle.collectors :as collectors]
+   [ai.miniforge.evidence-bundle.compliance-defaults :as compliance-defaults]
+   [ai.miniforge.evidence-bundle.dependency-health :as dependency-health]
+   [ai.miniforge.evidence-bundle.outcome :as outcome]
+   [ai.miniforge.evidence-bundle.phases :as phases]
    [ai.miniforge.evidence-bundle.protocols.impl.semantic-validator :as semantic-validator]
-   [ai.miniforge.evidence-bundle.schema :as schema]
-   [ai.miniforge.evidence-bundle.schema.compliance :as compliance]
    [ai.miniforge.evidence-bundle.scanner :as scanner]
-   [ai.miniforge.event-stream.interface :as event-stream]
-   [ai.miniforge.response.interface :as response]))
+   [ai.miniforge.evidence-bundle.schema :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Anomaly detection (dual shape during W2 convergence)
-(defn- ^{:stratum 0} any-anomaly?
-  "True when `x` is either a canonical anomaly (`:anomaly/type`) or a
-   legacy response anomaly (`:anomaly/category`).
-
-   evidence-bundle reads anomalies from arbitrary upstream producers
-   (workflow/error, error-info :anomaly), so it must detect both
-   shapes until W5 retires the legacy producers. Prefers the canonical
-   predicate; falls back to the legacy one. Mirrors the dispatch-key
-   pattern in `failure-classifier/classify-failure`."
-  [x]
-  (or (anomaly/anomaly? x)
-      (response/anomaly-map? x)))
-
-;; Intent Collection
 (defn ^{:stratum 0} extract-intent
   [workflow-spec]
   {:intent/type (get workflow-spec :intent/type :update)
@@ -58,44 +43,6 @@
    :intent/author (get workflow-spec :author "system")})
 
 ;; Compliance Defaults and Overrides
-(defn- ^{:stratum 0} build-default-compliance-metadata
-  "Return the default compliance map for assembled evidence bundles.
-   Uses schema.compliance-defined defaults so the single source of truth
-   lives there. Covers the assembly path; the template function covers
-   manual construction."
-  []
-  {:evidence/data-classification compliance/default-data-classification
-   :evidence/contains-pii?       false
-   :evidence/retention-policy    {:retain-days  compliance/default-retention-days
-                                  :auto-delete? true
-                                  :legal-hold?  false}
-   :evidence/regulatory-tags     #{}
-   :evidence/created-by          compliance/default-created-by-principal})
-
-(def ^{:stratum 0} ^:private compliance-override-keys
-  "Allowed keys for workflow-spec and opts compliance override maps."
-  #{:evidence/data-classification
-    :evidence/contains-pii?
-    :evidence/retention-policy
-    :evidence/regulatory-tags
-    :evidence/created-by})
-
-(defn- ^{:stratum 0} merge-compliance
-  "Merge compliance defaults with operator overrides.
-   :evidence/retention-policy is merged one level deep so callers may supply
-   only the keys they wish to change (e.g. just {:retain-days 365}) without
-   losing the other retention fields from the defaults."
-  [defaults overrides]
-  (let [base (merge defaults overrides)]
-    (if (and (contains? overrides :evidence/retention-policy)
-             (map? (get defaults :evidence/retention-policy))
-             (map? (get overrides :evidence/retention-policy)))
-      (assoc base :evidence/retention-policy
-             (merge (get defaults :evidence/retention-policy)
-                    (get overrides :evidence/retention-policy)))
-      base)))
-
-;; Access Log
 (defn ^{:stratum 0} append-access-log-entry
   "Append an access log entry to the bundle's :evidence/access-log.
    Stamps :access-log/timestamp on the entry when absent.
@@ -110,419 +57,37 @@
               (conj (vec (or access-log [])) stamped)))))
 
 ;; Phase Evidence Collection
-(defn- ^{:stratum 0} build-phase-output
-  "Extract the output map for phase evidence.
-
-   Handles both:
-   - Legacy shape: {:output {...}} — extracts :output directly
-   - New environment model: {:environment-id ... :summary ... :metrics ...}
-     — synthesizes an output map from the provenance metadata
-
-   In the new model, :evidence/implement captures summary + metrics (not code).
-   :evidence/verify captures test output. :evidence/release captures PR metadata."
-  [phase-result]
-  (or
-   ;; Legacy: explicit :output key
-   (get phase-result :output)
-   ;; New environment model: synthesize output from provenance metadata
-   (when (or (:summary phase-result) (:metrics phase-result)
-             (:environment-id phase-result))
-     (cond-> {}
-       (:summary phase-result)        (assoc :summary        (:summary phase-result))
-       (:metrics phase-result)        (assoc :metrics        (:metrics phase-result))
-       (:environment-id phase-result) (assoc :environment-id (:environment-id phase-result))))
-   {}))
-
-(defn ^{:stratum 0} collect-tool-invocations
-  "Collect tool invocation records from workflow state."
-  [workflow-state]
-  (vec (get workflow-state :workflow/tool-invocations [])))
-
-;------------------------------------------------------------------------------ Layer 1.5
-;; Rules Applied Evidence
-(defn- ^{:stratum 0} build-rule-applied-entry
-  "Normalize a manifest entry into the expected rule-applied shape.
-   Ensures all fields have valid defaults and annotates with phase name."
-  [entry phase-name]
-  {:id (or (:id entry) (random-uuid))
-   :title (get entry :title "unknown")
-   :role (get entry :role :unknown)
-   :tags-matched (vec (get entry :tags-matched []))
-   :score (double (get entry :score 0.0))
-   :phase (get entry :phase phase-name)})
-
-;; Policy Check Evidence
-(defn ^{:stratum 0} build-policy-check-evidence
-  "Build policy check evidence from gate result.
-   Returns policy check evidence per N6 spec."
-  [gate-result]
-  {:policy-check/pack-id (get gate-result :pack-id "unknown")
-   :policy-check/pack-version (get gate-result :pack-version "1.0.0")
-   :policy-check/phase (get gate-result :phase :unknown)
-   :policy-check/checked-at (get gate-result :checked-at (java.time.Instant/now))
-   :policy-check/violations (vec (get gate-result :violations []))
-   :policy-check/passed? (get gate-result :passed? true)
-   :policy-check/duration-ms (get gate-result :duration-ms 0)
-   :policy-check/envelope (get gate-result :envelope)})
-
-;; Pack Promotion Evidence
-(defn ^{:stratum 0} build-pack-promotion-evidence
-  "Build pack promotion evidence from promotion record.
-   Returns pack promotion evidence per N6 section 2.1.
-
-   If the promotion record already has the correct format (with :pack/id),
-   return it as-is. Otherwise, build from legacy format."
-  [promotion-record]
-  ;; If already in correct format, return as-is
-  (if (contains? promotion-record :pack/id)
-    promotion-record
-    ;; Otherwise, build from legacy format
-    {:pack/id (get promotion-record :pack-id "unknown")
-     :pack/type (get promotion-record :pack-type :knowledge)
-     :from-trust (get promotion-record :from-trust :untrusted)
-     :to-trust (get promotion-record :to-trust :trusted)
-     :promoted-by (get promotion-record :promoted-by "system")
-     :promoted-at (get promotion-record :promoted-at (java.time.Instant/now))
-     :promotion-policy (get promotion-record :promotion-policy "knowledge-safety")
-     :promotion-justification (get promotion-record :promotion-justification
-                                   "No justification provided")
-     :pack-hash (get promotion-record :pack-hash "")
-     :pack-signature (get promotion-record :pack-signature "")}))
-
-;------------------------------------------------------------------------------ Layer 3.5
-;; Supervision Decision Evidence (N6)
-(defn- ^{:stratum 0} collect-event-stream-events
-  [event-stream query]
-  (try
-    (when event-stream
-      (vec (event-stream/get-events event-stream query)))
-    (catch Exception _e
-      [])))
-
-;------------------------------------------------------------------------------ Layer 4.5
-;; Execution Evidence (N11 §9.1)
-(defn ^{:stratum 0} collect-execution-evidence
-  "Extract N11 §9.1 execution evidence fields from workflow state.
-   Looks in :execution/output for evidence fields produced by runner/extract-output.
-   Returns a map of evidence keys to merge into the bundle, or empty map."
-  [workflow-state]
-  (let [output (get workflow-state :execution/output {})]
-    (cond-> {}
-      (contains? output :evidence/execution-mode)
-      (assoc :evidence/execution-mode (:evidence/execution-mode output))
-
-      (contains? output :evidence/runtime-class)
-      (assoc :evidence/runtime-class (:evidence/runtime-class output))
-
-      (contains? output :evidence/task-started-at)
-      (assoc :evidence/task-started-at (:evidence/task-started-at output))
-
-      (contains? output :evidence/task-finished-at)
-      (assoc :evidence/task-finished-at (:evidence/task-finished-at output))
-
-      (contains? output :evidence/image-digest)
-      (assoc :evidence/image-digest (:evidence/image-digest output)))))
-
-(def ^{:stratum 0} ^:private dependency-event-types
-  #{:dependency/health-updated
-    :dependency/recovered})
-
-(def ^{:stratum 0} ^:private dependency-health-keys
-  [:dependency/id
-   :dependency/source
-   :dependency/kind
-   :dependency/status
-   :dependency/failure-count
-   :dependency/window-size
-   :dependency/incident-counts
-   :dependency/vendor
-   :dependency/class
-   :dependency/retryability
-   :failure/class
-   :dependency/last-observed-at
-   :dependency/last-recovered-at])
-
-(def ^{:stratum 0} ^:private failure-attribution-keys
-  [:failure/source
-   :failure/vendor
-   :failure/class
-   :failure/message
-   :dependency/class
-   :dependency/retryability
-   :dependency/id
-   :dependency/source
-   :dependency/kind
-   :dependency/vendor
-   :dependency/status])
-
-;; Workflow Integration Helpers
 (defn ^{:stratum 0} should-create-bundle?
   "Check if evidence bundle should be created for workflow.
    Always create bundle at completion, even on failure (per N6 spec)."
   [workflow-state]
   (contains? #{:completed :failed} (:workflow/status workflow-state)))
 
-;------------------------------------------------------------------------------ Layer 1
-
-(defn- ^{:stratum 1} normalize-compliance-overrides
-  "Return only documented compliance override keys from m, or nil for non-maps."
-  [m]
-  (when (map? m)
-    (select-keys m compliance-override-keys)))
-
-(defn ^{:stratum 1} build-phase-evidence
-  "Build phase evidence from phase execution context.
-   Returns phase evidence map per N6 spec.
-
-   Handles both legacy (:output map) and new-model (:environment-id, :summary,
-   :metrics) phase result shapes. In the new model, code is NOT captured here;
-   it is derived from the PR diff at release time."
-  [phase-name agent-id phase-result]
-  (let [started-at   (get phase-result :started-at (java.time.Instant/now))
-        completed-at (get phase-result :completed-at (java.time.Instant/now))]
-    {:phase/name                phase-name
-     :phase/agent               agent-id
-     :phase/agent-instance-id   (get phase-result :agent-instance-id (random-uuid))
-     :phase/started-at          started-at
-     :phase/completed-at        completed-at
-     :phase/duration-ms         (get phase-result :duration-ms
-                                     (- (.toEpochMilli completed-at)
-                                        (.toEpochMilli started-at)))
-     :phase/output              (build-phase-output phase-result)
-     :phase/artifacts           (vec (get phase-result :artifacts []))
-     :phase/inner-loop-iterations (get phase-result :inner-loop-iterations 0)
-     :phase/event-stream-range  (get phase-result :event-stream-range
-                                     {:start-seq 0 :end-seq 0})}))
-
-(defn ^{:stratum 1} collect-rules-applied
-  "Collect rules-applied evidence from phase results.
-   Each phase that captured a rules-manifest has its entries normalized
-   and annotated with the phase name.
-   Returns empty vector when no phases have a rules manifest."
-  [workflow-state]
-  (let [phases (get workflow-state :workflow/phases {})]
-    (vec (mapcat (fn [[phase-name phase-data]]
-                   (when-let [manifest (:rules-manifest phase-data)]
-                     (mapv #(build-rule-applied-entry % phase-name) manifest)))
-                 phases))))
-
-(defn ^{:stratum 1} collect-policy-checks
-  "Collect all policy check evidence from workflow state.
-   Returns vector of policy check evidence."
-  [workflow-state]
-  (let [gate-results (get workflow-state :workflow/gate-results [])]
-    (mapv build-policy-check-evidence gate-results)))
-
-(defn ^{:stratum 1} collect-pack-promotions
-  "Collect all pack promotion evidence from workflow state.
-   Returns vector of pack promotion evidence."
-  [workflow-state]
-  (let [promotions (get workflow-state :workflow/pack-promotions [])]
-    (mapv build-pack-promotion-evidence promotions)))
-
-(defn ^{:stratum 1} collect-supervision-decisions
-  "Collect supervision decision events from the event stream.
-
-   Filters for :supervision/tool-use-evaluated events and transforms
-   them into evidence records.
-
-   Arguments:
-   - event-stream: Event stream atom
-   - workflow-id: UUID of the workflow
-
-   Returns vector of supervision decision evidence maps."
-  [event-stream workflow-id]
-  (try
-    (when event-stream
-      (let [events (collect-event-stream-events event-stream
-                                                {:workflow-id workflow-id
-                                                 :event-type :supervision/tool-use-evaluated})]
-        (mapv (fn [event]
-                (cond-> {:supervision/tool-name (get event :tool/name "unknown")
-                         :supervision/decision (get event :supervision/decision "allow")
-                         :supervision/timestamp (get event :event/timestamp
-                                                     (java.util.Date.))}
-                  (:supervision/reasoning event)
-                  (assoc :supervision/reasoning (:supervision/reasoning event))
-
-                  (:supervision/meta-eval? event)
-                  (assoc :supervision/meta-eval? true)
-
-                  (:supervision/confidence event)
-                  (assoc :supervision/confidence (:supervision/confidence event))
-
-                  (:workflow/phase event)
-                  (assoc :supervision/phase (:workflow/phase event))))
-              events)))
-    (catch Exception _e
-      ;; event-stream dependency might not be loaded
-      [])))
-
-(defn ^{:stratum 1} collect-control-actions
-  "Collect control action events from the event stream.
-
-   Pairs :control-action/requested with :control-action/executed events.
-
-   Arguments:
-   - event-stream: Event stream atom
-   - workflow-id: UUID of the workflow
-
-   Returns vector of control action evidence maps."
-  [event-stream workflow-id]
-  (try
-    (when event-stream
-      (let [requested (collect-event-stream-events event-stream
-                                                   {:workflow-id workflow-id
-                                                    :event-type :control-action/requested})
-            executed (collect-event-stream-events event-stream
-                                                  {:workflow-id workflow-id
-                                                   :event-type :control-action/executed})
-            executed-by-id (into {} (map (fn [e] [(:action/id e) e]) executed))]
-        (mapv (fn [req-event]
-                (let [action-id (:action/id req-event)
-                      exec-event (get executed-by-id action-id)]
-                  (cond-> {:control-action/id action-id
-                           :control-action/type (:action/type req-event)
-                           :control-action/requester (get req-event :action/requester {})
-                           :control-action/timestamp (get req-event :event/timestamp
-                                                         (java.util.Date.))
-                           :control-action/result (if exec-event :executed :pending)}
-                    (:action/justification req-event)
-                    (assoc :control-action/justification (:action/justification req-event))
-
-                    (:action/target req-event)
-                    (assoc :control-action/target (:action/target req-event)))))
-              requested)))
-    (catch Exception _e
-      [])))
-
-;; Outcome Evidence
-(defn ^{:stratum 1} build-outcome-evidence
-  "Build outcome evidence from workflow final state.
-   Uses anomaly->outcome-evidence when anomaly maps are available.
-   Returns outcome evidence per N6 spec."
-  [workflow-state]
-  (let [status (:workflow/status workflow-state)
-        pr-info (:workflow/pr-info workflow-state)
-        error-info (:workflow/error workflow-state)
-        ;; Check for anomaly map in error-info or workflow state
-        ;; (dual-shape during W2: matches both canonical and legacy)
-        anomaly-map (cond
-                      (any-anomaly? error-info) error-info
-                      (any-anomaly? (:anomaly error-info)) (:anomaly error-info)
-                      :else nil)]
-    (merge
-     {:outcome/success (= status :completed)}
-     (when pr-info
-       {:outcome/pr-number (:number pr-info)
-        :outcome/pr-url (:url pr-info)
-        :outcome/pr-status (:status pr-info)
-        :outcome/pr-merged-at (:merged-at pr-info)})
-     (if anomaly-map
-       ;; Use boundary translator for anomaly maps
-       (response/anomaly->outcome-evidence anomaly-map)
-       ;; Fall back to legacy error shape
-       (when error-info
-         {:outcome/error-message (:message error-info)
-          :outcome/error-phase (:phase error-info)
-          :outcome/error-details error-info})))))
-
-(defn- ^{:stratum 1} canonical-dependency-entry
-  [dependency-id dependency]
-  (let [entity (select-keys dependency dependency-health-keys)
-        canonical-id (or dependency-id (:dependency/id entity))]
-    (when canonical-id
-      (assoc entity :dependency/id canonical-id))))
-
-(defn- ^{:stratum 1} failure-attribution
-  [failure]
-  (let [attribution (select-keys failure failure-attribution-keys)]
-    (when (seq attribution)
-      attribution)))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn- ^{:stratum 2} extract-compliance-overrides
-  "Read compliance overrides from workflow-spec or opts.
-   Checks the :compliance key on the spec map first, then falls back to opts.
-   Returns a map of overrides to merge into the bundle, or {} when absent.
-
-   Allowed override keys:
-   - :evidence/data-classification
-   - :evidence/contains-pii?
-   - :evidence/retention-policy  (partial — merged one level deep)
-   - :evidence/regulatory-tags
-   - :evidence/created-by"
-  [workflow-spec opts]
-  (or (normalize-compliance-overrides (:compliance workflow-spec))
-      (normalize-compliance-overrides (:compliance opts))
-      {}))
-
-(defn ^{:stratum 2} collect-phase-evidence
-  "Collect evidence for a single phase from workflow state.
-   Returns phase evidence map or nil if phase not executed."
-  [workflow-state phase-name]
-  (when-let [phase-data (get-in workflow-state [:workflow/phases phase-name])]
-    (build-phase-evidence
-     phase-name
-     (get phase-data :agent :unknown)
-     phase-data)))
-
-(defn- ^{:stratum 2} canonical-dependency-health
-  [dependency-health]
-  (into {}
-        (keep (fn [[dependency-id dependency]]
-                (when-let [entry (canonical-dependency-entry dependency-id dependency)]
-                  [(:dependency/id entry) entry])))
-        dependency-health))
-
-(defn- ^{:stratum 2} dependency-health-from-events
-  [stream workflow-id]
-  (->> dependency-event-types
-       (mapcat #(collect-event-stream-events stream
-                                             {:workflow-id workflow-id
-                                              :event-type %}))
-       (reduce (fn [projection event]
-                 (if-let [entry (canonical-dependency-entry (:dependency/id event) event)]
-                   (assoc projection (:dependency/id entry) entry)
-                   projection))
-               {})))
-
-(defn- ^{:stratum 2} collect-failure-attribution
-  [workflow-state opts]
-  (or (:failure-attribution opts)
-      (some-> (:workflow/error workflow-state) failure-attribution)
-      (some->> (:workflow/errors workflow-state)
-               (keep failure-attribution)
-               first)))
-
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} collect-all-phases
+(defn ^{:stratum 0} collect-all-phases
   "Collect evidence for all executed phases.
    Returns map of evidence keys to phase evidence."
   [workflow-state]
   (let [phases [:plan :design :implement :verify :review :release :observe]]
     (reduce
      (fn [acc phase-name]
-       (if-let [evidence (collect-phase-evidence workflow-state phase-name)]
+       (if-let [evidence (phases/collect-phase-evidence workflow-state phase-name)]
          (assoc acc (keyword "evidence" (name phase-name)) evidence)
          acc))
      {}
      phases)))
 
-(defn- ^{:stratum 3} collect-dependency-health
+(defn- ^{:stratum 0} collect-dependency-health
   [workflow-state stream workflow-id opts]
   (let [projection (or (:dependency-health opts)
                        (:dependency-health workflow-state)
                        (when stream
-                         (dependency-health-from-events stream workflow-id)))]
-    (canonical-dependency-health projection)))
+                         (dependency-health/dependency-health-from-events stream workflow-id)))]
+    (dependency-health/canonical-dependency-health projection)))
 
-;------------------------------------------------------------------------------ Layer 4
+;------------------------------------------------------------------------------ Layer 1
 
 ;; Complete Bundle Assembly
-(defn ^{:stratum 4} assemble-evidence-bundle
+(defn ^{:stratum 1} assemble-evidence-bundle
   "Assemble complete evidence bundle from workflow state and context.
    Merges N11 §9.1 execution evidence fields from :execution/output.
 
@@ -543,23 +108,23 @@
         event-stream (:event-stream opts)
         intent (extract-intent workflow-spec)
         phase-evidence (collect-all-phases workflow-state)
-        policy-checks (collect-policy-checks workflow-state)
-        pack-promotions (collect-pack-promotions workflow-state)
-        outcome (build-outcome-evidence workflow-state)
-        tool-invocations (collect-tool-invocations workflow-state)
-        rules-applied (collect-rules-applied workflow-state)
-        supervision-decisions (collect-supervision-decisions event-stream workflow-id)
-        control-actions (collect-control-actions event-stream workflow-id)
+        policy-checks (collectors/collect-policy-checks workflow-state)
+        pack-promotions (collectors/collect-pack-promotions workflow-state)
+        outcome (outcome/build-outcome-evidence workflow-state)
+        tool-invocations (collectors/collect-tool-invocations workflow-state)
+        rules-applied (collectors/collect-rules-applied workflow-state)
+        supervision-decisions (collectors/collect-supervision-decisions event-stream workflow-id)
+        control-actions (collectors/collect-control-actions event-stream workflow-id)
         dependency-health (collect-dependency-health workflow-state event-stream workflow-id opts)
-        failure-attribution (collect-failure-attribution workflow-state opts)
+        failure-attribution (outcome/collect-failure-attribution workflow-state opts)
 
         ;; N11 §9.1: extract execution evidence from workflow result
-        execution-evidence (collect-execution-evidence workflow-state)
+        execution-evidence (collectors/collect-execution-evidence workflow-state)
 
         ;; Compliance: defaults from schema + caller overrides from spec/opts
-        compliance-defaults (build-default-compliance-metadata)
-        compliance-overrides (extract-compliance-overrides workflow-spec opts)
-        compliance-data (merge-compliance compliance-defaults compliance-overrides)
+        compliance-defaults (compliance-defaults/build-default-compliance-metadata)
+        compliance-overrides (compliance-defaults/extract-compliance-overrides workflow-spec opts)
+        compliance-data (compliance-defaults/merge-compliance compliance-defaults compliance-overrides)
 
         ;; Get artifacts for semantic validation
         artifacts (when artifact-store
@@ -618,9 +183,9 @@
                  scan-result (merge scan-result))]
     (assoc bundle :evidence/content-hash (content-hash/content-hash bundle))))
 
-;------------------------------------------------------------------------------ Layer 5
+;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 5} auto-collect-evidence
+(defn ^{:stratum 2} auto-collect-evidence
   [workflow-id workflow-state artifact-store]
   (when (should-create-bundle? workflow-state)
     (assemble-evidence-bundle workflow-id workflow-state artifact-store)))

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collectors.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collectors.clj
@@ -1,0 +1,221 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.evidence-bundle.collectors
+  "Gathering evidence from workflow state and the event stream: tool
+   invocations, rules, policy checks, pack promotions, supervision
+   decisions, control actions, and execution output."
+  (:require
+   [ai.miniforge.event-stream.interface :as event-stream]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} build-rule-applied-entry
+  "Normalize a manifest entry into the expected rule-applied shape.
+   Ensures all fields have valid defaults and annotates with phase name."
+  [entry phase-name]
+  {:id (or (:id entry) (random-uuid))
+   :title (get entry :title "unknown")
+   :role (get entry :role :unknown)
+   :tags-matched (vec (get entry :tags-matched []))
+   :score (double (get entry :score 0.0))
+   :phase (get entry :phase phase-name)})
+
+;; Policy Check Evidence
+(defn ^{:stratum 0} build-policy-check-evidence
+  "Build policy check evidence from gate result.
+   Returns policy check evidence per N6 spec."
+  [gate-result]
+  {:policy-check/pack-id (get gate-result :pack-id "unknown")
+   :policy-check/pack-version (get gate-result :pack-version "1.0.0")
+   :policy-check/phase (get gate-result :phase :unknown)
+   :policy-check/checked-at (get gate-result :checked-at (java.time.Instant/now))
+   :policy-check/violations (vec (get gate-result :violations []))
+   :policy-check/passed? (get gate-result :passed? true)
+   :policy-check/duration-ms (get gate-result :duration-ms 0)
+   :policy-check/envelope (get gate-result :envelope)})
+
+;; Pack Promotion Evidence
+(defn ^{:stratum 0} build-pack-promotion-evidence
+  "Build pack promotion evidence from promotion record.
+   Returns pack promotion evidence per N6 section 2.1.
+
+   If the promotion record already has the correct format (with :pack/id),
+   return it as-is. Otherwise, build from legacy format."
+  [promotion-record]
+  ;; If already in correct format, return as-is
+  (if (contains? promotion-record :pack/id)
+    promotion-record
+    ;; Otherwise, build from legacy format
+    {:pack/id (get promotion-record :pack-id "unknown")
+     :pack/type (get promotion-record :pack-type :knowledge)
+     :from-trust (get promotion-record :from-trust :untrusted)
+     :to-trust (get promotion-record :to-trust :trusted)
+     :promoted-by (get promotion-record :promoted-by "system")
+     :promoted-at (get promotion-record :promoted-at (java.time.Instant/now))
+     :promotion-policy (get promotion-record :promotion-policy "knowledge-safety")
+     :promotion-justification (get promotion-record :promotion-justification
+                                   "No justification provided")
+     :pack-hash (get promotion-record :pack-hash "")
+     :pack-signature (get promotion-record :pack-signature "")}))
+
+;------------------------------------------------------------------------------ Layer 3.5
+;; Supervision Decision Evidence (N6)
+(defn ^{:stratum 0} collect-event-stream-events
+  [event-stream query]
+  (try
+    (when event-stream
+      (vec (event-stream/get-events event-stream query)))
+    (catch Exception _e
+      [])))
+
+;------------------------------------------------------------------------------ Layer 4.5
+;; Execution Evidence (N11 §9.1)
+(defn ^{:stratum 0} collect-tool-invocations
+  "Collect tool invocation records from workflow state."
+  [workflow-state]
+  (vec (get workflow-state :workflow/tool-invocations [])))
+
+;------------------------------------------------------------------------------ Layer 1.5
+;; Rules Applied Evidence
+(defn ^{:stratum 0} collect-execution-evidence
+  "Extract N11 §9.1 execution evidence fields from workflow state.
+   Looks in :execution/output for evidence fields produced by runner/extract-output.
+   Returns a map of evidence keys to merge into the bundle, or empty map."
+  [workflow-state]
+  (let [output (get workflow-state :execution/output {})]
+    (cond-> {}
+      (contains? output :evidence/execution-mode)
+      (assoc :evidence/execution-mode (:evidence/execution-mode output))
+
+      (contains? output :evidence/runtime-class)
+      (assoc :evidence/runtime-class (:evidence/runtime-class output))
+
+      (contains? output :evidence/task-started-at)
+      (assoc :evidence/task-started-at (:evidence/task-started-at output))
+
+      (contains? output :evidence/task-finished-at)
+      (assoc :evidence/task-finished-at (:evidence/task-finished-at output))
+
+      (contains? output :evidence/image-digest)
+      (assoc :evidence/image-digest (:evidence/image-digest output)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} collect-rules-applied
+  "Collect rules-applied evidence from phase results.
+   Each phase that captured a rules-manifest has its entries normalized
+   and annotated with the phase name.
+   Returns empty vector when no phases have a rules manifest."
+  [workflow-state]
+  (let [phases (get workflow-state :workflow/phases {})]
+    (vec (mapcat (fn [[phase-name phase-data]]
+                   (when-let [manifest (:rules-manifest phase-data)]
+                     (mapv #(build-rule-applied-entry % phase-name) manifest)))
+                 phases))))
+
+(defn ^{:stratum 1} collect-policy-checks
+  "Collect all policy check evidence from workflow state.
+   Returns vector of policy check evidence."
+  [workflow-state]
+  (let [gate-results (get workflow-state :workflow/gate-results [])]
+    (mapv build-policy-check-evidence gate-results)))
+
+(defn ^{:stratum 1} collect-pack-promotions
+  "Collect all pack promotion evidence from workflow state.
+   Returns vector of pack promotion evidence."
+  [workflow-state]
+  (let [promotions (get workflow-state :workflow/pack-promotions [])]
+    (mapv build-pack-promotion-evidence promotions)))
+
+(defn ^{:stratum 1} collect-supervision-decisions
+  "Collect supervision decision events from the event stream.
+
+   Filters for :supervision/tool-use-evaluated events and transforms
+   them into evidence records.
+
+   Arguments:
+   - event-stream: Event stream atom
+   - workflow-id: UUID of the workflow
+
+   Returns vector of supervision decision evidence maps."
+  [event-stream workflow-id]
+  (try
+    (when event-stream
+      (let [events (collect-event-stream-events event-stream
+                                                {:workflow-id workflow-id
+                                                 :event-type :supervision/tool-use-evaluated})]
+        (mapv (fn [event]
+                (cond-> {:supervision/tool-name (get event :tool/name "unknown")
+                         :supervision/decision (get event :supervision/decision "allow")
+                         :supervision/timestamp (get event :event/timestamp
+                                                     (java.util.Date.))}
+                  (:supervision/reasoning event)
+                  (assoc :supervision/reasoning (:supervision/reasoning event))
+
+                  (:supervision/meta-eval? event)
+                  (assoc :supervision/meta-eval? true)
+
+                  (:supervision/confidence event)
+                  (assoc :supervision/confidence (:supervision/confidence event))
+
+                  (:workflow/phase event)
+                  (assoc :supervision/phase (:workflow/phase event))))
+              events)))
+    (catch Exception _e
+      ;; event-stream dependency might not be loaded
+      [])))
+
+(defn ^{:stratum 1} collect-control-actions
+  "Collect control action events from the event stream.
+
+   Pairs :control-action/requested with :control-action/executed events.
+
+   Arguments:
+   - event-stream: Event stream atom
+   - workflow-id: UUID of the workflow
+
+   Returns vector of control action evidence maps."
+  [event-stream workflow-id]
+  (try
+    (when event-stream
+      (let [requested (collect-event-stream-events event-stream
+                                                   {:workflow-id workflow-id
+                                                    :event-type :control-action/requested})
+            executed (collect-event-stream-events event-stream
+                                                  {:workflow-id workflow-id
+                                                   :event-type :control-action/executed})
+            executed-by-id (into {} (map (fn [e] [(:action/id e) e]) executed))]
+        (mapv (fn [req-event]
+                (let [action-id (:action/id req-event)
+                      exec-event (get executed-by-id action-id)]
+                  (cond-> {:control-action/id action-id
+                           :control-action/type (:action/type req-event)
+                           :control-action/requester (get req-event :action/requester {})
+                           :control-action/timestamp (get req-event :event/timestamp
+                                                         (java.util.Date.))
+                           :control-action/result (if exec-event :executed :pending)}
+                    (:action/justification req-event)
+                    (assoc :control-action/justification (:action/justification req-event))
+
+                    (:action/target req-event)
+                    (assoc :control-action/target (:action/target req-event)))))
+              requested)))
+    (catch Exception _e
+      [])))
+
+;; Outcome Evidence

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collectors.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collectors.clj
@@ -24,6 +24,7 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
+;; Rules Applied Evidence
 (defn- ^{:stratum 0} build-rule-applied-entry
   "Normalize a manifest entry into the expected rule-applied shape.
    Ensures all fields have valid defaults and annotates with phase name."
@@ -73,7 +74,6 @@
      :pack-hash (get promotion-record :pack-hash "")
      :pack-signature (get promotion-record :pack-signature "")}))
 
-;------------------------------------------------------------------------------ Layer 3.5
 ;; Supervision Decision Evidence (N6)
 (defn ^{:stratum 0} collect-event-stream-events
   [event-stream query]
@@ -83,15 +83,12 @@
     (catch Exception _e
       [])))
 
-;------------------------------------------------------------------------------ Layer 4.5
-;; Execution Evidence (N11 §9.1)
 (defn ^{:stratum 0} collect-tool-invocations
   "Collect tool invocation records from workflow state."
   [workflow-state]
   (vec (get workflow-state :workflow/tool-invocations [])))
 
-;------------------------------------------------------------------------------ Layer 1.5
-;; Rules Applied Evidence
+;; Execution Evidence (N11 §9.1)
 (defn ^{:stratum 0} collect-execution-evidence
   "Extract N11 §9.1 execution evidence fields from workflow state.
    Looks in :execution/output for evidence fields produced by runner/extract-output.

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/compliance_defaults.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/compliance_defaults.clj
@@ -31,6 +31,7 @@
     :evidence/regulatory-tags
     :evidence/created-by})
 
+;; Compliance Defaults and Overrides
 (defn ^{:stratum 0} build-default-compliance-metadata
   "Return the default compliance map for assembled evidence bundles.
    Uses schema.compliance-defined defaults so the single source of truth
@@ -62,7 +63,6 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-;; Access Log
 (defn- ^{:stratum 1} normalize-compliance-overrides
   "Return only documented compliance override keys from m, or nil for non-maps."
   [m]

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/compliance_defaults.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/compliance_defaults.clj
@@ -1,0 +1,88 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.evidence-bundle.compliance-defaults
+  "Compliance metadata: template defaults, caller overrides, and the
+   one-level-deep merge between them."
+  (:require
+   [ai.miniforge.evidence-bundle.schema.compliance :as compliance]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private compliance-override-keys
+  "Allowed keys for workflow-spec and opts compliance override maps."
+  #{:evidence/data-classification
+    :evidence/contains-pii?
+    :evidence/retention-policy
+    :evidence/regulatory-tags
+    :evidence/created-by})
+
+(defn ^{:stratum 0} build-default-compliance-metadata
+  "Return the default compliance map for assembled evidence bundles.
+   Uses schema.compliance-defined defaults so the single source of truth
+   lives there. Covers the assembly path; the template function covers
+   manual construction."
+  []
+  {:evidence/data-classification compliance/default-data-classification
+   :evidence/contains-pii?       false
+   :evidence/retention-policy    {:retain-days  compliance/default-retention-days
+                                  :auto-delete? true
+                                  :legal-hold?  false}
+   :evidence/regulatory-tags     #{}
+   :evidence/created-by          compliance/default-created-by-principal})
+
+(defn ^{:stratum 0} merge-compliance
+  "Merge compliance defaults with operator overrides.
+   :evidence/retention-policy is merged one level deep so callers may supply
+   only the keys they wish to change (e.g. just {:retain-days 365}) without
+   losing the other retention fields from the defaults."
+  [defaults overrides]
+  (let [base (merge defaults overrides)]
+    (if (and (contains? overrides :evidence/retention-policy)
+             (map? (get defaults :evidence/retention-policy))
+             (map? (get overrides :evidence/retention-policy)))
+      (assoc base :evidence/retention-policy
+             (merge (get defaults :evidence/retention-policy)
+                    (get overrides :evidence/retention-policy)))
+      base)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Access Log
+(defn- ^{:stratum 1} normalize-compliance-overrides
+  "Return only documented compliance override keys from m, or nil for non-maps."
+  [m]
+  (when (map? m)
+    (select-keys m compliance-override-keys)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} extract-compliance-overrides
+  "Read compliance overrides from workflow-spec or opts.
+   Checks the :compliance key on the spec map first, then falls back to opts.
+   Returns a map of overrides to merge into the bundle, or {} when absent.
+
+   Allowed override keys:
+   - :evidence/data-classification
+   - :evidence/contains-pii?
+   - :evidence/retention-policy  (partial — merged one level deep)
+   - :evidence/regulatory-tags
+   - :evidence/created-by"
+  [workflow-spec opts]
+  (or (normalize-compliance-overrides (:compliance workflow-spec))
+      (normalize-compliance-overrides (:compliance opts))
+      {}))

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/dependency_health.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/dependency_health.clj
@@ -1,0 +1,74 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.evidence-bundle.dependency-health
+  "Dependency health, reconstructed either from recorded state or from
+   the event stream when state does not carry it."
+  (:require
+   [ai.miniforge.evidence-bundle.collectors :as collectors]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private dependency-event-types
+  #{:dependency/health-updated
+    :dependency/recovered})
+
+(def ^{:stratum 0} ^:private dependency-health-keys
+  [:dependency/id
+   :dependency/source
+   :dependency/kind
+   :dependency/status
+   :dependency/failure-count
+   :dependency/window-size
+   :dependency/incident-counts
+   :dependency/vendor
+   :dependency/class
+   :dependency/retryability
+   :failure/class
+   :dependency/last-observed-at
+   :dependency/last-recovered-at])
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} canonical-dependency-entry
+  [dependency-id dependency]
+  (let [entity (select-keys dependency dependency-health-keys)
+        canonical-id (or dependency-id (:dependency/id entity))]
+    (when canonical-id
+      (assoc entity :dependency/id canonical-id))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} canonical-dependency-health
+  [dependency-health]
+  (into {}
+        (keep (fn [[dependency-id dependency]]
+                (when-let [entry (canonical-dependency-entry dependency-id dependency)]
+                  [(:dependency/id entry) entry])))
+        dependency-health))
+
+(defn ^{:stratum 2} dependency-health-from-events
+  [stream workflow-id]
+  (->> dependency-event-types
+       (mapcat #(collectors/collect-event-stream-events stream
+                                             {:workflow-id workflow-id
+                                              :event-type %}))
+       (reduce (fn [projection event]
+                 (if-let [entry (canonical-dependency-entry (:dependency/id event) event)]
+                   (assoc projection (:dependency/id entry) entry)
+                   projection))
+               {})))

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/outcome.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/outcome.clj
@@ -1,0 +1,102 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.evidence-bundle.outcome
+  "Workflow outcome evidence and the attribution of a failure to the
+   phase that produced it."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.response.interface :as response]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Anomaly detection (dual shape during W2 convergence)
+(defn- ^{:stratum 0} any-anomaly?
+  "True when `x` is either a canonical anomaly (`:anomaly/type`) or a
+   legacy response anomaly (`:anomaly/category`).
+
+   evidence-bundle reads anomalies from arbitrary upstream producers
+   (workflow/error, error-info :anomaly), so it must detect both
+   shapes until W5 retires the legacy producers. Prefers the canonical
+   predicate; falls back to the legacy one. Mirrors the dispatch-key
+   pattern in `failure-classifier/classify-failure`."
+  [x]
+  (or (anomaly/anomaly? x)
+      (response/anomaly-map? x)))
+
+;; Intent Collection
+(def ^{:stratum 0} ^:private failure-attribution-keys
+  [:failure/source
+   :failure/vendor
+   :failure/class
+   :failure/message
+   :dependency/class
+   :dependency/retryability
+   :dependency/id
+   :dependency/source
+   :dependency/kind
+   :dependency/vendor
+   :dependency/status])
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Workflow Integration Helpers
+(defn ^{:stratum 1} build-outcome-evidence
+  "Build outcome evidence from workflow final state.
+   Uses anomaly->outcome-evidence when anomaly maps are available.
+   Returns outcome evidence per N6 spec."
+  [workflow-state]
+  (let [status (:workflow/status workflow-state)
+        pr-info (:workflow/pr-info workflow-state)
+        error-info (:workflow/error workflow-state)
+        ;; Check for anomaly map in error-info or workflow state
+        ;; (dual-shape during W2: matches both canonical and legacy)
+        anomaly-map (cond
+                      (any-anomaly? error-info) error-info
+                      (any-anomaly? (:anomaly error-info)) (:anomaly error-info)
+                      :else nil)]
+    (merge
+     {:outcome/success (= status :completed)}
+     (when pr-info
+       {:outcome/pr-number (:number pr-info)
+        :outcome/pr-url (:url pr-info)
+        :outcome/pr-status (:status pr-info)
+        :outcome/pr-merged-at (:merged-at pr-info)})
+     (if anomaly-map
+       ;; Use boundary translator for anomaly maps
+       (response/anomaly->outcome-evidence anomaly-map)
+       ;; Fall back to legacy error shape
+       (when error-info
+         {:outcome/error-message (:message error-info)
+          :outcome/error-phase (:phase error-info)
+          :outcome/error-details error-info})))))
+
+(defn ^{:stratum 1} failure-attribution
+  [failure]
+  (let [attribution (select-keys failure failure-attribution-keys)]
+    (when (seq attribution)
+      attribution)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} collect-failure-attribution
+  [workflow-state opts]
+  (or (:failure-attribution opts)
+      (some-> (:workflow/error workflow-state) failure-attribution)
+      (some->> (:workflow/errors workflow-state)
+               (keep failure-attribution)
+               first)))

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/outcome.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/outcome.clj
@@ -38,7 +38,6 @@
   (or (anomaly/anomaly? x)
       (response/anomaly-map? x)))
 
-;; Intent Collection
 (def ^{:stratum 0} ^:private failure-attribution-keys
   [:failure/source
    :failure/vendor
@@ -54,7 +53,7 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-;; Workflow Integration Helpers
+;; Outcome Evidence
 (defn ^{:stratum 1} build-outcome-evidence
   "Build outcome evidence from workflow final state.
    Uses anomaly->outcome-evidence when anomaly maps are available.

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/phases.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/phases.clj
@@ -1,0 +1,83 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.evidence-bundle.phases
+  "Per-phase evidence: one phase's output, one phase's evidence entry,
+   and the map of both across a workflow's phases.")
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} build-phase-output
+  "Extract the output map for phase evidence.
+
+   Handles both:
+   - Legacy shape: {:output {...}} — extracts :output directly
+   - New environment model: {:environment-id ... :summary ... :metrics ...}
+     — synthesizes an output map from the provenance metadata
+
+   In the new model, :evidence/implement captures summary + metrics (not code).
+   :evidence/verify captures test output. :evidence/release captures PR metadata."
+  [phase-result]
+  (or
+   ;; Legacy: explicit :output key
+   (get phase-result :output)
+   ;; New environment model: synthesize output from provenance metadata
+   (when (or (:summary phase-result) (:metrics phase-result)
+             (:environment-id phase-result))
+     (cond-> {}
+       (:summary phase-result)        (assoc :summary        (:summary phase-result))
+       (:metrics phase-result)        (assoc :metrics        (:metrics phase-result))
+       (:environment-id phase-result) (assoc :environment-id (:environment-id phase-result))))
+   {}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} build-phase-evidence
+  "Build phase evidence from phase execution context.
+   Returns phase evidence map per N6 spec.
+
+   Handles both legacy (:output map) and new-model (:environment-id, :summary,
+   :metrics) phase result shapes. In the new model, code is NOT captured here;
+   it is derived from the PR diff at release time."
+  [phase-name agent-id phase-result]
+  (let [started-at   (get phase-result :started-at (java.time.Instant/now))
+        completed-at (get phase-result :completed-at (java.time.Instant/now))]
+    {:phase/name                phase-name
+     :phase/agent               agent-id
+     :phase/agent-instance-id   (get phase-result :agent-instance-id (random-uuid))
+     :phase/started-at          started-at
+     :phase/completed-at        completed-at
+     :phase/duration-ms         (get phase-result :duration-ms
+                                     (- (.toEpochMilli completed-at)
+                                        (.toEpochMilli started-at)))
+     :phase/output              (build-phase-output phase-result)
+     :phase/artifacts           (vec (get phase-result :artifacts []))
+     :phase/inner-loop-iterations (get phase-result :inner-loop-iterations 0)
+     :phase/event-stream-range  (get phase-result :event-stream-range
+                                     {:start-seq 0 :end-seq 0})}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} collect-phase-evidence
+  "Collect evidence for a single phase from workflow state.
+   Returns phase evidence map or nil if phase not executed."
+  [workflow-state phase-name]
+  (when-let [phase-data (get-in workflow-state [:workflow/phases phase-name])]
+    (build-phase-evidence
+     phase-name
+     (get phase-data :agent :unknown)
+     phase-data)))

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/phases.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/phases.clj
@@ -21,6 +21,7 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
+;; Phase Evidence Collection
 (defn- ^{:stratum 0} build-phase-output
   "Extract the output map for phase evidence.
 

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/evidence_bundle.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/evidence_bundle.clj
@@ -20,6 +20,7 @@
    Pure functions organized in layers."
   (:require
    [ai.miniforge.evidence-bundle.collector :as collector]
+   [ai.miniforge.evidence-bundle.collectors :as collectors]
    [ai.miniforge.evidence-bundle.schema.domain :as domain]
    [ai.miniforge.evidence-bundle.schema.validation :as validation]
    [ai.miniforge.logging.interface :as log]))
@@ -48,7 +49,7 @@
   "Compatibility wrapper for execution evidence extraction.
    Delegates to the canonical collector implementation."
   [workflow-state]
-  (collector/collect-execution-evidence workflow-state))
+  (collectors/collect-execution-evidence workflow-state))
 
 (defn ^{:stratum 0} create-bundle-impl
   "Create evidence bundle from workflow state.

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/assembly_integration_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/assembly_integration_test.clj
@@ -27,6 +27,9 @@
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.content-hash.interface :as hash]
    [ai.miniforge.evidence-bundle.collector :as collector]
+   [ai.miniforge.evidence-bundle.collectors :as collectors]
+   [ai.miniforge.evidence-bundle.outcome :as outcome]
+   [ai.miniforge.evidence-bundle.phases :as phases]
    [ai.miniforge.evidence-bundle.schema :as schema]
    [ai.miniforge.evidence-bundle.schema.domain :as domain]
    [ai.miniforge.evidence-bundle.schema.validation :as validation]))
@@ -199,7 +202,7 @@
   (testing "Evidence is collected for an executed phase"
     (let [workflow-state (make-workflow-state
                           :phases {:implement (make-phase-data :agent :implementer)})
-          evidence (collector/collect-phase-evidence workflow-state :implement)]
+          evidence (phases/collect-phase-evidence workflow-state :implement)]
       (is (some? evidence)
           "Phase evidence should be returned")
       (is (= :implement (:phase/name evidence))
@@ -220,7 +223,7 @@
 (deftest ^{:stratum 2} collect-phase-evidence-missing-phase-test
   (testing "Returns nil for unexecuted phase"
     (let [workflow-state (make-workflow-state :phases {})
-          evidence (collector/collect-phase-evidence workflow-state :implement)]
+          evidence (phases/collect-phase-evidence workflow-state :implement)]
       (is (nil? evidence)
           "Should return nil for unexecuted phase"))))
 
@@ -251,7 +254,7 @@
                                     :url "https://github.com/org/repo/pull/42"
                                     :status :merged
                                     :merged-at (make-timestamp)})
-          outcome (collector/build-outcome-evidence workflow-state)]
+          outcome (outcome/build-outcome-evidence workflow-state)]
       (is (true? (:outcome/success outcome))
           "Outcome should indicate success")
       (is (= 42 (:outcome/pr-number outcome))
@@ -265,7 +268,7 @@
                           :status :failed
                           :error {:message "Compilation error"
                                   :phase :implement})
-          outcome (collector/build-outcome-evidence workflow-state)]
+          outcome (outcome/build-outcome-evidence workflow-state)]
       (is (false? (:outcome/success outcome))
           "Outcome should indicate failure")
       (is (= "Compilation error" (:outcome/error-message outcome))
@@ -279,7 +282,7 @@
     (let [workflow-state (make-workflow-state
                           :gate-results [(make-gate-result :phase :implement :passed? true)
                                          (make-gate-result :phase :review :passed? false)])
-          checks (collector/collect-policy-checks workflow-state)]
+          checks (collectors/collect-policy-checks workflow-state)]
       (is (= 2 (count checks))
           "Should collect both gate results")
       (is (true? (:policy-check/passed? (first checks)))
@@ -292,7 +295,7 @@
 (deftest ^{:stratum 2} collect-policy-checks-empty-test
   (testing "Empty gate results produce empty vector"
     (let [workflow-state (make-workflow-state :gate-results [])
-          checks (collector/collect-policy-checks workflow-state)]
+          checks (collectors/collect-policy-checks workflow-state)]
       (is (empty? checks)
           "Should return empty vector when no gate results"))))
 
@@ -395,7 +398,7 @@
                                             :role :quality
                                             :tags-matched [:clojure]
                                             :score 0.9}])})
-          rules (collector/collect-rules-applied workflow-state)]
+          rules (collectors/collect-rules-applied workflow-state)]
       (is (= 1 (count rules))
           "Should collect one rule")
       (is (= rule-id (:id (first rules)))
@@ -406,7 +409,7 @@
 (deftest ^{:stratum 2} collect-rules-applied-empty-test
   (testing "Returns empty vector when no rules manifests exist"
     (let [workflow-state (make-workflow-state :phases {:implement (make-phase-data)})
-          rules (collector/collect-rules-applied workflow-state)]
+          rules (collectors/collect-rules-applied workflow-state)]
       (is (empty? rules)
           "Should return empty vector"))))
 
@@ -420,7 +423,7 @@
           workflow-state (make-workflow-state)
           state-with-tools (assoc workflow-state
                                   :workflow/tool-invocations [invocation])
-          invocations (collector/collect-tool-invocations state-with-tools)]
+          invocations (collectors/collect-tool-invocations state-with-tools)]
       (is (= 1 (count invocations))
           "Should collect one invocation")
       (is (= :gh-pr-create (:tool/id (first invocations)))

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/execution_evidence_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/execution_evidence_test.clj
@@ -19,7 +19,7 @@
   "Tests for N11 section 9.1 execution evidence collection.
 
    Covers:
-   - collectors/collect-execution-evidence (public, Layer 4.5)
+   - collectors/collect-execution-evidence (public)
    - evidence_bundle/extract-execution-evidence (private, Layer 1)
    - runner/extract-output evidence field enrichment"
   (:require

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/execution_evidence_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/execution_evidence_test.clj
@@ -19,12 +19,12 @@
   "Tests for N11 section 9.1 execution evidence collection.
 
    Covers:
-   - collector/collect-execution-evidence (public, Layer 4.5)
+   - collectors/collect-execution-evidence (public, Layer 4.5)
    - evidence_bundle/extract-execution-evidence (private, Layer 1)
    - runner/extract-output evidence field enrichment"
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.evidence-bundle.collector :as collector]
+   [ai.miniforge.evidence-bundle.collectors :as collectors]
    [ai.miniforge.dag-executor.executor :as dag-exec]
    [ai.miniforge.workflow.runner :as runner]))
 
@@ -38,7 +38,7 @@
                        'extract-execution-evidence)))
 
 ;; ============================================================================
-;; collector/collect-execution-evidence — pure data extraction
+;; collectors/collect-execution-evidence — pure data extraction
 ;; ============================================================================
 (deftest ^{:stratum 0} collect-evidence-all-fields-present-test
   (testing "extracts all five evidence fields when present"
@@ -50,7 +50,7 @@
                   :evidence/task-started-at started
                   :evidence/task-finished-at finished
                   :evidence/image-digest    "sha256:abc123"}}
-          result (collector/collect-execution-evidence state)]
+          result (collectors/collect-execution-evidence state)]
       (is (= :governed (:evidence/execution-mode result)))
       (is (= :docker (:evidence/runtime-class result)))
       (is (= started (:evidence/task-started-at result)))
@@ -59,12 +59,12 @@
 
 (deftest ^{:stratum 0} collect-evidence-empty-output-test
   (testing "returns empty map when :execution/output is absent"
-    (let [result (collector/collect-execution-evidence {})]
+    (let [result (collectors/collect-execution-evidence {})]
       (is (= {} result)))))
 
 (deftest ^{:stratum 0} collect-evidence-nil-output-test
   (testing "returns empty map when :execution/output is nil"
-    (let [result (collector/collect-execution-evidence {:execution/output nil})]
+    (let [result (collectors/collect-execution-evidence {:execution/output nil})]
       (is (= {} result)))))
 
 (deftest ^{:stratum 0} collect-evidence-partial-fields-test
@@ -74,7 +74,7 @@
                   :evidence/runtime-class  :worktree
                   ;; no timestamps, no image-digest
                   :artifacts []}}
-          result (collector/collect-execution-evidence state)]
+          result (collectors/collect-execution-evidence state)]
       (is (= :local (:evidence/execution-mode result)))
       (is (= :worktree (:evidence/runtime-class result)))
       (is (not (contains? result :evidence/task-started-at)))
@@ -84,7 +84,7 @@
 (deftest ^{:stratum 0} collect-evidence-image-digest-only-test
   (testing "extracts image-digest alone when other fields absent"
     (let [state {:execution/output {:evidence/image-digest "sha256:deadbeef"}}
-          result (collector/collect-execution-evidence state)]
+          result (collectors/collect-execution-evidence state)]
       (is (= "sha256:deadbeef" (:evidence/image-digest result)))
       (is (not (contains? result :evidence/execution-mode))))))
 

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/outcome_anomaly_shape_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/outcome_anomaly_shape_test.clj
@@ -28,7 +28,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.anomaly.interface :as anomaly]
-   [ai.miniforge.evidence-bundle.collector :as collector]
+   [ai.miniforge.evidence-bundle.outcome :as outcome]
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -48,7 +48,7 @@
 (deftest ^{:stratum 1} canonical-anomaly-at-error-info-routes-through-outcome
   (testing "a canonical anomaly map as :workflow/error is detected"
     (let [a       (anomaly/anomaly :fault "Compilation error" {})
-          outcome (collector/build-outcome-evidence
+          outcome (outcome/build-outcome-evidence
                    (workflow-state-with-error a))]
       (is (false? (:outcome/success outcome)))
       (is (= "Compilation error" (:outcome/error-message outcome))))))
@@ -56,7 +56,7 @@
 (deftest ^{:stratum 1} canonical-anomaly-nested-under-anomaly-routes-through-outcome
   (testing "a canonical anomaly under {:anomaly a} is also detected"
     (let [a       (anomaly/anomaly :timeout "agent timed out" {})
-          outcome (collector/build-outcome-evidence
+          outcome (outcome/build-outcome-evidence
                    (workflow-state-with-error {:anomaly a}))]
       (is (false? (:outcome/success outcome)))
       (is (= "agent timed out" (:outcome/error-message outcome))))))
@@ -65,7 +65,7 @@
 (deftest ^{:stratum 1} legacy-anomaly-at-error-info-still-detected
   (testing "a legacy :anomaly/category map as :workflow/error is detected"
     (let [a       (response/make-anomaly :anomalies/fault "boom")
-          outcome (collector/build-outcome-evidence
+          outcome (outcome/build-outcome-evidence
                    (workflow-state-with-error a))]
       (is (false? (:outcome/success outcome)))
       (is (= "boom" (:outcome/error-message outcome))))))
@@ -73,7 +73,7 @@
 (deftest ^{:stratum 1} legacy-anomaly-nested-under-anomaly-still-detected
   (testing "a legacy anomaly under {:anomaly a} is still detected"
     (let [a       (response/make-anomaly :anomalies/timeout "slow")
-          outcome (collector/build-outcome-evidence
+          outcome (outcome/build-outcome-evidence
                    (workflow-state-with-error {:anomaly a}))]
       (is (false? (:outcome/success outcome)))
       (is (= "slow" (:outcome/error-message outcome))))))
@@ -82,7 +82,7 @@
 (deftest ^{:stratum 1} non-anomaly-error-falls-back-to-legacy-shape
   (testing "a plain error map (no :anomaly/type, no :anomaly/category)
             is preserved via the legacy non-anomaly fall-through"
-    (let [outcome (collector/build-outcome-evidence
+    (let [outcome (outcome/build-outcome-evidence
                    (workflow-state-with-error
                     {:message "old style" :phase :verify}))]
       (is (false? (:outcome/success outcome)))


### PR DESCRIPTION
## Why

`collector.clj` was 639 lines across six strata; SL003 allows three.

The finding is pre-existing — it surfaced when an unrelated change put
the file into the linted set, exactly as event-stream's `core.clj` did
in [#1799](https://github.com/miniforge-ai/miniforge/pull/1799). Nothing
can touch this file until it is under budget, so this lands on its own
rather than buried inside a behavioural change.

## The split

Grouped by subject rather than by stratum, so each namespace answers one
question:

| namespace | holds |
|---|---|
| `compliance-defaults` | template defaults, caller overrides, their one-level merge |
| `phases` | one phase's output, its evidence entry, all phases |
| `collectors` | gathering from workflow state and the event stream |
| `dependency-health` | health from recorded state, or from events when state lacks it |
| `outcome` | outcome evidence and failure attribution |

`collector.clj` keeps what assembles a bundle out of those pieces:
`extract-intent`, `append-access-log-entry`, `should-create-bundle?`,
`collect-all-phases`, `collect-dependency-health`,
`assemble-evidence-bundle`, `auto-collect-evidence`.

Eight private forms became public because they are now referenced across
a namespace boundary. References were updated in the seven files that
named the moved functions — all inside this component.

## Behaviour

None intended, and verified rather than asserted — twice.

First by name: the set of 36 top-level forms is identical before and
after, nothing lost and nothing added. That check also caught a section
comment my extraction had stripped (`;; Anomaly detection (dual shape
during W2 convergence)`), which is restored.

Then by body: each form's source compared against the original, after
normalising away the three differences a split is allowed to introduce —
added alias qualification, `defn-` to `defn` where a form is now
referenced across a namespace boundary, and file-local stratum
renumbering. Of 36 forms, exactly 4 differ, and all 4 differ only in
their stratum tag (`collect-all-phases` 3→0, `collect-dependency-health`
3→0, `assemble-evidence-bundle` 4→1, `auto-collect-evidence` 5→2). No
form body changed.

- 126 tests / 388 assertions pass
- `poly check` OK, kondo 0 errors / 0 warnings
- every file now at three strata or fewer

## Budget

843 reportable lines, over the 600 CI budget. The bulk is
`collector.clj` counting as a rewrite because form order changed; the
forms themselves moved unaltered, which the form-set comparison above
verifies.

MINIFORGE_PR_BUDGET_OVERRIDE: Mechanical namespace split required to bring collector.clj under the SL003 layer budget before any change can touch the file. Behaviour-preserving: the same 36 top-level forms exist before and after, verified by name-set comparison, with nothing lost or added. Splitting this into smaller PRs is not possible — the file is over budget until the whole split lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

