### PR TITLE
chore: lint staged prose with plainspeak in the pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,7 +7,7 @@ set -e
 # Runs here, not in the bb task, because it needs the staged-file
 # list. Filenames containing newlines are out of scope (macOS bash 3.2).
 if command -v plainspeak >/dev/null 2>&1; then
-  prose_files=$(git diff --cached --name-only --diff-filter=ACM -- "*.md" "*.markdown" "*.txt")
+  prose_files=$(git diff --cached --name-only --diff-filter=ACMR -- "*.md" "*.markdown" "*.txt")
   if [ -n "$prose_files" ]; then
     printf "%s\n" "$prose_files" | tr "\n" "\0" | xargs -0 plainspeak --
   fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e
 
+# Prose lint (plainspeak): staged .md/.markdown/.txt must pass.
+# Skips when the linter is not installed (CI, fresh machines):
+#   pipx install git+https://github.com/miniforge-ai/plainspeak.git
+if command -v plainspeak >/dev/null 2>&1; then
+  prose_files=$(git diff --cached --name-only --diff-filter=ACM -- "*.md" "*.markdown" "*.txt")
+  if [ -n "$prose_files" ]; then
+    printf "%s\n" "$prose_files" | tr "\n" "\0" | xargs -0 plainspeak
+  fi
+fi
+
 echo "🔒 Running pre-commit validation..."
 echo ""
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,10 +4,12 @@ set -e
 # Prose lint (plainspeak): staged .md/.markdown/.txt must pass.
 # Skips when the linter is not installed (CI, fresh machines):
 #   pipx install git+https://github.com/miniforge-ai/plainspeak.git
+# Runs here, not in the bb task, because it needs the staged-file
+# list. Filenames containing newlines are out of scope (macOS bash 3.2).
 if command -v plainspeak >/dev/null 2>&1; then
   prose_files=$(git diff --cached --name-only --diff-filter=ACM -- "*.md" "*.markdown" "*.txt")
   if [ -n "$prose_files" ]; then
-    printf "%s\n" "$prose_files" | tr "\n" "\0" | xargs -0 plainspeak
+    printf "%s\n" "$prose_files" | tr "\n" "\0" | xargs -0 plainspeak --
   fi
 fi
 

--- a/docs/pull-requests/2026-08-27-plainspeak-prose-hook.md
+++ b/docs/pull-requests/2026-08-27-plainspeak-prose-hook.md
@@ -1,0 +1,40 @@
+# chore: lint staged prose with plainspeak in the pre-commit hook
+
+## Overview
+
+Adds a prose-lint step to `.githooks/pre-commit`: staged `.md`,
+`.markdown`, and `.txt` files must pass plainspeak
+(https://github.com/miniforge-ai/plainspeak).
+
+## Motivation
+
+Keep new prose free of marketing language, filler, meta-narration,
+and LLM style artifacts, repo by repo, at the cheapest point.
+
+## Changes in Detail
+
+- The hook lints only staged prose files, so legacy documents block
+  nothing until they are edited.
+- The step is skipped when the `plainspeak` binary is absent, so CI
+  and fresh machines are unaffected.
+- Findings can be suppressed per line (`plainspeak:ignore`) or per
+  code via `[tool.plainspeak]`.
+
+## Testing Plan
+
+Hook exercised locally with a staged prose file containing a known
+finding (blocked) and after fixing it (passed).
+
+## Deployment Plan
+
+None; per-clone hooks activate via the repo's existing
+`git config core.hooksPath .githooks` setup.
+
+## Related Issues/PRs
+
+Part of the workspace-wide plainspeak rollout.
+
+## Checklist
+
+- [x] Hook change reviewed
+- [x] PR doc included

--- a/docs/pull-requests/2026-08-27-plainspeak-prose-hook.md
+++ b/docs/pull-requests/2026-08-27-plainspeak-prose-hook.md
@@ -14,7 +14,8 @@ and LLM style artifacts, repo by repo, at the cheapest point.
 ## Changes in Detail
 
 - The hook lints only staged prose files, so legacy documents block
-  nothing until they are edited.
+  nothing until they are edited or renamed — a rename is a deliberate
+  touch, and per-line suppression covers grandfathered text.
 - The step is skipped when the `plainspeak` binary is absent, so CI
   and fresh machines are unaffected.
 - Findings can be suppressed per line (`plainspeak:ignore`) or per

--- a/docs/pull-requests/2026-08-27-plainspeak-prose-hook.md
+++ b/docs/pull-requests/2026-08-27-plainspeak-prose-hook.md
@@ -18,7 +18,8 @@ and LLM style artifacts, repo by repo, at the cheapest point.
 - The step is skipped when the `plainspeak` binary is absent, so CI
   and fresh machines are unaffected.
 - Findings can be suppressed per line (`plainspeak:ignore`) or per
-  code via `[tool.plainspeak]`.
+  finding code, via the repo-level `disable` list in
+  `[tool.plainspeak]`.
 
 ## Testing Plan
 


### PR DESCRIPTION
Adds a prose-lint step to `.githooks/pre-commit`: staged `.md`/`.markdown`/`.txt` files must pass [plainspeak](https://github.com/miniforge-ai/plainspeak). Only staged files are linted, so legacy docs block nothing until edited; the step is skipped when the binary is absent (CI, fresh machines). Suppression: `plainspeak:ignore` per line, `[tool.plainspeak]` per repo.

Part of the workspace-wide plainspeak rollout.

PR doc: `docs/pull-requests/2026-08-27-plainspeak-prose-hook.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)