### PR TITLE
fix(cli): remove four dead TODO placeholder message keys

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -113,9 +113,7 @@
   :runtime/info-probed "Probed:         {probed}"
   :runtime/error-no-runtime "No usable container runtime: {code} — {message}"
   :status/workflow "Status for workflow: {workflow-id}"
-  :status/workflow-todo "TODO: Query workflow component"
   :status/all-workflows "All workflows:"
-  :status/all-workflows-todo "TODO: List active workflows"
   ;; Workflow-status field labels emitted by `print-workflow-status` and
   ;; the all-workflows summary view.
   :status/field-status "  status: {value}"
@@ -502,10 +500,8 @@
   :pr/query-failed "Failed to query GitHub: {error}"
   :pr/review-usage "Usage: {command}"
   :pr/reviewing "Reviewing: {url}"
-  :pr/review-todo "TODO: Implement PR review with agent"
   :pr/respond-usage "Usage: {command}"
   :pr/responding "Responding to comments on: {url}"
-  :pr/respond-todo "TODO: Implement PR comment response"
   :pr/merge-usage "Usage: {command}"
   :pr/merge-not-available "PR merge is not yet implemented — run: {hint}"
 


### PR DESCRIPTION
## Summary

- Remove four dead message keys from `bases/cli/resources/config/cli/messages/en-US.edn` that have no callers anywhere in the codebase.

## Motivation

`:status/workflow-todo`, `:status/all-workflows-todo`, `:pr/review-todo`, and `:pr/respond-todo` were placeholder strings added before the `status` and `pr` commands were implemented. The commands now have complete implementations that use different message keys; these stubs are never called. Under dewey 008 (no-dead-code), dead configuration must be removed in the same change that discovers it.

A repo-wide `grep` confirmed zero code references to any of the four keys.

## Changes

| File/Area | Change |
|-----------|--------|
| `bases/cli/resources/config/cli/messages/en-US.edn` | Remove 4 dead `:status/workflow-todo`, `:status/all-workflows-todo`, `:pr/review-todo`, `:pr/respond-todo` entries |

## Testing

- [x] EDN file parses correctly after removal (validated with Python)
- [x] No code references any of the removed keys (grep-verified)
- [x] Pre-commit hooks pass (--no-verify never used)

## Checklist

### Required

- [x] All tests pass (`bb test`)
- [x] Pre-commit validation passes (no `--no-verify`)
- [x] No commented-out tests
- [x] No giant functions
- [x] Functions are small and composable
- [ ] New behavior has tests — N/A: deletion-only change

### Best Practices

- [x] Code follows development guidelines
- [x] Focused PR (single concern)

## Related

- Dewey 008 (no-dead-code): dead code/config must be removed in the same PR that finds it.

---
_Generated by [Claude Code](https://claude.ai/code/session_0141s6munGkd9MBtVjgQv9r3)_