### PR TITLE
feat(evidence-bundle): redact bundles before sealing them (N6.SD.4)

### DIFF
--- a/components/evidence-bundle/deps.edn
+++ b/components/evidence-bundle/deps.edn
@@ -4,6 +4,7 @@
         ai.miniforge/content-hash {:local/root "../content-hash"}
         ai.miniforge/event-stream {:local/root "../event-stream"}
         ai.miniforge/logging      {:local/root "../logging"}
+        ai.miniforge/redaction    {:local/root "../redaction"}
         ai.miniforge/response     {:local/root "../response"}
         ai.miniforge/schema       {:local/root "../schema"}
         ai.miniforge/workflow     {:local/root "../workflow"}}

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
@@ -25,6 +25,7 @@
    [ai.miniforge.evidence-bundle.dependency-health :as dependency-health]
    [ai.miniforge.evidence-bundle.outcome :as outcome]
    [ai.miniforge.evidence-bundle.phases :as phases]
+   [ai.miniforge.redaction.interface :as redaction]
    [ai.miniforge.evidence-bundle.protocols.impl.semantic-validator :as semantic-validator]
    [ai.miniforge.evidence-bundle.scanner :as scanner]
    [ai.miniforge.evidence-bundle.schema :as schema]))
@@ -181,7 +182,19 @@
 
         ;; Merge compliance metadata
         bundle (cond-> bundle
-                 scan-result (merge scan-result))]
+                 scan-result (merge scan-result))
+
+        ;; N6.SD.4: redact on detection — flagging alone does not satisfy
+        ;; N3 §8.1, which is a MUST NOT on the content, not a labelling
+        ;; requirement. Until now the scanner recorded that a bundle held
+        ;; a secret and then stored the secret anyway.
+        ;;
+        ;; After the scan, so the compliance finding survives: that a
+        ;; secret *was* present is the auditable fact, and redacting
+        ;; first would erase the evidence of it. Before the hash, because
+        ;; N6 §7.2 seals only after the substitution — hashing first
+        ;; would bind the bundle to its un-redacted form.
+        bundle (redaction/redact bundle)]
     (assoc bundle :evidence/content-hash (content-hash/content-hash bundle))))
 
 ;------------------------------------------------------------------------------ Layer 2

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/scanner.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/scanner.clj
@@ -16,7 +16,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.evidence-bundle.scanner
-  "Sensitive-data scanner for assembled evidence bundles.")
+  "Sensitive-data scanner for assembled evidence bundles."
+  (:require
+   [ai.miniforge.redaction.interface :as redaction]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -31,7 +33,17 @@
 (def ^{:stratum 0} ^:private pii-finding-types
   #{:email :ssn})
 
+(def ^{:stratum 0} ^:private secret-finding-types
+  #{:aws-access-key :embedded-secret})
+
 (defn- ^{:stratum 0} bundle-text
+  "Render BUNDLE for pattern matching.
+
+   Bounded by print-length and print-level, so detection sees a truncated
+   view of a deep or wide bundle. That makes the findings best-effort
+   metadata, not a security boundary: redaction walks the whole structure
+   and does not share this limit, so a secret past level 20 is still
+   removed even when nothing reports it."
   [bundle]
   (binding [*print-length* 1000
             *print-level* 20]
@@ -47,11 +59,28 @@
   [bundle]
   (let [text (bundle-text bundle)]
     {:scan/findings
-     (vec
-      (keep (fn [{:finding/keys [type pattern]}]
-              (when (re-find pattern text)
-                {:finding/type type}))
-            sensitive-patterns))}))
+     (let [labelled (vec
+                     (keep (fn [{:finding/keys [type pattern]}]
+                             (when (re-find pattern text)
+                               {:finding/type type}))
+                           sensitive-patterns))]
+       ;; N6.SD.3 requires the bundle to scan independently of the
+       ;; stream — not to hold a different definition of "secret". The
+       ;; patterns above name specific types worth reporting; this
+       ;; covers the rest of the N3 §8 set (private keys, connection
+       ;; strings, JWTs, provider tokens), so a bundle cannot report
+       ;; clean on a value the stream would have redacted.
+       ;;
+       ;; A fallback rather than an additional label, so one secret is
+       ;; not reported twice under two names. A bundle holding both a
+       ;; named and an unnamed secret reports only the named one, which
+       ;; costs nothing: the answer to "does this contain secrets" is
+       ;; unchanged, and redaction below is unconditional either way.
+       (cond-> labelled
+         (and (redaction/secret-string? text)
+              (not-any? #(contains? secret-finding-types (:finding/type %))
+                        labelled))
+         (conj {:finding/type :embedded-secret})))}))
 
 (defn ^{:stratum 1} compliance-metadata
   "Convert scan results into evidence compliance metadata."

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/assembly_integration_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/assembly_integration_test.clj
@@ -24,6 +24,7 @@
 
    All externals are mocked — no artifact store, no event stream, no network."
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.content-hash.interface :as hash]
    [ai.miniforge.evidence-bundle.collector :as collector]
@@ -428,3 +429,58 @@
           "Should collect one invocation")
       (is (= :gh-pr-create (:tool/id (first invocations)))
           "Tool ID should match"))))
+
+;; N6 §7.2 — sensitive data in assembled bundles
+(deftest ^{:stratum 2} assembled-bundle-is-redacted-before-sealing-test
+  (testing "a secret in phase output does not survive into the bundle"
+    ;; N6.SD.4: flagging alone does not satisfy N3 §8.1. Before this, the
+    ;; scanner recorded that a bundle held a secret and stored it anyway.
+    (let [secret "AKIAIOSFODNN7EXAMPLE"
+          phase  (assoc-in (make-phase-data)
+                           [:output :summary]
+                           (str "Deployed with " secret))
+          bundle (collector/assemble-evidence-bundle
+                  (make-workflow-id)
+                  (make-workflow-state :phases {:implement phase})
+                  nil)
+          text   (pr-str bundle)]
+      (is (not (str/includes? text secret))
+          "the secret must not survive anywhere in the bundle")
+      (is (str/includes? text "[REDACTED]")
+          "the marker records that a value was removed")))
+
+  (testing "the compliance finding survives the redaction that follows it"
+    ;; Scan first, then redact: that a secret *was* present is the
+    ;; auditable fact. Redacting first would erase the evidence of it.
+    (let [phase  (assoc-in (make-phase-data)
+                           [:output :summary]
+                           "Deployed with AKIAIOSFODNN7EXAMPLE")
+          bundle (collector/assemble-evidence-bundle
+                  (make-workflow-id)
+                  (make-workflow-state :phases {:implement phase})
+                  nil)]
+      (is (some #(= :aws-access-key (:finding/type %))
+                (:compliance/sensitive-findings bundle))
+          "the scan finding is still reported after redaction")))
+
+  (testing "the content hash binds the redacted bundle, not the original"
+    ;; N6 §7.2 seals only after the substitution. Hashing first would
+    ;; bind the bundle to a form that no longer exists.
+    (let [phase  (assoc-in (make-phase-data)
+                           [:output :summary]
+                           "Deployed with AKIAIOSFODNN7EXAMPLE")
+          bundle (collector/assemble-evidence-bundle
+                  (make-workflow-id)
+                  (make-workflow-state :phases {:implement phase})
+                  nil)]
+      (is (= (:evidence/content-hash bundle)
+             (hash/content-hash (dissoc bundle :evidence/content-hash)))
+          "the stored hash recomputes over the redacted bundle")))
+
+  (testing "token counts in phase metrics survive"
+    (let [bundle (collector/assemble-evidence-bundle
+                  (make-workflow-id)
+                  (make-workflow-state :phases {:implement (make-phase-data)})
+                  nil)]
+      (is (str/includes? (pr-str bundle) ":tokens 1000")
+          "an LLM token count is not a bearer token"))))

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/scanner_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/scanner_test.clj
@@ -46,3 +46,26 @@
                    {:intent/description "Key AKIAABCDEFGHIJKLMNOP"}})]
       (is (= {:compliance/sensitive-findings [{:finding/type :aws-access-key}]}
              (scanner/compliance-metadata result))))))
+
+(deftest ^{:stratum 0} scan-covers-the-streams-secret-set
+  (testing "a secret the labelled patterns do not name is still reported"
+    ;; N6.SD.3 requires the bundle to scan independently of the stream,
+    ;; not to hold a narrower definition of "secret". A GitHub token
+    ;; matches no pattern in this file, but the stream would redact it.
+    (let [result (scanner/scan-artifact
+                  {:evidence/intent
+                   {:intent/description "used ghp_abcdefghijklmnopqrstuvwxyz0123"}})]
+      (is (= [{:finding/type :embedded-secret}] (:scan/findings result)))))
+
+  (testing "a named secret is not also reported as an unnamed one"
+    (let [result (scanner/scan-artifact
+                  {:evidence/intent
+                   {:intent/description "Key AKIAABCDEFGHIJKLMNOP"}})]
+      (is (= [{:finding/type :aws-access-key}] (:scan/findings result))
+          "one secret, one finding")))
+
+  (testing "PII alone is not a secret finding"
+    (let [result (scanner/scan-artifact
+                  {:evidence/intent
+                   {:intent/description "Contact alice@example.com"}})]
+      (is (= [{:finding/type :email}] (:scan/findings result))))))

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/scanner_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/scanner_test.clj
@@ -17,7 +17,9 @@
 ;; limitations under the License.
 (ns ai.miniforge.evidence-bundle.scanner-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.redaction.interface :as redaction]
    [ai.miniforge.evidence-bundle.scanner :as scanner]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -69,3 +71,21 @@
                   {:evidence/intent
                    {:intent/description "Contact alice@example.com"}})]
       (is (= [{:finding/type :email}] (:scan/findings result))))))
+
+(deftest ^{:stratum 0} detection-is-bounded-but-redaction-is-not
+  (testing "a secret too deep to scan is still redacted"
+    ;; bundle-text is bounded by print-level, so detection sees a
+    ;; truncated view. That makes findings best-effort metadata rather
+    ;; than a security boundary — redaction walks the whole structure and
+    ;; does not share the limit. Asserted here so the asymmetry stays a
+    ;; documented property rather than an assumption.
+    (let [deep (reduce (fn [acc _] {:n acc})
+                       {:leaked "AKIAIOSFODNN7EXAMPLE"}
+                       (range 30))]
+      (is (empty? (:scan/findings (scanner/scan-artifact deep)))
+          "the scan cannot see past its print-level bound")
+      (is (not (str/includes?
+                (binding [*print-level* nil *print-length* nil]
+                  (pr-str (redaction/redact deep)))
+                "AKIAIOSFODNN7EXAMPLE"))
+          "redaction removes it regardless"))))

--- a/components/redaction/src/ai/miniforge/redaction/interface.clj
+++ b/components/redaction/src/ai/miniforge/redaction/interface.clj
@@ -19,6 +19,7 @@
   "Redaction of never-emitted values per N3 §8."
   (:require
    [ai.miniforge.redaction.core :as core]
+   [ai.miniforge.redaction.match :as match]
    [ai.miniforge.redaction.policy :as policy]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -36,6 +37,16 @@
   "True when X carries no value excluded by N3 §8.1."
   [x]
   (core/clean? x))
+
+(defn ^{:stratum 0} secret-string?
+  "True when S contains a value excluded by N3 §8.1 by its shape.
+
+   Exposed so a consumer that must *detect* rather than replace — the
+   evidence-bundle scanner, recording that a secret was present — uses
+   the same pattern set as the stream. Two independent lists would let
+   the bundle report clean while the stream redacted, or the reverse."
+  [s]
+  (match/secret-string? s))
 
 (defn ^{:stratum 0} marker
   "The redaction marker substituted for an excluded value."

--- a/components/redaction/src/ai/miniforge/redaction/match.clj
+++ b/components/redaction/src/ai/miniforge/redaction/match.clj
@@ -59,9 +59,16 @@
   (not (or (nil? v) (number? v) (boolean? v) (inst? v) (uuid? v))))
 
 (defn ^{:stratum 0} secret-string?
-  "True when S contains a secret-shaped value."
+  "True when S contains a secret-shaped value.
+
+   False for anything that is not a string. A predicate reached through
+   the interface should answer rather than throw, and \"does this
+   non-string contain a secret\" has an answer: no. Only a string can
+   carry one by shape — a key names it instead, which is `secret-key?`."
   [s]
-  (boolean (some #(re-find % s) (:redaction/secret-value-patterns @policy/policy))))
+  (boolean
+   (when (string? s)
+     (some #(re-find % s) (:redaction/secret-value-patterns @policy/policy)))))
 
 (defn ^{:stratum 0} redact-string
   "Replace every secret-looking substring in S with the marker.

--- a/components/redaction/src/ai/miniforge/redaction/match.clj
+++ b/components/redaction/src/ai/miniforge/redaction/match.clj
@@ -58,6 +58,11 @@
   [v]
   (not (or (nil? v) (number? v) (boolean? v) (inst? v) (uuid? v))))
 
+(defn ^{:stratum 0} secret-string?
+  "True when S contains a secret-shaped value."
+  [s]
+  (boolean (some #(re-find % s) (:redaction/secret-value-patterns @policy/policy))))
+
 (defn ^{:stratum 0} redact-string
   "Replace every secret-looking substring in S with the marker.
 

--- a/components/redaction/test/ai/miniforge/redaction/interface_test.clj
+++ b/components/redaction/test/ai/miniforge/redaction/interface_test.clj
@@ -55,6 +55,16 @@
 
 (defrecord ^{:stratum 0} Wrapper [inner])
 
+(deftest ^{:stratum 0} secret-string?-answers-for-non-strings-test
+  (testing "a predicate on the interface answers rather than throws"
+    ;; Only a string can carry a secret by shape, so the answer for
+    ;; anything else is no — not an NPE.
+    (is (false? (sut/secret-string? nil)))
+    (is (false? (sut/secret-string? 42)))
+    (is (false? (sut/secret-string? :keyword)))
+    (is (false? (sut/secret-string? {:a 1})))
+    (is (true? (sut/secret-string? "AKIAIOSFODNN7EXAMPLE")))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (deftest ^{:stratum 1} marker-is-the-one-N3-mandates-test


### PR DESCRIPTION
## What

N6.SD.4 requires redaction **on detection**. Flagging alone does not
satisfy N3 §8.1, which is a MUST NOT on the content rather than a
labelling requirement. The scanner recorded that a bundle held a secret
and then stored the secret anyway — `[REDACTED]` appeared nowhere in the
component.

## Where, and why exactly there

Between the scan and the hash. Both halves carry weight:

- **After the scan**, so the compliance finding survives. That a secret
  *was* present is the auditable fact; redacting first would erase the
  evidence of it and the bundle would report clean.
- **Before the hash**, because N6 §7.2 seals only after the
  substitution. Hashing first would bind the bundle to a form that no
  longer exists.

## Shared secret set

N6.SD.3 requires the bundle to scan **independently** of the stream —
not to hold a narrower definition of "secret". The scanner's three
patterns (email, SSN, AWS access key) name specific types worth
reporting; an `:embedded-secret` finding now covers the rest of the N3
§8 set — private keys, connection strings, JWTs, provider tokens — so a
bundle cannot report clean on a value the stream would have redacted.

It is a fallback rather than an extra label, so one secret is not
reported twice under two names. A bundle holding both a named and an
unnamed secret reports only the named one, which costs nothing: the
answer to "does this contain secrets" is unchanged, and redaction is
unconditional either way.

## An asymmetry, now documented

`bundle-text` is bounded by `*print-length*` / `*print-level*`, so
detection sees a truncated view of a deep bundle while redaction walks
the whole structure. That is the right way round — the findings are
best-effort metadata, the redaction is the security property — but it
was undocumented, so a secret past level 20 is removed without anything
reporting it.

## Tests

Verified by mutation rather than by passing:

| mutation | result |
|---|---|
| remove the redaction | 2 failures |
| hash before redacting instead of after | 1 failure |

Full evidence-bundle suite: 128 tests / 396 assertions, 0 failures.
`poly check` OK, kondo 0 errors / 0 warnings.

Also covered: an LLM token count in `:metrics {:tokens 1000}` survives
assembly. `:tokens` is the only secret-matching key in the bundle
schema, and it is typed `N` — the case that broke the web dashboard in
#1842 before the value rule existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
