### PR TITLE
docs: PR documentation for the redaction wave (dewey 721)

### DIFF
--- a/docs/pull-requests/2026-08-26-chris-redaction-bundle-n6-s7.md
+++ b/docs/pull-requests/2026-08-26-chris-redaction-bundle-n6-s7.md
@@ -1,0 +1,59 @@
+# feat: redact bundles before sealing them (N6.SD.4)
+
+Historical record. Merged as PR #1844.
+
+## Overview
+
+Evidence bundles are redacted between the sensitive-data scan and the
+content hash, so a secret is removed from the bundle rather than merely
+flagged in its metadata.
+
+## Motivation
+
+N6.SD.4 requires redaction **on detection**. Flagging alone does not satisfy
+N3 §8.1, which is a MUST NOT on the content rather than a labelling
+requirement. The scanner recorded that a bundle held a secret and then
+stored the secret anyway — `[REDACTED]` appeared nowhere in the component.
+
+## Changes in Detail
+
+**Placement.** After the scan, so the compliance finding survives: that a
+secret *was* present is the auditable fact, and redacting first would erase
+the evidence of it. Before the hash, because N6 §7.2 seals only after the
+substitution — hashing first would bind the bundle to a form that no longer
+exists.
+
+**Shared secret set.** N6.SD.3 requires the bundle to scan *independently*
+of the stream, not to hold a narrower definition of "secret". The scanner's
+three patterns name specific types worth reporting; an `:embedded-secret`
+finding covers the rest of the N3 §8 set. It is a fallback rather than an
+extra label, so one secret is not reported twice under two names.
+
+**A documented asymmetry.** `bundle-text` is bounded by `*print-length*` and
+`*print-level*`, so detection sees a truncated view while redaction walks the
+whole structure. Findings are best-effort metadata; the redaction is the
+security property.
+
+## Testing Plan
+
+Verified by mutation rather than by passing:
+
+| mutation | failures |
+|---|---|
+| remove the redaction | 2 |
+| hash before redacting instead of after | 1 |
+
+Plus a test at depth 30 asserting the scan reports nothing and the secret is
+removed anyway. 128 tests / 396 assertions.
+
+## Related Issues/PRs
+
+- PR #1842 — the stream half; supplies the shared pattern set
+- PR #1843 — prerequisite `collector.clj` split
+
+## Checklist
+
+- [x] Redaction ordered after the scan and before the hash
+- [x] Stream and bundle share one definition of "secret"
+- [x] Detection/redaction asymmetry documented and pinned
+- [x] Both orderings mutation-tested

--- a/docs/pull-requests/2026-08-26-chris-redaction-bundle-n6-s7.md
+++ b/docs/pull-requests/2026-08-26-chris-redaction-bundle-n6-s7.md
@@ -1,3 +1,9 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
 # feat: redact bundles before sealing them (N6.SD.4)
 
 Historical record. Merged as PR #1844.

--- a/docs/pull-requests/2026-08-26-chris-redaction-n3-s8.md
+++ b/docs/pull-requests/2026-08-26-chris-redaction-n3-s8.md
@@ -1,0 +1,71 @@
+# feat: redact secrets at event construction per N3 §8.1
+
+Historical record. Merged as PR #1842.
+
+## Overview
+
+Adds the `ai.miniforge.redaction` component and wires it into
+`event-stream/core/publish!`, so a secret-bearing value never reaches a
+sink, the in-memory log, or a subscriber.
+
+## Motivation
+
+N3 §8.1 had required this since 0.9.0 and nothing enforced it. The
+requirement is a MUST NOT on **emission**, not a filter on delivery:
+
+> A redacting sink does not make a secret-bearing event conformant — the
+> event is already in memory, already sequenced, and already durable per
+> §4.3. Redact at construction.
+
+## Changes in Detail
+
+**Wired at `core/publish!`**, not `interface.clj`, because `heartbeat.clj`
+calls `core/publish!` directly; interface-level wiring would have left
+heartbeat events unredacted. `publish!` is also the last point at which no
+durable or delivered copy exists.
+
+**Two detection mechanisms**, because secrets hide in two places:
+
+- *by key name* — `password`, `secret`, `token`, `api-key`. A password's
+  value is unremarkable; only its key identifies it.
+- *by value shape* — `AKIA…`, `sk-…`, `gh[pousr]_…`, PEM blocks, JWTs,
+  connection strings with inline credentials, `Bearer`/`Basic` headers.
+
+Patterns live in `resources/config/redaction/patterns.edn` (dewey 007) as
+strings compiled with `re-pattern` — EDN has no regex literal, and N8 §5.2
+forbids a function as a configuration value.
+
+Excluded values are replaced with `"[REDACTED]"` rather than dropped, per
+§8.2: an absent key is indistinguishable from a key never set.
+
+**Narrowed twice after CI caught a regression.** The `token` pattern matched
+`{:metrics {:tokens 42}}` and replaced an LLM token count with a string,
+breaking the web dashboard with a ClassCastException. Values that cannot
+carry a secret (number, boolean, nil, inst, uuid) are exempt from the key
+rule, and keys ending in a qualifier (`-id`, `-endpoint`, `-scope`) name a
+*reference to* a secret rather than the secret. The second is safe only
+because it disables the key rule alone — the value is still shape-scanned.
+
+## Testing Plan
+
+Assertions cover the returned event, the in-memory log, and the subscriber;
+the return value alone would look correct under a sink-level fix. Full
+event-stream suite: 357 tests / 1894 assertions.
+
+## Performance Impact
+
+~65us/KB, linear in payload size. Combining the value patterns into one
+alternation measured ~45% *slower* — Java applies a literal-prefix
+optimisation per pattern and loses it once combined. Left sequential.
+
+## Related Issues/PRs
+
+- PR #1843 — `collector.clj` split (prerequisite for the bundle half)
+- PR #1844 — bundle-side redaction (N6.SD.4)
+- PR #1845 — leaks in keys, namespaces, and metadata
+
+## Checklist
+
+- [x] Wired where no durable copy exists yet
+- [x] Patterns as config, not code
+- [x] Regression from over-matching narrowed and tested

--- a/docs/pull-requests/2026-08-26-chris-redaction-n3-s8.md
+++ b/docs/pull-requests/2026-08-26-chris-redaction-n3-s8.md
@@ -1,3 +1,9 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
 # feat: redact secrets at event construction per N3 §8.1
 
 Historical record. Merged as PR #1842.
@@ -10,8 +16,14 @@ sink, the in-memory log, or a subscriber.
 
 ## Motivation
 
-N3 §8.1 had required this since 0.9.0 and nothing enforced it. The
-requirement is a MUST NOT on **emission**, not a filter on delivery:
+Four specs recorded this contract as unimplemented in their annexes — N3,
+N6, N8 and N9 — and `REDACTED` appeared nowhere in the tree. The only
+redaction that existed was `dag-executor/host_git_guard/redact-credentials`,
+which strips userinfo from git remote URLs: real, but scoped to one field of
+one subsystem.
+
+N3 §8.1 had required this since 0.9.0. The requirement is a MUST NOT on
+**emission**, not a filter on delivery:
 
 > A redacting sink does not make a secret-bearing event conformant — the
 > event is already in memory, already sequenced, and already durable per

--- a/docs/pull-requests/2026-08-26-chris-redaction-n3-s8.md
+++ b/docs/pull-requests/2026-08-26-chris-redaction-n3-s8.md
@@ -17,7 +17,8 @@ sink, the in-memory log, or a subscriber.
 ## Motivation
 
 Four specs recorded this contract as unimplemented in their annexes — N3,
-N6, N8 and N9 — and `REDACTED` appeared nowhere in the tree. The only
+N6, N8 and N9 — and the marker they mandate, `"[REDACTED]"`, appeared
+nowhere in the tree. The only
 redaction that existed was `dag-executor/host_git_guard/redact-credentials`,
 which strips userinfo from git remote URLs: real, but scoped to one field of
 one subsystem.

--- a/docs/pull-requests/2026-08-26-chris-split-evidence-collector.md
+++ b/docs/pull-requests/2026-08-26-chris-split-evidence-collector.md
@@ -1,0 +1,56 @@
+# refactor: split collector.clj under the layer budget
+
+Historical record. Merged as PR #1843.
+
+## Overview
+
+`collector.clj` was 639 lines across six strata; SL003 allows three. Split
+into five namespaces grouped by subject, with `collector.clj` keeping what
+assembles a bundle from those pieces.
+
+## Motivation
+
+Pre-existing debt, surfaced when an unrelated change put the file into the
+linted set — the same way `event-stream/core.clj` did in PR #1799. Nothing
+could touch the file until it was under budget, so this landed on its own
+rather than buried inside a behavioural change.
+
+## Changes in Detail
+
+| namespace | holds |
+|---|---|
+| `compliance-defaults` | template defaults, caller overrides, their merge |
+| `phases` | one phase's output, its evidence entry, all phases |
+| `collectors` | gathering from workflow state and the event stream |
+| `dependency-health` | health from recorded state, or from events |
+| `outcome` | outcome evidence and failure attribution |
+
+Eight private forms became public because they are now referenced across a
+namespace boundary. References were updated in the seven files that named
+the moved functions — all inside this component.
+
+## Testing Plan
+
+Behaviour preservation was verified, not asserted, in two passes:
+
+1. **By name** — the set of 36 top-level forms is identical before and
+   after. This also caught a section comment the extraction had stripped.
+2. **By body** — each form's source compared against the original after
+   normalising the three differences a split may introduce: added alias
+   qualification, `defn-` to `defn` where a form crosses a namespace
+   boundary, and file-local stratum renumbering. Exactly 4 of 36 differ,
+   all only in their stratum tag.
+
+126 tests / 388 assertions; `poly check` OK; kondo clean.
+
+## Related Issues/PRs
+
+- PR #1799 — the same split, for `event-stream/core.clj`
+- PR #1844 — the change that surfaced this and depended on it
+
+## Checklist
+
+- [x] Form set identical before and after, verified by comparison
+- [x] Form bodies unchanged beyond qualification and stratum tags
+- [x] Section headers reattached to their own forms after reordering
+- [x] Every file at three strata or fewer

--- a/docs/pull-requests/2026-08-26-chris-split-evidence-collector.md
+++ b/docs/pull-requests/2026-08-26-chris-split-evidence-collector.md
@@ -1,3 +1,9 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
 # refactor: split collector.clj under the layer budget
 
 Historical record. Merged as PR #1843.


### PR DESCRIPTION
## What

Adds the three missing `docs/pull-requests/` entries for the merged
redaction PRs. The fourth ([#1845](https://github.com/miniforge-ai/miniforge/pull/1845))
carries its own.

| doc | PR |
|---|---|
| `2026-08-26-chris-redaction-n3-s8.md` | [#1842](https://github.com/miniforge-ai/miniforge/pull/1842) |
| `2026-08-26-chris-split-evidence-collector.md` | [#1843](https://github.com/miniforge-ai/miniforge/pull/1843) |
| `2026-08-26-chris-redaction-bundle-n6-s7.md` | [#1844](https://github.com/miniforge-ai/miniforge/pull/1844) |

## Why this was missed

Dewey 721 (`pr-documentation`) is `alwaysApply` and requires a doc per PR,
created when the branch is. All four PRs in the wave shipped without one.

The cause is worth recording: `standards/miniforge` is a git submodule that
was not initialised in this worktree. My standards gap analysis for those
PRs therefore checked conventions inferred from surrounding code — copyright
headers, config-as-data, named constants, `ex-info` style — rather than the
standards themselves. An earlier search for the directory came back empty
and I read that as "not present on this machine" instead of investigating.

Nothing else would have caught it. CI does not enforce 721, and the
convention has largely lapsed in practice: the newest of 536 existing docs
predates this wave by a week, and one of the last twelve merged PRs has one.

Initialising the submodule also surfaced two live violations in
[#1845](https://github.com/miniforge-ai/miniforge/pull/1845), both now fixed
there — an `ex-info` in a component code path (dewey 005) whose message was
raw English at an emit site (dewey 050), replaced by
`config/load-config-resource`, which owns that boundary and localizes its
message.

## Content

Written as historical records, per 721's lifecycle table ("After Merge: doc
becomes static historical record"). Each covers what the PR did, why, and
what verification it actually carried — including the findings that arrived
after the fact, since the point of these is context for whoever reads them
next rather than a tidy account.

No code changes. `markdownlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)