### PR TITLE
fix(redaction): close three leaks in keys and metadata

### DIFF
--- a/components/event-stream/test/ai/miniforge/event_stream/redaction_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/redaction_test.clj
@@ -47,6 +47,30 @@
       (is (= (:event/type event) (:event/type out)))
       (is (= (:event/version event) (:event/version out))))))
 
+(deftest ^{:stratum 0} every-position-is-covered-at-the-stream-test
+  (testing "a secret reaches the log from no position in an event"
+    ;; Through publish! rather than redact directly, because that is the
+    ;; boundary §8.1 governs. Each position here was a live leak at some
+    ;; point: free text and secret-named keys were the original two,
+    ;; then key names, key namespaces, and metadata each in turn.
+    (let [secret "AKIAIOSFODNN7EXAMPLE"]
+      (doseq [[position event]
+              [["free text"     {:message (str "ran deploy with " secret)}]
+               ["secret key"    {:password "hunter2"}]
+               ["key name"      {(keyword secret) :held}]
+               ["key namespace" {(keyword secret "field") :held}]
+               ["metadata"      {:carrier (with-meta {:a 1} {:note secret})}]]]
+        (let [stream (sut/create-event-stream)]
+          (sut/publish! stream (assoc event
+                                      :event/type :tool/invoked
+                                      :workflow/id (str (random-uuid))))
+          ;; *print-meta* or a metadata-borne secret is invisible to the
+          ;; check that is supposed to catch it.
+          (let [log (binding [*print-meta* true]
+                      (pr-str (sut/get-events stream)))]
+            (is (not (str/includes? log secret))
+                (str "secret survived in " position))))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (deftest ^{:stratum 1} secret-reaches-no-destination-test

--- a/components/redaction/deps.edn
+++ b/components/redaction/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {}
+ :deps {ai.miniforge/config {:local/root "../config"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {}}}}

--- a/components/redaction/src/ai/miniforge/redaction/core.clj
+++ b/components/redaction/src/ai/miniforge/redaction/core.clj
@@ -44,9 +44,9 @@
             ;; key into a string containing a printed vector, so each
             ;; kind grows in its own way instead.
             (cond
-              (string? k) (str k " " n)
+              (string? k) (str k policy/disambiguator-separator n)
               (map? k)    (assoc k ::disambiguator n)
-              (set? k)    (conj k (str (policy/marker) " " n))
+              (set? k)    (conj k (str (policy/marker) policy/disambiguator-separator n))
               ;; conj, not (conj (vec k) ...): vec would coerce a seq
               ;; or a queue to a vector, which is the coercion this
               ;; branch exists to avoid. conj adds wherever the type
@@ -57,8 +57,8 @@
               ;; branch returns a LazySeq — so seq-ness is preserved but
               ;; the concrete class is not. That is upstream of this
               ;; branch, not a coercion it introduces.
-              (coll? k)   (conj k (str (policy/marker) " " n))
-              :else       (str k " " n)))]
+              (coll? k)   (conj k (str (policy/marker) policy/disambiguator-separator n))
+              :else       (str k policy/disambiguator-separator n)))]
     (if (contains? m k)
       (first (for [n (iterate inc 2)
                    :let [candidate (nth-form k n)]

--- a/components/redaction/src/ai/miniforge/redaction/core.clj
+++ b/components/redaction/src/ai/miniforge/redaction/core.clj
@@ -28,7 +28,25 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(defn ^{:stratum 0} redact
+(defn- ^{:stratum 0} free-key
+  "K, or K with a counter appended until it is absent from M.
+
+   Two different secrets redact to the same marker, so a map keyed by
+   both would collapse to one entry and silently drop a value — the
+   keys were secret, but the values they held were not. Only runs for a
+   key that actually changed, which is rare, so the common path pays
+   nothing."
+  [m k]
+  (if (contains? m k)
+    (first (for [n (iterate inc 2)
+                 :let [candidate (str k " " n)]
+                 :when (not (contains? m candidate))]
+             candidate))
+    k))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} redact
   "Redact X — any nested data structure — per N3 §8.1/§8.2.
 
    Two rules, applied together:
@@ -68,7 +86,8 @@
                      ;; would test equal to its redacted self and the
                      ;; original would stay in the map.
                      (or (not= k k*) (not= (meta k) (meta k*)))
-                     (-> (dissoc k) (assoc k* v*)))))
+                     (-> (dissoc k)
+                         (as-> m' (assoc m' (free-key m' k*) v*))))))
                x
                x)
 
@@ -102,9 +121,9 @@
         result)
       result)))
 
-;------------------------------------------------------------------------------ Layer 1
+;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 1} clean?
+(defn ^{:stratum 2} clean?
   "True when X carries no value excluded by N3 §8.1. Redaction is
    idempotent, so this is `redact` reaching a fixed point.
 

--- a/components/redaction/src/ai/miniforge/redaction/core.clj
+++ b/components/redaction/src/ai/miniforge/redaction/core.clj
@@ -37,44 +37,79 @@
      2. A string containing a secret-shaped value has that value
         replaced in place.
 
-   Map keys are not redacted: a key names a field, and losing the name
-   would hide that the field existed at all."
+   Map keys keep their names — a key names a field — but a secret
+   hiding *in* a key is still removed by shape, and metadata is walked
+   like any other value. See `match/redact-key`."
   [x]
-  (cond
-    ;; Rebuilt onto X itself rather than (empty x): records throw
-    ;; UnsupportedOperationException on empty, and a record in an event
-    ;; payload would crash publish! on the hot path. Assoc'ing every key
-    ;; back onto X preserves the type — record, sorted map, or plain.
-    (map? x)
-    (reduce-kv (fn [m k v]
-                 (assoc m k (if (and (match/secret-key? k)
-                                     (match/redactable-value? v))
-                              (policy/marker)
-                              (redact v))))
+  (let [result
+        (cond
+          ;; Rebuilt onto X itself rather than (empty x): records throw
+          ;; UnsupportedOperationException on empty, and a record in an event
+          ;; payload would crash publish! on the hot path. Assoc'ing every key
+          ;; back onto X preserves the type — record, sorted map, or plain.
+          (map? x)
+          (reduce-kv (fn [m k v]
+                 (let [;; A collection can be a key too, and match/redact-key
+                       ;; only knows scalars — it cannot recurse without
+                       ;; depending on this namespace. Dispatch here, where
+                       ;; the recursion already lives.
+                       k* (if (coll? k) (redact k) (match/redact-key k))
+                       v* (if (and (match/secret-key? k)
+                                   (match/redactable-value? v))
+                            (policy/marker)
+                            (redact v))]
+                   (cond-> (assoc m k v*)
+                     ;; Only touch the key when it actually changed —
+                     ;; dissoc/assoc would otherwise reorder an array-map
+                     ;; and re-sort a sorted-map for nothing.
+                     ;;
+                     ;; Metadata compared separately because = ignores it,
+                     ;; so a key whose secret sat only in its metadata
+                     ;; would test equal to its redacted self and the
+                     ;; original would stay in the map.
+                     (or (not= k k*) (not= (meta k) (meta k*)))
+                     (-> (dissoc k) (assoc k* v*)))))
                x
                x)
 
-    (vector? x) (mapv redact x)
-    (set? x)    (into (empty x) (map redact) x)
+          (vector? x) (mapv redact x)
+          (set? x)    (into (empty x) (map redact) x)
 
-    ;; doall, not a bare map: a lazy seq would defer redaction and keep
-    ;; the un-redacted value alive in the closure, so the secret would
-    ;; still be reachable from an event §8.1 calls conformant.
-    (seq? x)    (doall (map redact x))
+          ;; doall, not a bare map: a lazy seq would defer redaction and keep
+          ;; the un-redacted value alive in the closure, so the secret would
+          ;; still be reachable from an event §8.1 calls conformant.
+          (seq? x)    (doall (map redact x))
 
-    ;; Any other Clojure collection. A PersistentQueue is coll? but none
-    ;; of map?, vector?, set? or seq?, so without this clause its
-    ;; contents pass through untouched — the cond above enumerates
-    ;; concrete types, and enumerations of types leak.
-    (coll? x)   (into (empty x) (map redact) x)
+          ;; Any other Clojure collection. A PersistentQueue is coll? but none
+          ;; of map?, vector?, set? or seq?, so without this clause its
+          ;; contents pass through untouched — the cond above enumerates
+          ;; concrete types, and enumerations of types leak.
+          (coll? x)   (into (empty x) (map redact) x)
 
-    (string? x) (match/redact-string x)
-    :else       x))
+          (string? x) (match/redact-string x)
+          :else       x)]
+    ;; Metadata is data. pr-str drops it, so a sink that serializes never
+    ;; sees it — but the in-memory log and every in-process subscriber
+    ;; hold the object itself, and §8.1 is about what is emitted, not
+    ;; about what one representation happens to show.
+    ;;
+    ;; Inline rather than a redact*/redact pair: two mutually recursive
+    ;; names are a reference cycle the stratifier rejects (SL007), while
+    ;; a single self-recursive function is one node.
+    (if-let [m (meta x)]
+      (if (instance? clojure.lang.IObj result)
+        (with-meta result (redact m))
+        result)
+      result)))
 
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} clean?
   "True when X carries no value excluded by N3 §8.1. Redaction is
-   idempotent, so this is `redact` reaching a fixed point."
+   idempotent, so this is `redact` reaching a fixed point.
+
+   Blind to metadata: `=` ignores it, so a secret carried only in
+   metadata reports clean here even though `redact` removes it. `redact`
+   is the security property; this is a convenience predicate."
   [x]
   (= x (redact x)))

--- a/components/redaction/src/ai/miniforge/redaction/core.clj
+++ b/components/redaction/src/ai/miniforge/redaction/core.clj
@@ -47,7 +47,17 @@
               (string? k) (str k " " n)
               (map? k)    (assoc k ::disambiguator n)
               (set? k)    (conj k (str (policy/marker) " " n))
-              (coll? k)   (conj (vec k) (str (policy/marker) " " n))
+              ;; conj, not (conj (vec k) ...): vec would coerce a seq
+              ;; or a queue to a vector, which is the coercion this
+              ;; branch exists to avoid. conj adds wherever the type
+              ;; adds, so a vector, set and queue each keep their exact
+              ;; class and a list gains the element at the front.
+              ;;
+              ;; A list arrives here as a seq regardless — redact's seq
+              ;; branch returns a LazySeq — so seq-ness is preserved but
+              ;; the concrete class is not. That is upstream of this
+              ;; branch, not a coercion it introduces.
+              (coll? k)   (conj k (str (policy/marker) " " n))
               :else       (str k " " n)))]
     (if (contains? m k)
       (first (for [n (iterate inc 2)

--- a/components/redaction/src/ai/miniforge/redaction/core.clj
+++ b/components/redaction/src/ai/miniforge/redaction/core.clj
@@ -69,7 +69,14 @@
 
    Map keys keep their names — a key names a field — but a secret
    hiding *in* a key is still removed by shape, and metadata is walked
-   like any other value. See `match/redact-key`."
+   like any other value. See `match/redact-key`.
+
+   Covers Clojure data, which is what an N3 event is: §4.3 makes every
+   event durable, so anything in one has to survive pr-str and
+   edn/read-string. A java.util collection, an array, or an atom is not
+   walked and its contents are returned untouched — such a value cannot
+   be in a conformant event to begin with, but the limit is real and
+   worth naming rather than discovering. `boundary-cases-test` pins it."
   [x]
   (let [result
         (cond

--- a/components/redaction/src/ai/miniforge/redaction/core.clj
+++ b/components/redaction/src/ai/miniforge/redaction/core.clj
@@ -37,12 +37,24 @@
    key that actually changed, which is rare, so the common path pays
    nothing."
   [m k]
-  (if (contains? m k)
-    (first (for [n (iterate inc 2)
-                 :let [candidate (str k " " n)]
-                 :when (not (contains? m candidate))]
-             candidate))
-    k))
+  (letfn [(nth-form [k n]
+            ;; Type-preserving: a map key is compared by value, so the
+            ;; only way to keep two entries is to make the keys differ by
+            ;; value. Appending to the string form would turn a vector
+            ;; key into a string containing a printed vector, so each
+            ;; kind grows in its own way instead.
+            (cond
+              (string? k) (str k " " n)
+              (map? k)    (assoc k ::disambiguator n)
+              (set? k)    (conj k (str (policy/marker) " " n))
+              (coll? k)   (conj (vec k) (str (policy/marker) " " n))
+              :else       (str k " " n)))]
+    (if (contains? m k)
+      (first (for [n (iterate inc 2)
+                   :let [candidate (nth-form k n)]
+                   :when (not (contains? m candidate))]
+               candidate))
+      k)))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -66,30 +78,45 @@
           ;; payload would crash publish! on the hot path. Assoc'ing every key
           ;; back onto X preserves the type — record, sorted map, or plain.
           (map? x)
-          (reduce-kv (fn [m k v]
-                 (let [;; A collection can be a key too, and match/redact-key
-                       ;; only knows scalars — it cannot recurse without
-                       ;; depending on this namespace. Dispatch here, where
-                       ;; the recursion already lives.
-                       k* (if (coll? k) (redact k) (match/redact-key k))
-                       v* (if (and (match/secret-key? k)
-                                   (match/redactable-value? v))
-                            (policy/marker)
-                            (redact v))]
-                   (cond-> (assoc m k v*)
-                     ;; Only touch the key when it actually changed —
-                     ;; dissoc/assoc would otherwise reorder an array-map
-                     ;; and re-sort a sorted-map for nothing.
-                     ;;
-                     ;; Metadata compared separately because = ignores it,
-                     ;; so a key whose secret sat only in its metadata
-                     ;; would test equal to its redacted self and the
-                     ;; original would stay in the map.
-                     (or (not= k k*) (not= (meta k) (meta k*)))
-                     (-> (dissoc k)
-                         (as-> m' (assoc m' (free-key m' k*) v*))))))
-               x
-               x)
+          (reduce-kv
+           (fn [m k v]
+             (let [;; A collection can be a key too, and match/redact-key
+                   ;; knows only scalars — it cannot recurse without
+                   ;; depending on this namespace. Dispatch here, where
+                   ;; the recursion already lives.
+                   ;;
+                   ;; A scalar key needs its metadata walked as well.
+                   ;; Only a symbol can carry any — keywords and strings
+                   ;; are not IObj — but a symbol key's metadata is as
+                   ;; reachable as a value's.
+                   k* (if (coll? k)
+                        (redact k)
+                        (let [rk (match/redact-key k)]
+                          (if-let [km (meta k)]
+                            (if (instance? clojure.lang.IObj rk)
+                              (with-meta rk (redact km))
+                              rk)
+                            rk)))
+                   v* (if (and (match/secret-key? k)
+                             (match/redactable-value? v))
+                        (policy/marker)
+                        (redact v))]
+               (cond-> (assoc m k v*)
+                 ;; Only touch the key when it actually changed —
+                 ;; dissoc/assoc would otherwise reorder an array-map
+                 ;; and re-sort a sorted-map for nothing.
+                 ;;
+                 ;; Identity, not =. Equality ignores metadata at every
+                 ;; depth, so a key whose secret sat in the metadata of
+                 ;; something nested inside it tested equal to its own
+                 ;; redacted form and the original stayed in the map.
+                 ;; redact-key returns k itself when nothing changed, so
+                 ;; a scalar key still costs nothing.
+                 (not (identical? k k*))
+                 (-> (dissoc k)
+                     (as-> m' (assoc m' (free-key m' k*) v*))))))
+           x
+           x)
 
           (vector? x) (mapv redact x)
           (set? x)    (into (empty x) (map redact) x)

--- a/components/redaction/src/ai/miniforge/redaction/match.clj
+++ b/components/redaction/src/ai/miniforge/redaction/match.clj
@@ -86,3 +86,34 @@
     (reduce (fn [acc pattern] (str/replace acc pattern marker))
             s
             (:redaction/secret-value-patterns @policy/policy))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} redact-key
+  "Redact a secret hiding in K itself, by shape.
+
+   Keys normally keep their names: a key names a field, and losing the
+   name would hide that the field existed. That holds for a structural
+   key like :password or :event/type — but not for a key that *is*
+   data. A map keyed by session token carries the secret in the key and
+   nowhere else.
+
+   Shape separates the two. No field name looks like an AWS access key
+   or a JWT, so only the value-shape rules apply here; the key-name rule
+   deliberately does not, since replacing the whole of `:password` would
+   destroy the field.
+
+   A redacted keyword or symbol comes back as a string, because the
+   marker is not readable inside one: `(keyword \"[REDACTED]\")` prints
+   as `:[REDACTED]`, which `edn/read-string` rejects, and N3 §4.3 makes
+   every event durable — an unreadable key corrupts the log. The type
+   change is honest anyway; such a key was data, not a field name."
+  [k]
+  (letfn [(shorten [s] (let [r (redact-string s)] (when (not= r s) r)))]
+    (cond
+      (string? k)  (or (shorten k) k)
+      (keyword? k) (or (some->> (name k) shorten (str (when-let [n (namespace k)] (str n "/"))))
+                       k)
+      (symbol? k)  (or (some->> (name k) shorten (str (when-let [n (namespace k)] (str n "/"))))
+                       k)
+      :else        k)))

--- a/components/redaction/src/ai/miniforge/redaction/match.clj
+++ b/components/redaction/src/ai/miniforge/redaction/match.clj
@@ -109,11 +109,18 @@
    every event durable — an unreadable key corrupts the log. The type
    change is honest anyway; such a key was data, not a field name."
   [k]
-  (letfn [(shorten [s] (let [r (redact-string s)] (when (not= r s) r)))]
+  (letfn [(qualified [k]
+            ;; Namespace as well as name: a secret can sit in either
+            ;; half, and `(keyword "AKIA..." "v")` hides it entirely in
+            ;; the namespace.
+            (let [n  (namespace k)
+                  nm (name k)
+                  n* (some-> n redact-string)
+                  nm* (redact-string nm)]
+              (when (or (not= n n*) (not= nm nm*))
+                (if n* (str n* "/" nm*) nm*))))]
     (cond
-      (string? k)  (or (shorten k) k)
-      (keyword? k) (or (some->> (name k) shorten (str (when-let [n (namespace k)] (str n "/"))))
-                       k)
-      (symbol? k)  (or (some->> (name k) shorten (str (when-let [n (namespace k)] (str n "/"))))
-                       k)
+      (string? k)  (let [r (redact-string k)] (if (= r k) k r))
+      (keyword? k) (or (qualified k) k)
+      (symbol? k)  (or (qualified k) k)
       :else        k)))

--- a/components/redaction/src/ai/miniforge/redaction/policy.clj
+++ b/components/redaction/src/ai/miniforge/redaction/policy.clj
@@ -57,8 +57,14 @@
   (delay
     (let [raw (config/load-config-resource
                config-resource
+               ;; Every key the compile step below touches. Leaving one
+               ;; out does not throw — (mapv f nil) is [] — it silently
+               ;; yields an empty pattern list, so a truncated resource
+               ;; would quietly change what gets redacted instead of
+               ;; failing at the boundary.
                [:redaction/marker
                 :redaction/secret-key-patterns
+                :redaction/secret-key-exclusions
                 :redaction/secret-value-patterns])]
       (-> raw
           (update :redaction/secret-key-patterns #(mapv re-pattern %))

--- a/components/redaction/src/ai/miniforge/redaction/policy.clj
+++ b/components/redaction/src/ai/miniforge/redaction/policy.clj
@@ -23,8 +23,7 @@
    007), and N8 §5.2 forbids a function as a redaction configuration
    value since it cannot be serialized, diffed, or audited."
   (:require
-   [clojure.edn :as edn]
-   [clojure.java.io :as io]))
+   [ai.miniforge.config.interface :as config]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -37,19 +36,22 @@
   "The redaction policy, patterns compiled.
 
    EDN has no regex literal, so the config holds pattern strings and
+   EDN has no regex literal, so the config holds pattern strings and
    they are compiled here — the policy stays inspectable data on disk
-   (dewey 007) and becomes usable regexes exactly once."
+   (dewey 007) and becomes usable regexes exactly once.
+
+   Loaded through config's resource boundary rather than io/resource +
+   slurp here. That namespace owns resource loading, so its throw is a
+   boundary throw (dewey 005 forbids ex-info in component code paths),
+   and its message is localized (dewey 050). The required-keys argument
+   makes a truncated or half-written config fail at load rather than
+   silently redacting nothing."
   (delay
-    (let [url (or (io/resource config-resource)
-                  ;; Fail naming the resource. A bare slurp of nil throws
-                  ;; an NPE with no hint, and the failure mode that
-                  ;; produces it — the resource missing from a package or
-                  ;; a test classpath — is one where redaction silently
-                  ;; not running is the dangerous outcome.
-                  (throw (ex-info "Redaction policy resource missing from classpath"
-                                  {:anomaly/category :anomaly/not-found
-                                   :redaction/resource config-resource})))
-          raw (-> url slurp edn/read-string)]
+    (let [raw (config/load-config-resource
+               config-resource
+               [:redaction/marker
+                :redaction/secret-key-patterns
+                :redaction/secret-value-patterns])]
       (-> raw
           (update :redaction/secret-key-patterns #(mapv re-pattern %))
           (update :redaction/secret-key-exclusions #(mapv re-pattern %))

--- a/components/redaction/src/ai/miniforge/redaction/policy.clj
+++ b/components/redaction/src/ai/miniforge/redaction/policy.clj
@@ -30,6 +30,14 @@
 (def ^{:stratum 0} ^:private config-resource
   "config/redaction/patterns.edn")
 
+(def ^{:stratum 0} disambiguator-separator
+  "Between a redacted key and the counter that keeps two of them apart.
+
+   A space, so `[REDACTED] 2` reads as one redacted key rather than as a
+   key literally named for the marker — and so the counter cannot be
+   mistaken for part of the marker N3 §8.2 mandates."
+  " ")
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (def ^{:stratum 1} policy

--- a/components/redaction/test/ai/miniforge/redaction/interface_test.clj
+++ b/components/redaction/test/ai/miniforge/redaction/interface_test.clj
@@ -97,6 +97,20 @@
         (is (not (str/includes? text "AKIA"))
             (str "secret survived: " text))))))
 
+(deftest ^{:stratum 0} boundary-cases-test
+  (testing "redaction covers Clojure data, and stops there"
+    ;; Not an endorsement — a record of where the guarantee ends. N3 §4.3
+    ;; makes every event durable, so a conformant event contains only
+    ;; values that survive pr-str and edn/read-string; none of these do.
+    ;; If one ever appears in an event, this test is where to start.
+    (let [secret "AKIAIOSFODNN7EXAMPLE"]
+      (doseq [[what v] {"java.util.List" (doto (java.util.ArrayList.) (.add secret))
+                        "java.util.Map"  (doto (java.util.HashMap.) (.put "k" secret))
+                        "array"          (into-array String [secret])
+                        "atom"           (atom secret)}]
+        (is (identical? v (sut/redact v))
+            (str what " is passed through, not walked"))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (deftest ^{:stratum 1} marker-is-the-one-N3-mandates-test

--- a/components/redaction/test/ai/miniforge/redaction/interface_test.clj
+++ b/components/redaction/test/ai/miniforge/redaction/interface_test.clj
@@ -266,10 +266,6 @@
       (doseq [outer containers
               inner containers]
         (let [nested (outer (inner secret))
-              ;; pr-str prints a PersistentQueue as #object[...] without
-              ;; its contents, which would hide a surviving secret as
-              ;; readily as a redacted one. Normalise every non-map
-              ;; collection to a vector first so the check can see in.
               out    (str/join " " (strings-in (sut/redact nested)))]
           (is (not (str/includes? out secret))
               (str "secret survived " (pr-str nested)))

--- a/components/redaction/test/ai/miniforge/redaction/interface_test.clj
+++ b/components/redaction/test/ai/miniforge/redaction/interface_test.clj
@@ -233,6 +233,11 @@
     (let [secret     "AKIAIOSFODNN7EXAMPLE"
           containers [identity
                       #(hash-map % :held-as-a-key)
+                      ;; namespace position only makes sense for a string
+                      #(if (string? %)
+                         (hash-map (keyword % "v") :held-in-a-namespace)
+                         (hash-map % :held-in-a-namespace))
+                      #(hash-map (with-meta (symbol "sym") {:note %}) :held-in-key-meta)
                       #(with-meta {:carrier true} {:note %})
                       vector
                       list
@@ -272,3 +277,25 @@
           "every key is marked redacted")
       (is (not-any? #(str/includes? % "AKIA") (keys out))
           "no secret survives in a key"))))
+
+(deftest ^{:stratum 1} secrets-inside-keys-test
+  (testing "a keyword's namespace is as exposed as its name"
+    (let [out (sut/redact {(keyword "AKIAIOSFODNN7EXAMPLE" "v") :held})]
+      (is (= {"[REDACTED]/v" :held} out))))
+
+  (testing "a symbol key's metadata is walked"
+    ;; Only symbols among scalar keys can carry metadata — keywords and
+    ;; strings are not IObj — but a symbol key's metadata is as reachable
+    ;; as any value's.
+    (let [out (sut/redact {(with-meta 'sym {:note "AKIAIOSFODNN7EXAMPLE"}) :v})]
+      (is (= [{:note marker}] (map meta (keys out))))))
+
+  (testing "colliding keys keep their type"
+    ;; Appending to the string form would turn a vector key into a string
+    ;; containing a printed vector — two keys from one collision ending
+    ;; up as different types.
+    (let [out (sut/redact {["AKIAIOSFODNN7EXAMPLE"] :a
+                           ["AKIAJJJJJJJJJJJJJJJJ"] :b})]
+      (is (= 2 (count out)) "both entries survive")
+      (is (every? vector? (keys out)) "both keys are still vectors")
+      (is (= #{:a :b} (set (vals out)))))))

--- a/components/redaction/test/ai/miniforge/redaction/interface_test.clj
+++ b/components/redaction/test/ai/miniforge/redaction/interface_test.clj
@@ -111,6 +111,25 @@
         (is (identical? v (sut/redact v))
             (str what " is passed through, not walked"))))))
 
+(deftest ^{:stratum 0} collision-disambiguation-keeps-the-collection-kind-test
+  (testing "disambiguating a collection key does not coerce it"
+    ;; (conj (vec k) ...) would turn every colliding collection key into
+    ;; a vector — the coercion the branch exists to avoid.
+    (let [a "AKIAIOSFODNN7EXAMPLE"
+          b "AKIAJJJJJJJJJJJJJJJJ"]
+      (doseq [[kind build pred]
+              [["vector" vector                                              vector?]
+               ["set"    hash-set                                            set?]
+               ["queue"  #(into clojure.lang.PersistentQueue/EMPTY [%])
+                #(instance? clojure.lang.PersistentQueue %)]
+               ;; a list arrives as a seq from redact's seq branch, so
+               ;; seq-ness is what survives here, not the concrete class
+               ["list"   list                                                seq?]]]
+        (let [out (sut/redact {(build a) :first (build b) :second})]
+          (is (= 2 (count out)) (str kind ": both entries survive"))
+          (is (every? pred (keys out)) (str kind ": both keys keep the kind"))
+          (is (= #{:first :second} (set (vals out)))))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (deftest ^{:stratum 1} marker-is-the-one-N3-mandates-test

--- a/components/redaction/test/ai/miniforge/redaction/interface_test.clj
+++ b/components/redaction/test/ai/miniforge/redaction/interface_test.clj
@@ -19,8 +19,8 @@
   "N3 §8 conformance — N3.SD.1 (never emit excluded values), N3.SD.3
    (substitute the marker, never omit the key)."
   (:require
+   [clojure.edn :as edn]
    [clojure.string :as str]
-   [clojure.walk :as walk]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.redaction.interface :as sut]))
 
@@ -64,6 +64,38 @@
     (is (false? (sut/secret-string? :keyword)))
     (is (false? (sut/secret-string? {:a 1})))
     (is (true? (sut/secret-string? "AKIAIOSFODNN7EXAMPLE")))))
+
+(defn- ^{:stratum 0} strings-in
+  "Every string reachable from X — values, keys, and metadata — as text.
+
+   Independent of printing, so it sees what pr-str hides."
+  [x]
+  (concat
+   (when-let [m (meta x)] (strings-in m))
+   (cond
+     (string? x)  [x]
+     (keyword? x) [(str x)]
+     (symbol? x)  [(str x)]
+     (map? x)     (mapcat (fn [[k v]] (concat (strings-in k) (strings-in v))) x)
+     (coll? x)    (mapcat strings-in x)
+     :else        [])))
+
+(deftest ^{:stratum 0} redacted-events-still-round-trip-test
+  (testing "redaction never makes an event unreadable"
+    ;; N3 §4.3 makes every event durable, so a redacted event must still
+    ;; serialize and read back. Naming a keyword "[REDACTED]" prints as
+    ;; :[REDACTED], which edn/read-string rejects — a redacted key comes
+    ;; back as a string for exactly this reason.
+    (doseq [event [{"AKIAIOSFODNN7EXAMPLE" :v}
+                   {(keyword "ghp_abcdefghijklmnopqrstuvwxyz0123") :v}
+                   {(keyword "auth" "sk-abcdefghijklmnopqrst") :v}
+                   {(symbol "xoxb-abcdefghijklmnop") :v}
+                   {:password "p" :nested {:items ["AKIAIOSFODNN7EXAMPLE"]}}]]
+      (let [text (pr-str (sut/redact event))]
+        (is (some? (edn/read-string text))
+            (str "did not read back: " text))
+        (is (not (str/includes? text "AKIA"))
+            (str "secret survived: " text))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -189,13 +221,19 @@
 
 (deftest ^{:stratum 1} no-container-lets-a-secret-through-test
   (testing "a secret survives no container type, at any nesting depth"
-    ;; Two defects in review were the same shape: redaction that looked
-    ;; correct but silently missed a container — the PEM body, and
-    ;; PersistentQueue. Checking against `clean?` would not have caught
-    ;; either, because `clean?` walks with the same code that missed
-    ;; them. `pr-str` is independent of the walk, so it can.
+    ;; Defects found in review were all this shape: redaction that
+    ;; looked correct but silently missed a container. Checking against
+    ;; `clean?` would not catch them, since `clean?` walks with the same
+    ;; code that missed them and agrees with itself.
+    ;;
+    ;; `strings-in` collects every string reachable from the structure,
+    ;; keys and metadata included, without going through pr-str — which
+    ;; prints a PersistentQueue as #object[...] and drops metadata
+    ;; entirely, hiding a surviving secret in both places.
     (let [secret     "AKIAIOSFODNN7EXAMPLE"
           containers [identity
+                      #(hash-map % :held-as-a-key)
+                      #(with-meta {:carrier true} {:note %})
                       vector
                       list
                       #(hash-set %)
@@ -213,9 +251,7 @@
               ;; its contents, which would hide a surviving secret as
               ;; readily as a redacted one. Normalise every non-map
               ;; collection to a vector first so the check can see in.
-              out    (pr-str (walk/postwalk
-                              #(if (and (coll? %) (not (map? %))) (vec %) %)
-                              (sut/redact nested)))]
+              out    (str/join " " (strings-in (sut/redact nested)))]
           (is (not (str/includes? out secret))
               (str "secret survived " (pr-str nested)))
           (is (str/includes? out marker)

--- a/components/redaction/test/ai/miniforge/redaction/interface_test.clj
+++ b/components/redaction/test/ai/miniforge/redaction/interface_test.clj
@@ -256,3 +256,19 @@
               (str "secret survived " (pr-str nested)))
           (is (str/includes? out marker)
               (str "no marker in " out)))))))
+
+(deftest ^{:stratum 1} colliding-secret-keys-keep-their-values-test
+  (testing "two secrets redact to the same marker without losing an entry"
+    ;; The keys were secret; the values they held were not. Collapsing
+    ;; them would silently drop data, which is the exact class of defect
+    ;; this component keeps producing — something that looks right.
+    (let [m   {"AKIAIOSFODNN7EXAMPLE" :first
+               "AKIAJJJJJJJJJJJJJJJJ" :second
+               "AKIAKKKKKKKKKKKKKKKK" :third}
+          out (sut/redact m)]
+      (is (= (count m) (count out)) "no entry is lost")
+      (is (= (set (vals m)) (set (vals out))) "every value survives")
+      (is (every? #(str/starts-with? % marker) (keys out))
+          "every key is marked redacted")
+      (is (not-any? #(str/includes? % "AKIA") (keys out))
+          "no secret survives in a key"))))

--- a/docs/pull-requests/2026-08-26-chris-redaction-keys-and-meta.md
+++ b/docs/pull-requests/2026-08-26-chris-redaction-keys-and-meta.md
@@ -1,3 +1,9 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
 # fix: close three leaks in keys and metadata
 
 ## Overview

--- a/docs/pull-requests/2026-08-26-chris-redaction-keys-and-meta.md
+++ b/docs/pull-requests/2026-08-26-chris-redaction-keys-and-meta.md
@@ -1,0 +1,110 @@
+# fix: close three leaks in keys and metadata
+
+## Overview
+
+Redaction (N3 §8.1) shipped in #1842 covering values. This closes the
+positions it did not reach: a secret held in a map key, in a keyword's
+namespace, or in metadata.
+
+## Motivation
+
+PR #1842 reasoned that "map keys are not redacted: a key names a field,
+and losing the name would hide that the field existed at all." That holds for a
+key that *names* something and fails for a key that *is* data — a map keyed
+by session token carries the secret in the key and nowhere else.
+
+Verified against `main` before writing the fix, publishing through the real
+stream and isolating each position:
+
+| position | leaked on main |
+|---|---|
+| free text | no |
+| secret-named key | no |
+| key name | **yes** |
+| key namespace | **yes** |
+| metadata | **yes** |
+
+## Changes in Detail
+
+**Keys.** `match/redact-key` applies the value-shape rules to a key, and
+only those — the key-*name* rule still does not apply, since replacing the
+whole of `:password` would destroy the field it names. Shape is what
+separates a field name from data: no field name looks like an AWS access
+key. Both a keyword's namespace and its name are covered.
+
+A redacted keyword or symbol returns as a string. `(keyword "[REDACTED]")`
+prints as `:[REDACTED]`, which `edn/read-string` rejects, and N3 §4.3 makes
+every event durable — an unreadable key corrupts the log.
+
+**Metadata** is walked like any other value. `pr-str` drops it, so a
+serializing sink never sees it, but the in-memory log and every in-process
+subscriber hold the object itself.
+
+**Collisions.** Two secrets redact to the same marker, so a map keyed by
+both collapsed to one entry, silently dropping a value. `free-key` appends
+a counter, growing each collection kind in its own way so the type survives.
+
+**Config loading** moved to `config/load-config-resource`. That namespace
+owns the resource boundary, so its throw is a boundary throw rather than an
+`ex-info` in component code (dewey 005), and its message is localized
+(dewey 050).
+
+## Testing Plan
+
+- Container matrix, 16x16 nestings, asserting the secret is absent and the
+  marker present. Checks every reachable string — keys and metadata
+  included — rather than `pr-str`, which prints a `PersistentQueue` as
+  `#object[...]` and drops metadata, blind in exactly the places two of
+  these defects were.
+- Integration test through `publish!` covering all five positions, since
+  that is the boundary §8.1 governs.
+- EDN round-trip test: every redacted event still reads back.
+- `boundary-cases-test` pins where the guarantee ends (see below).
+- Each fix verified by mutation, not by passing:
+
+| mutation | failures |
+|---|---|
+| remove key redaction | 51 |
+| remove metadata walking | 50 |
+| compare keys without metadata | 2 |
+| no namespace redaction | 33 |
+| `free-key` stringifies everything | 1 |
+| `=` instead of `identical?` | 63 |
+
+## Deployment Plan
+
+Ships with main. No migration: redaction is applied at construction, so
+existing durable events are unaffected and new ones are covered from the
+first publish after deploy.
+
+## Performance Impact
+
+A small event goes from 9us to 20us — the value patterns now run over keys
+as well, at roughly 1.2us per key. A 200-key map is 239us.
+
+Combining the value patterns into one alternation was measured and rejected:
+~45% *slower*, because Java applies a literal-prefix optimisation per
+pattern and loses it once they are combined.
+
+## Security Considerations
+
+The whole PR is one. Worth naming where the guarantee ends: a `java.util`
+collection, an array, and an atom are not walked. That follows from the
+design — N3 §4.3 makes events durable, so a conformant event holds only what
+survives `pr-str`/`edn/read-string`, which none of those do. Documented and
+pinned rather than fixed: enumerating more container types is what produced
+four of the defects here.
+
+## Related Issues/PRs
+
+- #1842 — redaction at event construction (the values half)
+- #1843 — `collector.clj` split, prerequisite for #1844
+- #1844 — bundle-side redaction (N6.SD.4)
+
+## Checklist
+
+- [x] Leak positions verified on `main` before fixing
+- [x] Every fix mutation-tested
+- [x] Coverage boundary documented and pinned
+- [x] `poly check`, kondo, stratum lint clean
+- [x] Review comments addressed


### PR DESCRIPTION
Follow-up to [#1842](https://github.com/miniforge-ai/miniforge/pull/1842).
Three positions where a secret survived redaction intact.

## The leaks

```clojure
{"AKIAIOSFODNN7EXAMPLE" :v}     ; secret as a map key
{:ghp_abcdefghij... :v}         ; secret as a keyword name
^{:note "AKIA..."} {:a 1}       ; secret in metadata
```

**Keys.** #1842 said "map keys are not redacted: a key names a field."
That is right for a key that *names* something and wrong for a key that
*is* data — a map keyed by session token carries the secret in the key
and nowhere else.

Shape separates the two. No field name looks like an AWS access key or a
JWT, so `redact-key` applies the value-shape rules only. The key-*name*
rule still does not apply to keys, since replacing the whole of
`:password` would destroy the field it names.

**Metadata.** §8.1 is about what is emitted, not about what one
representation happens to show. `pr-str` drops metadata, so a sink that
serializes never sees it — but the in-memory log and every in-process
subscriber hold the object itself.

## A redacted keyword becomes a string

`(keyword "[REDACTED]")` prints as `:[REDACTED]`, which
`edn/read-string` rejects. N3 §4.3 makes every event durable, so that
would put an unreadable key in the log. Redacted keyword and symbol keys
come back as strings, which round-trip; there is a test asserting every
redacted event still reads back. The type change is honest anyway — such
a key was data, not a field name.

## Two more, found by the same test

Extending #1842's container matrix to cover key and metadata positions
found both immediately:

- A **collection used as a key** was not walked. `redact-key` knows only
  scalars and cannot recurse without depending on `core`, so the
  dispatch moved to `core` where the recursion already lives.
- A key whose secret sat **only in its metadata** tested equal to its
  redacted self, because `=` ignores metadata — so the original key
  stayed in the map. Metadata is now compared separately.

## The check that found them

#1842's matrix compared `pr-str` output. That was already the right
instinct — not `clean?`, which walks with the same code under test — but
`pr-str` prints a `PersistentQueue` as `#object[...]` and drops metadata
entirely, hiding a surviving secret in exactly the two places these
defects were.

It now collects every string reachable from the structure — values,
keys, and metadata — without going through printing at all. 13x13
container nestings, 408 assertions.

## One the fix itself introduced

Two different secrets redact to the same marker, so a map keyed by both
collapsed to a single entry:

```clojure
{"AKIAIOSFODNN7EXAMPLE" :first
 "AKIAJJJJJJJJJJJJJJJJ" :second}   ; => {"[REDACTED]" :second}
```

The keys were secret; the values they held were not. Silently dropping
one is the same class of defect as the leaks above — something that
looks correct and is not. A counter is appended when a redacted key is
already taken, and it only runs for a key that actually changed, so the
common path pays nothing.

## Found in review

Three from Copilot, each real:

- **A keyword's namespace was never redacted.**
  `(keyword "AKIAIOSFODNN7EXAMPLE" "v")` kept the secret whole; I had
  only shape-redacted the *name*. Both halves now.
- **A symbol key's metadata was never walked.** One narrowing on the
  report: among scalar keys only symbols can carry metadata — keywords
  and strings are not `IObj` — so the symbol case was the real one.
- **`free-key` appended the counter to the string form**, so a vector
  key colliding with another became a string containing a printed
  vector — one collision, two key types. Each kind grows in its own way
  now, so the type survives.

Extending the matrix to cover those turned up a fourth: a *collection*
key whose secret sat in metadata nested inside it tested equal to its own
redacted form, so the original stayed in the map. I had already hit this
at the top level and guarded it by comparing `(meta k)` — but `=` ignores
metadata at every depth, not just the top. The guard is `identical?` now,
which costs nothing for scalars since `redact-key` returns `k` itself
when nothing changed.

## Where the guarantee ends

A `java.util` collection, an array, and an atom pass through with their
contents untouched. That follows from the design — `redact` walks
Clojure data, and N3 §4.3 makes every event durable, so a conformant
event holds only what survives `pr-str`/`edn/read-string`, which none of
those do.

Named anyway, in the docstring and in `boundary-cases-test`. Every
defect in this component has been under-redaction that looks like
success, and an undocumented limit is indistinguishable from an
unnoticed one. This is deliberately *not* a proposal to walk them:
enumerating more container types is what produced the four defects
above.

## Verification

Mutation, not just passing:

| mutation | failures |
|---|---|
| remove key redaction | 51 |
| remove metadata walking | 50 |
| compare keys without metadata | 2 |

Full event-stream suite: 357 tests / 1894 assertions, 0 failures.
`poly check` OK, kondo clean, stratum clean.

## Cost

A small event goes from 9us to 20us — the value patterns now run over
keys as well, at roughly 1.2us per key. Absolute cost stays small; a
200-key map is 239us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

