### PR TITLE
fix(deliberation-workspace): make the commit path's agent-reachable failures routable

### DIFF
--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/commit.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/commit.clj
@@ -30,6 +30,28 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
+(defn- ^{:stratum 0} assert-known-targets
+  "Every id an operation touches must already exist in the workspace.
+
+   `validation/check-targets` refuses a missing target, so one arriving here
+   is a broken contract between validation and commit rather than agent
+   input — rule 005 territory, and it throws. Degrading instead is what let
+   the two writers below disagree: `apply-links` filtered unknown targets
+   out while `apply-status` handed them to `update-in`, where `object/touch`
+   received nil and `assoc` fabricated a `#:object{:touched-at n}`
+   placeholder carrying no type, status, or statement. Both readers of
+   `touched-ids` now share this single precondition instead of each holding
+   a private opinion about an id that cannot legally be here."
+  [workspace operation]
+  (let [known (get workspace :workspace/objects {})
+        missing (remove #(contains? known %) (tx/touched-ids operation))]
+    (when (seq missing)
+      (throw (IllegalArgumentException.
+              (str "Operation " (pr-str (:op operation))
+                   " targets objects absent from the workspace: "
+                   (pr-str (vec missing))
+                   " — validation must reject these before commit"))))))
+
 (defn- ^{:stratum 0} apply-links
   "Add the operation's edges to the objects it declared as targets.
 
@@ -37,10 +59,13 @@
    destinations in `:links`. Writing onto the destinations instead would
    mutate objects the validator never saw: `touched-ids` reads `:targets`
    only, so target-existence, staleness, and terminal checks would all be
-   bypassed for anything reachable through `:links`."
+   bypassed for anything reachable through `:links`.
+
+   Targets are written unscreened. `assert-known-targets` has already
+   established that each one exists, so filtering here could only differ
+   from `apply-status` about a case neither is allowed to see."
   [workspace operation]
-  (let [targets (tx/touched-ids operation)
-        known (get workspace :workspace/objects {})]
+  (let [targets (tx/touched-ids operation)]
     (reduce (fn [ws [edge destinations]]
               (reduce (fn [w target-id]
                         (reduce (fn [acc destination]
@@ -49,7 +74,7 @@
                                 w
                                 destinations))
                       ws
-                      (filter known targets)))
+                      targets))
             workspace
             (get operation :links {}))))
 
@@ -97,7 +122,11 @@
 (defn- ^{:stratum 0} apply-status
   "Impose the operation's status on its targets and advance their staleness
    clock. A status illegal for the target's type is skipped; the object is
-   still touched, so the clock stays honest."
+   still touched, so the clock stays honest.
+
+   Every target is known to exist by the time this runs — see
+   `assert-known-targets` — so `update-in` always lands on a real object
+   rather than seeding a placeholder at a missing id."
   [workspace operation version]
   (let [status (if (= :close-goal (:op operation))
                  (tx/goal-outcomes (:outcome operation))
@@ -116,6 +145,7 @@
 
 (defn- ^{:stratum 1} apply-operation [workspace operation context]
   (let [version (:version context)]
+    (assert-known-targets workspace operation)
     (-> workspace
         (insert-created operation context)
         (apply-status operation version)
@@ -129,7 +159,11 @@
 
    The version increments once per committed transaction — it is the clock
    every basis check and staleness measure reads, so it must move exactly
-   with the log, never with wall time."
+   with the log, never with wall time.
+
+   `transaction` must already have passed `validation/validate`: an
+   operation touching an object the workspace does not hold throws rather
+   than being quietly absorbed."
   [workspace transaction]
   (let [version (inc (get workspace :workspace/version 0))
         context {:role (:tx/role transaction)

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
@@ -17,16 +17,17 @@
 ;; limitations under the License.
 (ns ai.miniforge.deliberation-workspace.validation
   "The concurrency stages of the N14 §3.4 transaction validation pipeline:
-   schema conformance, target existence, role permission, and basis
-   staleness. Rejections are anomalies as data — a routable value the
-   scheduler logs, never an exception.
+   schema conformance, creation-payload conformance, target existence, role
+   permission, and basis staleness. Rejections are anomalies as data — a
+   routable value the scheduler logs, never an exception.
 
    The abuse guards (hard-constraint immutability, anti-livelock,
    idempotency) compose onto this chain in a sibling namespace."
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.deliberation-workspace.object :as object]
-   [ai.miniforge.deliberation-workspace.transaction :as tx]))
+   [ai.miniforge.deliberation-workspace.transaction :as tx]
+   [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -41,6 +42,38 @@
   [workspace]
   (get workspace :workspace/objects {}))
 
+(defn- ^{:stratum 0} creation-defect
+  "The first structural defect in a `:creates` specification, as
+   `[reason data]`, or nil when the engine can construct the object.
+
+   Mirrors every condition `object/new-object` throws on, plus the shape
+   those throws take for granted: the constructor calls `keys` on `:links`,
+   so a non-map `:links` reaches it as a ClassCastException before any of
+   its own guards run. Each predicate here is total over arbitrary EDN —
+   a validator that crashes on the input it exists to refuse would move the
+   crash rather than remove it."
+  [spec]
+  (let [statement (:statement spec)
+        links (get spec :links {})
+        mapped? (or (nil? links) (map? links))
+        unknown-edges (when mapped? (seq (remove object/link-types (keys links))))
+        scalar-edges (when mapped? (seq (remove (comp coll? val) links)))]
+    (cond
+      (not (contains? object/object-types (:type spec)))
+      [:unknown-type {:type (:type spec)}]
+
+      (not (and (string? statement) (not (str/blank? statement))))
+      [:blank-statement {:statement statement}]
+
+      (not mapped?)
+      [:malformed-links {:links links}]
+
+      unknown-edges
+      [:unknown-link-type {:link-types (vec unknown-edges)}]
+
+      scalar-edges
+      [:non-collection-links {:link-types (mapv key scalar-edges)}])))
+
 (defn ^{:stratum 0} validate-operation
   "Run `stages` against one operation in order, returning the first anomaly
    or nil. `context` carries :role and :basis from the enclosing transaction."
@@ -54,6 +87,45 @@
     (reject :invalid-input :anomalies.deliberation/unknown-operation
             "Operation is outside the closed N14 §3.2 vocabulary"
             {:op (:op operation)})))
+
+(defn- ^{:stratum 1} check-creates
+  "N14 §3.2 conformance for the objects an operation asks to create.
+
+   `object/new-object` throws IllegalArgumentException on an unknown type, a
+   blank statement, or malformed `:links`. That contract is right for a
+   programmer error, but `:creates` carries agent-supplied data and no stage
+   inspected it: a transaction cleared validation and then crashed the engine
+   partway through commit. Those conditions are agent-reachable input, so
+   they belong here as a routable rejection.
+
+   The id collision is the same gap without the crash. `insert-created`
+   writes with `assoc-in`, so creating an object at an id the graph already
+   holds replaces it outright — the previous type, status, statement and
+   links are gone, and every edge pointing at that id now resolves to the
+   new object."
+  [workspace operation _context]
+  (let [creates (get operation :creates)
+        known (objects-of workspace)]
+    (cond
+      (nil? creates) nil
+
+      (not (coll? creates))
+      (reject :invalid-input :anomalies.deliberation/invalid-creation
+              "Operation :creates must be a collection of object specifications"
+              {:op (:op operation) :reason :malformed-creates :creates creates})
+
+      :else
+      (or (some (fn [spec]
+                  (when-let [[reason data] (creation-defect spec)]
+                    (reject :invalid-input :anomalies.deliberation/invalid-creation
+                            "Operation creates an object the engine cannot construct"
+                            (merge {:op (:op operation) :reason reason :id (:id spec)}
+                                   data))))
+                creates)
+          (when-let [taken (seq (filter #(contains? known (:id %)) creates))]
+            (reject :conflict :anomalies.deliberation/duplicate-object-id
+                    "Operation creates objects at ids the workspace already holds"
+                    {:op (:op operation) :ids (mapv :id taken)}))))))
 
 (defn- ^{:stratum 1} check-targets [workspace operation _context]
   (let [known (objects-of workspace)
@@ -115,5 +187,7 @@
 
 (def ^{:stratum 2} concurrency-stages
   "Ordered §3.4 stages. Schema conformance runs first because every later
-   stage reads the operation vocabulary."
-  [check-schema check-targets check-permission check-basis])
+   stage reads the operation vocabulary, and payload conformance follows it
+   for the same reason: an operation outside the vocabulary should be
+   reported as an unknown operation, not as a bad creation."
+  [check-schema check-creates check-targets check-permission check-basis])

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
@@ -109,8 +109,8 @@
    partway through commit. Those conditions are agent-reachable input, so
    they belong here as a routable rejection.
 
-   `:creates` must be a sequence, not merely a collection. A map is
-   `coll?` too, and reducing over one yields MapEntries: `insert-created`
+   `:creates` must be a sequence or a set, not merely a collection. A map
+   is `coll?` too, and reducing over one yields MapEntries: `insert-created`
    would then `assoc` onto a MapEntry and die on a non-integer key, while
    the per-spec checks below would read nil out of every entry and
    blame `:blank-id` — a reason that misroutes, because the payload's shape
@@ -135,7 +135,7 @@
 
       (not (or (sequential? creates) (set? creates)))
       (reject :invalid-input :anomalies.deliberation/invalid-creation
-              "Operation :creates must be a sequence of object specifications"
+              "Operation :creates must be a sequence or set of object specifications"
               {:op (:op operation) :reason :malformed-creates :creates creates})
 
       :else

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
@@ -109,6 +109,13 @@
    partway through commit. Those conditions are agent-reachable input, so
    they belong here as a routable rejection.
 
+   `:creates` must be a sequence, not merely a collection. A map is
+   `coll?` too, and reducing over one yields MapEntries: `insert-created`
+   would then `assoc` onto a MapEntry and die on a non-integer key, while
+   the per-spec checks below would read nil out of every entry and
+   blame `:blank-id` — a reason that misroutes, because the payload's shape
+   is what is wrong.
+
    The id collisions are the same gap without the crash. `insert-created`
    writes with `assoc-in`, so a create at an id that already exists replaces
    it outright — the previous type, status, statement and links are gone,
@@ -126,9 +133,9 @@
     (cond
       (nil? creates) nil
 
-      (not (coll? creates))
+      (not (or (sequential? creates) (set? creates)))
       (reject :invalid-input :anomalies.deliberation/invalid-creation
-              "Operation :creates must be a collection of object specifications"
+              "Operation :creates must be a sequence of object specifications"
               {:op (:op operation) :reason :malformed-creates :creates creates})
 
       :else

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
@@ -51,14 +51,25 @@
    so a non-map `:links` reaches it as a ClassCastException before any of
    its own guards run. Each predicate here is total over arbitrary EDN —
    a validator that crashes on the input it exists to refuse would move the
-   crash rather than remove it."
+   crash rather than remove it.
+
+   The id is required to be a non-blank string, which `new-object` does not
+   itself demand. Without it a spec with no `:id` lands in the object graph
+   under a nil key, and the collision check below — which reads `:id` — has
+   nothing to compare. Every id in the component is already a string, so
+   holding the graph to one key type costs nothing and keeps `:workspace/
+   objects` addressable."
   [spec]
-  (let [statement (:statement spec)
+  (let [id (:id spec)
+        statement (:statement spec)
         links (get spec :links {})
         mapped? (or (nil? links) (map? links))
         unknown-edges (when mapped? (seq (remove object/link-types (keys links))))
         scalar-edges (when mapped? (seq (remove (comp coll? val) links)))]
     (cond
+      (not (and (string? id) (not (str/blank? id))))
+      [:blank-id {:id id}]
+
       (not (contains? object/object-types (:type spec)))
       [:unknown-type {:type (:type spec)}]
 
@@ -98,11 +109,17 @@
    partway through commit. Those conditions are agent-reachable input, so
    they belong here as a routable rejection.
 
-   The id collision is the same gap without the crash. `insert-created`
-   writes with `assoc-in`, so creating an object at an id the graph already
-   holds replaces it outright — the previous type, status, statement and
-   links are gone, and every edge pointing at that id now resolves to the
-   new object."
+   The id collisions are the same gap without the crash. `insert-created`
+   writes with `assoc-in`, so a create at an id that already exists replaces
+   it outright — the previous type, status, statement and links are gone,
+   and every edge pointing at that id now resolves to the new object. Both
+   directions are refused: against the objects the workspace already holds,
+   and against the other specs in this same `:creates`, where the reduce
+   would otherwise let a later spec quietly overwrite an earlier one.
+
+   Collisions with a create in a SIBLING operation of the same transaction
+   are still undetected: `validate-operation` sees one operation at a time,
+   and blaming either of the two for the other's id would be arbitrary."
   [workspace operation _context]
   (let [creates (get operation :creates)
         known (objects-of workspace)]
@@ -122,6 +139,12 @@
                             (merge {:op (:op operation) :reason reason :id (:id spec)}
                                    data))))
                 creates)
+          (when-let [repeated (seq (for [[id n] (frequencies (map :id creates))
+                                         :when (> n 1)]
+                                     id))]
+            (reject :conflict :anomalies.deliberation/duplicate-object-id
+                    "Operation creates more than one object at the same id"
+                    {:op (:op operation) :ids (vec repeated)}))
           (when-let [taken (seq (filter #(contains? known (:id %)) creates))]
             (reject :conflict :anomalies.deliberation/duplicate-object-id
                     "Operation creates objects at ids the workspace already holds"

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
@@ -109,12 +109,19 @@
    partway through commit. Those conditions are agent-reachable input, so
    they belong here as a routable rejection.
 
-   `:creates` must be a sequence or a set, not merely a collection. A map
-   is `coll?` too, and reducing over one yields MapEntries: `insert-created`
-   would then `assoc` onto a MapEntry and die on a non-integer key, while
-   the per-spec checks below would read nil out of every entry and
-   blame `:blank-id` — a reason that misroutes, because the payload's shape
-   is what is wrong.
+   `:creates` must be a sequence. A map is `coll?` too, and reducing over
+   one yields MapEntries: `insert-created` would then `assoc` onto a
+   MapEntry and die on a non-integer key, while the per-spec checks below
+   would read nil out of every entry and blame `:blank-id` — a reason that
+   misroutes, because the payload's shape is what is wrong.
+
+   A set is refused for a different reason. Its elements would construct
+   correctly, but the scan below reports the FIRST defect it finds, and a
+   set has no first: two malformed specs in one payload could be blamed on
+   either, so the `:reason` routing dispatches on would vary between runs
+   over identical input. Sorting them back into an order is not available
+   here either — the ids are exactly what may be missing or malformed in
+   the payloads this has to describe.
 
    The id collisions are the same gap without the crash. `insert-created`
    writes with `assoc-in`, so a create at an id that already exists replaces
@@ -133,9 +140,9 @@
     (cond
       (nil? creates) nil
 
-      (not (or (sequential? creates) (set? creates)))
+      (not (sequential? creates))
       (reject :invalid-input :anomalies.deliberation/invalid-creation
-              "Operation :creates must be a sequence or set of object specifications"
+              "Operation :creates must be a sequence of object specifications"
               {:op (:op operation) :reason :malformed-creates :creates creates})
 
       :else

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/commit_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/commit_test.clj
@@ -17,9 +17,11 @@
 ;; limitations under the License.
 (ns ai.miniforge.deliberation-workspace.commit-test
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.deliberation-workspace.commit :as commit]
    [ai.miniforge.deliberation-workspace.object :as object]
    [ai.miniforge.deliberation-workspace.transaction :as tx]
+   [ai.miniforge.deliberation-workspace.validation :as validation]
    [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -159,3 +161,45 @@
                        {:op :challenge :targets #{"claim-2"}})]
       (is (= #{"challenge-6-0-claim-1" "challenge-6-1-claim-2"}
              (set (keys (:workspace/challenges ws))))))))
+
+(deftest ^{:stratum 1} an-unknown-target-reaching-commit-is-a-programmer-error
+  (testing "a status-bearing operation no longer seeds a placeholder at the missing id"
+    (is (thrown-with-msg?
+         IllegalArgumentException #"absent from the workspace"
+         (transact (workspace) :synthesizer
+                   {:op :accept-decision :targets #{"ghost-404"}}))))
+  (testing "a link-bearing operation answers the same way instead of skipping"
+    (is (thrown-with-msg?
+         IllegalArgumentException #"absent from the workspace"
+         (transact (workspace (obj "evidence-1" :evidence)) :proposer
+                   {:op :attach-evidence :targets #{"ghost-404"}
+                    :links {:supports #{"evidence-1"}}}))))
+  (testing "an operation carrying neither status nor links is refused too"
+    (is (thrown-with-msg?
+         IllegalArgumentException #"absent from the workspace"
+         (transact (workspace) :proposer
+                   {:op :add-question :targets #{"ghost-404"}}))))
+  (testing "the message names the operation and the ids"
+    (is (thrown-with-msg?
+         IllegalArgumentException #":accept-decision.*ghost-404"
+         (transact (workspace) :synthesizer
+                   {:op :accept-decision :targets #{"ghost-404"}})))))
+
+(deftest ^{:stratum 1} validation-refuses-an-unknown-target-before-commit-can-throw
+  (testing "the throw is the contract behind the gate, never what a run surfaces"
+    (let [ws (workspace)
+          proposed (tx/new-transaction
+                    {:role :synthesizer :activation "act-9" :basis 5
+                     :operations [{:op :accept-decision :targets #{"ghost-404"}}]})]
+      (is (= :anomalies.deliberation/unknown-target
+             (anomaly/subtype
+              (validation/validate ws proposed validation/concurrency-stages)))))))
+
+(deftest ^{:stratum 1} known-targets-still-commit-unchanged
+  (testing "the precondition admits every operation validation would have passed"
+    (let [ws (transact (workspace (obj "claim-1" :claim) (obj "evidence-1" :evidence))
+                       :proposer
+                       {:op :attach-evidence :targets #{"claim-1"}
+                        :links {:supports #{"evidence-1"}}})]
+      (is (= #{"evidence-1"} (object/linked (object-at ws "claim-1") :supports)))
+      (is (= 6 (:object/touched-at (object-at ws "claim-1")))))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
@@ -169,3 +169,19 @@
         event (first (events-of after :activation/completed))]
     (is (= :conflict (:reason event)))
     (is (= "conflict-1" (:target event)) "the trigger must be auditable")))
+
+(deftest ^{:stratum 2} a-creation-the-engine-cannot-construct-is-routed-not-thrown
+  (testing "the rejection reaches the event log as a subtype, like every other"
+    (let [propose (fn [{:keys [role]}]
+                    (tx/new-transaction
+                     {:role role :activation "act-1" :basis 1
+                      :operations [{:op :assert-claim
+                                    :creates [{:id "x" :type :wormhole
+                                               :statement "unconstructable"}]}]}))
+          after (run/step (workspace) propose)]
+      (is (= [:anomalies.deliberation/invalid-creation]
+             (mapv :reason (events-of after :transaction/rejected))))
+      (is (= 1 (:workspace/version after))
+          "a rejected transaction does not advance the clock")
+      (is (= #{"goal-1"} (set (keys (:workspace/objects after))))
+          "and leaves no half-created object behind"))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
@@ -133,7 +133,7 @@
                              {:op :refine-claim :targets #{"claim-404"}}))))))
 
 (deftest ^{:stratum 1} creations-the-engine-cannot-construct-are-refused
-  (testing "every payload object/new-object throws on is rejected as data first"
+  (testing "every payload that object/new-object throws on is rejected as data first"
     (doseq [[label spec] [["unknown type" {:id "x" :type :wormhole :statement "s"}]
                           ["blank statement" {:id "x" :type :claim :statement "   "}]
                           ["missing statement" {:id "x" :type :claim}]
@@ -176,7 +176,24 @@
     (is (= :anomalies.deliberation/invalid-creation
            (subtype-of (validate-tx (workspace)
                                     (transaction :proposer 10
-                                                 {:op :assert-claim :creates 5})))))))
+                                                 {:op :assert-claim :creates 5}))))))
+  (testing "a map is coll? too, and reducing over one yields MapEntries"
+    (let [rejection (validate-tx (workspace)
+                                 (transaction :proposer 10
+                                              {:op :assert-claim
+                                               :creates {:id "x" :type :claim
+                                                         :statement "s"}}))]
+      (is (= :anomalies.deliberation/invalid-creation (subtype-of rejection)))
+      (is (= :malformed-creates (:reason (:anomaly/data rejection)))
+          "the shape is what is wrong, so blaming :blank-id would misroute")))
+  (testing "a sequence of specs is what the stage accepts"
+    (doseq [[label creates] [["vector" [{:id "c-1" :type :claim :statement "s"}]]
+                             ["list" (list {:id "c-1" :type :claim :statement "s"})]
+                             ["set" #{{:id "c-1" :type :claim :statement "s"}}]]]
+      (is (nil? (validate-tx (workspace)
+                             (transaction :proposer 10
+                                          {:op :assert-claim :creates creates})))
+          label))))
 
 (deftest ^{:stratum 1} creations-may-not-overwrite-an-object-the-workspace-holds
   (testing "insert-created writes with assoc-in, so a collision would erase the original"

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
@@ -131,3 +131,73 @@
                 (transaction :proposer 10
                              {:op :attach-evidence :targets #{"claim-1"}}
                              {:op :refine-claim :targets #{"claim-404"}}))))))
+
+(deftest ^{:stratum 1} creations-the-engine-cannot-construct-are-refused
+  (testing "every payload object/new-object throws on is rejected as data first"
+    (doseq [[label spec] [["unknown type" {:id "x" :type :wormhole :statement "s"}]
+                          ["blank statement" {:id "x" :type :claim :statement "   "}]
+                          ["missing statement" {:id "x" :type :claim}]
+                          ["non-string statement" {:id "x" :type :claim :statement :s}]
+                          ["unknown link type" {:id "x" :type :claim :statement "s"
+                                                :links {:bogus #{"claim-1"}}}]
+                          ["scalar link value" {:id "x" :type :claim :statement "s"
+                                                :links {:supports "claim-1"}}]
+                          ["non-map links" {:id "x" :type :claim :statement "s"
+                                            :links [:supports]}]]]
+      (is (= :anomalies.deliberation/invalid-creation
+             (subtype-of (validate-tx (workspace)
+                                      (transaction :proposer 10
+                                                   {:op :assert-claim :creates [spec]}))))
+          label))))
+
+(deftest ^{:stratum 1} a-creation-rejection-carries-the-reason-it-failed
+  (testing "routing reads the reason without parsing the message"
+    (is (= :unknown-type
+           (-> (validate-tx (workspace)
+                            (transaction :proposer 10
+                                         {:op :assert-claim
+                                          :creates [{:id "x" :type :wormhole
+                                                     :statement "s"}]}))
+               :anomaly/data :reason)))))
+
+(deftest ^{:stratum 1} a-well-formed-creation-passes
+  (testing "the stage refuses malformed specs, not creation itself"
+    (is (nil? (validate-tx (workspace)
+                           (transaction :proposer 10
+                                        {:op :assert-claim
+                                         :creates [{:id "claim-9" :type :claim
+                                                    :statement "the invariant holds"
+                                                    :links {:supports #{"claim-1"}}}]})))))
+  (testing "an operation that creates nothing is untouched by the stage"
+    (is (nil? (validate-tx (workspace) (transaction :proposer 10 {:op :add-question}))))))
+
+(deftest ^{:stratum 1} a-malformed-creates-payload-is-rejected-not-thrown
+  (testing "insert-created reduces over :creates, so a scalar would crash the engine"
+    (is (= :anomalies.deliberation/invalid-creation
+           (subtype-of (validate-tx (workspace)
+                                    (transaction :proposer 10
+                                                 {:op :assert-claim :creates 5})))))))
+
+(deftest ^{:stratum 1} creations-may-not-overwrite-an-object-the-workspace-holds
+  (testing "insert-created writes with assoc-in, so a collision would erase the original"
+    (is (= :anomalies.deliberation/duplicate-object-id
+           (subtype-of (validate-tx
+                        (workspace (object-at "claim-1" 4))
+                        (transaction :proposer 10
+                                     {:op :assert-claim
+                                      :creates [{:id "claim-1" :type :goal
+                                                 :statement "clobbered"}]}))))))
+  (testing "a fresh id is free to be created"
+    (is (nil? (validate-tx (workspace (object-at "claim-1" 4))
+                           (transaction :proposer 10
+                                        {:op :assert-claim
+                                         :creates [{:id "claim-2" :type :claim
+                                                    :statement "a second claim"}]}))))))
+
+(deftest ^{:stratum 1} an-unknown-operation-outranks-a-bad-creation
+  (testing "payload conformance runs after schema, so the vocabulary is reported first"
+    (is (= :anomalies.deliberation/unknown-operation
+           (subtype-of (validate-tx (workspace)
+                                    (transaction :proposer 10
+                                                 {:op :rewrite-history
+                                                  :creates [{:id "x" :type :wormhole}]})))))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
@@ -201,3 +201,41 @@
                                     (transaction :proposer 10
                                                  {:op :rewrite-history
                                                   :creates [{:id "x" :type :wormhole}]})))))))
+
+(deftest ^{:stratum 1} a-creation-must-carry-a-usable-id
+  (testing "without one the object lands in the graph under a nil key"
+    (doseq [[label spec] [["missing" {:type :claim :statement "s"}]
+                          ["blank" {:id "  " :type :claim :statement "s"}]
+                          ["non-string" {:id :claim-1 :type :claim :statement "s"}]]]
+      (is (= :anomalies.deliberation/invalid-creation
+             (subtype-of (validate-tx (workspace)
+                                      (transaction :proposer 10
+                                                   {:op :assert-claim :creates [spec]}))))
+          label)))
+  (testing "the reason names the id, so the collision check is not silently vacuous"
+    (is (= :blank-id
+           (-> (validate-tx (workspace)
+                            (transaction :proposer 10
+                                         {:op :assert-claim
+                                          :creates [{:type :claim :statement "s"}]}))
+               :anomaly/data :reason)))))
+
+(deftest ^{:stratum 1} one-operation-may-not-create-two-objects-at-one-id
+  (testing "insert-created reduces, so the later spec would overwrite the earlier"
+    (is (= :anomalies.deliberation/duplicate-object-id
+           (subtype-of (validate-tx
+                        (workspace)
+                        (transaction :proposer 10
+                                     {:op :assert-claim
+                                      :creates [{:id "claim-1" :type :claim
+                                                 :statement "first"}
+                                                {:id "claim-1" :type :goal
+                                                 :statement "second"}]}))))))
+  (testing "distinct ids in one operation are fine"
+    (is (nil? (validate-tx (workspace)
+                           (transaction :proposer 10
+                                        {:op :assert-claim
+                                         :creates [{:id "claim-1" :type :claim
+                                                    :statement "first"}
+                                                   {:id "claim-2" :type :claim
+                                                    :statement "second"}]}))))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
@@ -186,10 +186,18 @@
       (is (= :anomalies.deliberation/invalid-creation (subtype-of rejection)))
       (is (= :malformed-creates (:reason (:anomaly/data rejection)))
           "the shape is what is wrong, so blaming :blank-id would misroute")))
-  (testing "a sequence of specs is what the stage accepts"
+  (testing "a set is refused: the scan reports the first defect, and a set has no first"
+    (is (= :malformed-creates
+           (-> (validate-tx (workspace)
+                            (transaction :proposer 10
+                                         {:op :assert-claim
+                                          :creates #{{:id "c-1" :type :claim
+                                                      :statement "s"}}}))
+               :anomaly/data :reason))
+        "an unordered payload would make the routed :reason vary between runs"))
+  (testing "an ordered sequence of specs is what the stage accepts"
     (doseq [[label creates] [["vector" [{:id "c-1" :type :claim :statement "s"}]]
-                             ["list" (list {:id "c-1" :type :claim :statement "s"})]
-                             ["set" #{{:id "c-1" :type :claim :statement "s"}}]]]
+                             ["list" (list {:id "c-1" :type :claim :statement "s"})]]]
       (is (nil? (validate-tx (workspace)
                              (transaction :proposer 10
                                           {:op :assert-claim :creates creates})))


### PR DESCRIPTION
Follow-up to #1840. Copilot flagged two gaps in the commit path there; both were pre-existing and left out of scope for that PR.

## 1. `:creates` was never validated

`insert-created` calls `object/new-object`, which throws `IllegalArgumentException` on an unknown type, a blank statement, or malformed `:links`. The validation pipeline checked only that `:op` was known (`check-schema`) and that `:targets` existed (`check-targets`) — nothing inspected `:creates`. So a transaction could pass validation and then crash the engine partway through commit, on an agent-supplied payload.

That breaks the anomalies-as-data discipline: agent-reachable bad input has to be a routable rejection, not an exception.

Adds `check-creates` to `concurrency-stages`. Verified all four `new-object` throws reproduce first, plus a fifth the report didn't list — a non-map `:links` reaches the constructor as a `ClassCastException` from `keys`, before any of its own guards run. That shaped the design: every predicate in `creation-defect` is total over arbitrary EDN, because a validator that crashes on the input it exists to refuse relocates the crash instead of removing it. Same reason `:creates` itself is shape-checked — `insert-created` reduces over it, so a scalar would crash.

Also refuses id collisions. `insert-created` writes with `assoc-in`, so a create at an id that already exists replaces it outright, and every edge pointing at that id then resolves to the new object. Both directions are covered: against the objects the workspace already holds, and against the other specs in the same `:creates`. A non-blank string `:id` is required — without it the object lands under a `nil` key and the collision check, which reads `:id`, has nothing to compare.

Two subtypes rather than one, because the generic anomaly type differs — folding them would force one to lie about its type:

| subtype | type | carries |
| --- | --- | --- |
| `:anomalies.deliberation/invalid-creation` | `:invalid-input` | specific `:reason` in `:anomaly/data` for routing |
| `:anomalies.deliberation/duplicate-object-id` | `:conflict` | the colliding `:ids` |

The stage runs after `check-schema`, so an operation outside the vocabulary is still reported as an unknown operation rather than a bad creation.

## 2. `apply-status` fabricated placeholders

`apply-status` reduced over `(tx/touched-ids operation)` and called `update-in ... object/touch` for every id. For an id absent from `:workspace/objects`, `object/touch` received nil and `assoc` created a malformed placeholder. Confirmed pre-fix: `#:object{:touched-at 6}` — no type, no status, no statement.

`apply-links` guarded the same condition differently, with `(filter known targets)`. Two readers of `touched-ids`, two opinions about a missing id.

Resolved toward failing fast, not toward the silent skip. `check-targets` already refuses a missing target, so an id reaching `commit` is a broken validation/commit contract rather than agent input — rule 005, programmer error. Rather than duplicate a guard into both functions, `assert-known-targets` runs once in `apply-operation` and throws; `apply-links` drops its filter. The two can't disagree because neither decides any more. Docstrings on all three say why.

The throw is the contract behind the gate, never what a run surfaces — validation rejects the same input as `:anomalies.deliberation/unknown-target` first, which the tests assert alongside the throw.

## Verification

Component suite 89 tests / 258 assertions, 0 failures on this main base. clj-kondo clean, `bb lint:stratum` clean, full pre-commit gate green on all three commits. Sliced to stay under the 200-line commit budget.

Routing was verified end-to-end against the run loop by hand — `run/step` logs `:transaction/rejected` with `:reason :anomalies.deliberation/invalid-creation`, version unchanged, no half-created object. The regression test for that lives in `run_test.clj`, which arrives with #1841; it will be added here once that lands.

## Still open

Two agent-reachable defects of the same class remain, verified but outside this PR's scope:

1. Operation-level `:links` — as opposed to the `:links` inside `:creates` — with an unknown edge type throws from `object/add-link`.
2. A scalar destination there crashes the reduce in `apply-links`.

A third case is deliberately left undetected and documented in the `check-creates` docstring: an id collision against a create in a *sibling* operation of the same transaction. `validate-operation` sees one operation at a time, so blaming either of the two would be arbitrary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)