### PR TITLE
fix(deliberation-workspace): validate an operation's own :links, and creates across a transaction

### DIFF
--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
@@ -42,16 +42,44 @@
   [workspace]
   (get workspace :workspace/objects {}))
 
+(defn- ^{:stratum 0} link-defect
+  "The first structural defect in a `:links` map, as `[reason data]`, or nil
+   when the engine can write every edge the map declares.
+
+   Two callers read `:links`. `object/new-object` reads the map on a
+   `:creates` spec, and `commit/apply-links` reads the one an operation
+   carries itself; both reach `object/add-link`, which throws
+   IllegalArgumentException on an edge outside `object/link-types`, and both
+   walk each destination as a collection. One definition keeps the two paths
+   from forming different opinions about the same payload.
+
+   Total over arbitrary EDN: `keys` throws on a non-map, so that check
+   guards the two after it. A validator that crashes on the input it exists
+   to refuse would move the crash rather than remove it."
+  [links]
+  (let [mapped? (or (nil? links) (map? links))
+        unknown-edges (when mapped? (seq (remove object/link-types (keys links))))
+        scalar-edges (when mapped? (seq (remove (comp coll? val) links)))]
+    (cond
+      (not mapped?)
+      [:malformed-links {:links links}]
+
+      unknown-edges
+      [:unknown-link-type {:link-types (vec unknown-edges)}]
+
+      scalar-edges
+      [:non-collection-links {:link-types (mapv key scalar-edges)}])))
+
 (defn- ^{:stratum 0} creation-defect
   "The first structural defect in a `:creates` specification, as
    `[reason data]`, or nil when the engine can construct the object.
 
-   Mirrors every condition `object/new-object` throws on, plus the shape
-   those throws take for granted: the constructor calls `keys` on `:links`,
-   so a non-map `:links` reaches it as a ClassCastException before any of
-   its own guards run. Each predicate here is total over arbitrary EDN —
-   a validator that crashes on the input it exists to refuse would move the
-   crash rather than remove it.
+   Covers the fields `object/new-object` throws on that belong to the spec
+   alone; [[link-defect]] is its sibling for the `:links` half, and
+   `check-creates` runs the two in order over each spec. They are separate
+   because an operation carries a `:links` map of its own with no spec
+   around it, and that map needs the same reading. Each predicate here is
+   total over arbitrary EDN.
 
    The id is required to be a non-blank string, which `new-object` does not
    itself demand. Without it a spec with no `:id` lands in the object graph
@@ -61,11 +89,7 @@
    objects` addressable."
   [spec]
   (let [id (:id spec)
-        statement (:statement spec)
-        links (get spec :links {})
-        mapped? (or (nil? links) (map? links))
-        unknown-edges (when mapped? (seq (remove object/link-types (keys links))))
-        scalar-edges (when mapped? (seq (remove (comp coll? val) links)))]
+        statement (:statement spec)]
     (cond
       (not (and (string? id) (not (str/blank? id))))
       [:blank-id {:id id}]
@@ -74,16 +98,7 @@
       [:unknown-type {:type (:type spec)}]
 
       (not (and (string? statement) (not (str/blank? statement))))
-      [:blank-statement {:statement statement}]
-
-      (not mapped?)
-      [:malformed-links {:links links}]
-
-      unknown-edges
-      [:unknown-link-type {:link-types (vec unknown-edges)}]
-
-      scalar-edges
-      [:non-collection-links {:link-types (mapv key scalar-edges)}])))
+      [:blank-statement {:statement statement}])))
 
 (defn ^{:stratum 0} validate-operation
   "Run `stages` against one operation in order, returning the first anomaly
@@ -147,7 +162,8 @@
 
       :else
       (or (some (fn [spec]
-                  (when-let [[reason data] (creation-defect spec)]
+                  (when-let [[reason data] (or (creation-defect spec)
+                                               (link-defect (:links spec)))]
                     (reject :invalid-input :anomalies.deliberation/invalid-creation
                             "Operation creates an object the engine cannot construct"
                             (merge {:op (:op operation) :reason reason :id (:id spec)}
@@ -163,6 +179,32 @@
             (reject :conflict :anomalies.deliberation/duplicate-object-id
                     "Operation creates objects at ids the workspace already holds"
                     {:op (:op operation) :ids (mapv :id taken)}))))))
+
+(defn- ^{:stratum 1} check-links
+  "N14 §3.2 conformance for the edges an operation writes onto its targets.
+
+   `check-creates` covers the `:links` of the objects an operation CREATES.
+   Nothing covered the map the operation carries at its own top level, and
+   `commit/apply-links` reduces over exactly that map: an edge outside
+   `object/link-types` reached `object/add-link` and threw
+   IllegalArgumentException partway through commit, after earlier operations
+   in the same transaction had already been applied to the accumulator.
+
+   The destinations are walked as a collection, so a scalar there dies in
+   `reduce` instead. A string is the case worth naming: it is not `coll?`,
+   and left admitted it would not crash at all — `reduce` would walk its
+   characters and write one edge per letter. A non-map `:links` reaches
+   neither, since destructuring `[edge destinations]` out of it throws
+   first.
+
+   All of it is agent-supplied payload, so it belongs here as a routable
+   rejection rather than as an exception — the same contract #1851 restored
+   one layer down."
+  [_workspace operation _context]
+  (when-let [[reason data] (link-defect (:links operation))]
+    (reject :invalid-input :anomalies.deliberation/invalid-links
+            "Operation declares edges the engine cannot write"
+            (merge {:op (:op operation) :reason reason} data))))
 
 (defn- ^{:stratum 1} check-targets [workspace operation _context]
   (let [known (objects-of workspace)
@@ -226,5 +268,11 @@
   "Ordered §3.4 stages. Schema conformance runs first because every later
    stage reads the operation vocabulary, and payload conformance follows it
    for the same reason: an operation outside the vocabulary should be
-   reported as an unknown operation, not as a bad creation."
-  [check-schema check-creates check-targets check-permission check-basis])
+   reported as an unknown operation, not as a bad creation.
+
+   Both payload stages precede the three that read the object graph. A
+   transaction can carry a malformed payload and a missing target at once,
+   and the payload is the more basic fault: the ids a graph stage would
+   report come out of the same payload whose shape is not yet established."
+  [check-schema check-creates check-links
+   check-targets check-permission check-basis])

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
@@ -100,6 +100,21 @@
       (not (and (string? statement) (not (str/blank? statement))))
       [:blank-statement {:statement statement}])))
 
+(defn- ^{:stratum 0} proposed-specs
+  "Every object specification the operations of one transaction ask to
+   create, in the order the payload lists them.
+
+   Operations whose `:creates` is not a sequence are skipped rather than
+   interpreted: `check-creates` refuses that shape on its own behalf, and
+   reading specs out of a payload whose shape is unestablished is how a
+   validator ends up reporting the wrong fault."
+  [operations]
+  (for [operation operations
+        :let [creates (get operation :creates)]
+        :when (sequential? creates)
+        spec creates]
+    spec))
+
 (defn ^{:stratum 0} validate-operation
   "Run `stages` against one operation in order, returning the first anomaly
    or nil. `context` carries :role and :basis from the enclosing transaction."
@@ -141,15 +156,27 @@
    The id collisions are the same gap without the crash. `insert-created`
    writes with `assoc-in`, so a create at an id that already exists replaces
    it outright — the previous type, status, statement and links are gone,
-   and every edge pointing at that id now resolves to the new object. Both
-   directions are refused: against the objects the workspace already holds,
-   and against the other specs in this same `:creates`, where the reduce
-   would otherwise let a later spec quietly overwrite an earlier one.
+   and every edge pointing at that id now resolves to the new object.
 
-   Collisions with a create in a SIBLING operation of the same transaction
-   are still undetected: `validate-operation` sees one operation at a time,
-   and blaming either of the two for the other's id would be arbitrary."
-  [workspace operation _context]
+   Two directions are refused, and the second reads the whole transaction
+   rather than this operation alone. `commit` reduces every operation onto
+   one accumulator, so two creates at one id overwrite each other whether
+   they sit in one `:creates` vector or in two operations of the same
+   transaction — one rule, not two. Reading only this operation would have
+   left the cross-operation half of an identical failure admitted.
+
+   Blaming one of the two operations was the objection to checking it, and
+   it does not survive contact: a rejected transaction is discarded whole
+   (§3.4), so no operation is being singled out for a penalty. What the
+   anomaly carries is where the pipeline noticed, and the message says the
+   transaction is at fault. `:tx/operations` is a vector, so which operation
+   notices is fixed by the payload rather than by iteration order.
+
+   Only specs the engine could construct are counted. A sibling carrying
+   two id-less specs would otherwise collide with itself at the id nil and
+   be reported as a duplicate, when the fault it will be rejected for on
+   its own turn is the missing id."
+  [workspace operation context]
   (let [creates (get operation :creates)
         known (objects-of workspace)]
     (cond
@@ -169,12 +196,15 @@
                             (merge {:op (:op operation) :reason reason :id (:id spec)}
                                    data))))
                 creates)
-          (when-let [repeated (seq (for [[id n] (frequencies (map :id creates))
-                                         :when (> n 1)]
-                                     id))]
-            (reject :conflict :anomalies.deliberation/duplicate-object-id
-                    "Operation creates more than one object at the same id"
-                    {:op (:op operation) :ids (vec repeated)}))
+          (let [ids (->> (get context :siblings [operation])
+                         proposed-specs
+                         (remove creation-defect)
+                         (map :id))
+                counts (frequencies ids)]
+            (when-let [repeated (seq (distinct (filter #(< 1 (get counts %)) ids)))]
+              (reject :conflict :anomalies.deliberation/duplicate-object-id
+                      "Transaction creates more than one object at the same id"
+                      {:op (:op operation) :ids (vec repeated)})))
           (when-let [taken (seq (filter #(contains? known (:id %)) creates))]
             (reject :conflict :anomalies.deliberation/duplicate-object-id
                     "Operation creates objects at ids the workspace already holds"

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
@@ -148,12 +148,17 @@
    The transaction is what a collision faults, and it is discarded whole
    (§3.4); `:op` records where the pipeline noticed. `:tx/operations` is a
    vector, so which operation notices is fixed by the payload, and `:ids`
-   is ordered by first appearance. Only specs the engine could construct
-   are counted, so a sibling's id-less specs are its own `:blank-id`
-   rejection rather than a collision at nil."
+   is ordered by first appearance.
+
+   Only specs that would reach the graph are counted, read by the same
+   `defect` the per-spec scan reports on. A defective spec never reaches
+   `insert-created`, so counting one invents a collision whose blame lands
+   on whichever operation the scan happens to run first, ahead of the
+   defect its own operation would report."
   [workspace operation context]
   (let [creates (get operation :creates)
-        known (objects-of workspace)]
+        known (objects-of workspace)
+        defect (fn [spec] (or (creation-defect spec) (link-defect (:links spec))))]
     (cond
       (nil? creates) nil
 
@@ -164,8 +169,7 @@
 
       :else
       (or (some (fn [spec]
-                  (when-let [[reason data] (or (creation-defect spec)
-                                               (link-defect (:links spec)))]
+                  (when-let [[reason data] (defect spec)]
                     (reject :invalid-input :anomalies.deliberation/invalid-creation
                             "Operation creates an object the engine cannot construct"
                             (merge {:op (:op operation) :reason reason :id (:id spec)}
@@ -173,7 +177,7 @@
                 creates)
           (let [ids (->> (get context :siblings [operation])
                          proposed-specs
-                         (remove creation-defect)
+                         (remove defect)
                          (map :id))
                 counts (frequencies ids)]
             (when-let [repeated (seq (distinct (filter #(< 1 (get counts %)) ids)))]

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
@@ -44,18 +44,16 @@
 
 (defn- ^{:stratum 0} link-defect
   "The first structural defect in a `:links` map, as `[reason data]`, or nil
-   when the engine can write every edge the map declares.
+   when the engine can write every edge the map declares: a map, keyed by
+   `object/link-types`, each value a collection of object ids.
 
-   Two callers read `:links`. `object/new-object` reads the map on a
-   `:creates` spec, and `commit/apply-links` reads the one an operation
-   carries itself; both reach `object/add-link`, which throws
-   IllegalArgumentException on an edge outside `object/link-types`, and both
-   walk each destination as a collection. One definition keeps the two paths
-   from forming different opinions about the same payload.
+   The one reading for both writers of `:links` — `object/new-object` on a
+   `:creates` spec, `commit/apply-links` on the map an operation carries
+   itself.
 
-   Total over arbitrary EDN: `keys` throws on a non-map, so that check
-   guards the two after it. A validator that crashes on the input it exists
-   to refuse would move the crash rather than remove it."
+   Total over arbitrary EDN, `keys` on a non-map included: a validator that
+   crashes on the input it exists to refuse moves the crash rather than
+   removing it."
   [links]
   (let [mapped? (or (nil? links) (map? links))
         unknown-edges (when mapped? (seq (remove object/link-types (keys links))))
@@ -74,19 +72,14 @@
   "The first structural defect in a `:creates` specification, as
    `[reason data]`, or nil when the engine can construct the object.
 
-   Covers the fields `object/new-object` throws on that belong to the spec
-   alone; [[link-defect]] is its sibling for the `:links` half, and
-   `check-creates` runs the two in order over each spec. They are separate
-   because an operation carries a `:links` map of its own with no spec
-   around it, and that map needs the same reading. Each predicate here is
-   total over arbitrary EDN.
+   Covers the fields belonging to the spec alone; [[link-defect]] is the
+   sibling reading for its `:links`, and `check-creates` runs the two in
+   order. Each predicate here is total over arbitrary EDN.
 
-   The id is required to be a non-blank string, which `new-object` does not
-   itself demand. Without it a spec with no `:id` lands in the object graph
-   under a nil key, and the collision check below — which reads `:id` — has
-   nothing to compare. Every id in the component is already a string, so
-   holding the graph to one key type costs nothing and keeps `:workspace/
-   objects` addressable."
+   The id must be a non-blank string, which `object/new-object` does not
+   itself demand: without one the object lands in `:workspace/objects` under
+   a nil key, and the collision checks below read `:id`. Holding the graph
+   to one key type keeps it addressable."
   [spec]
   (let [id (:id spec)
         statement (:statement spec)]
@@ -104,10 +97,10 @@
   "Every object specification the operations of one transaction ask to
    create, in the order the payload lists them.
 
-   Operations whose `:creates` is not a sequence are skipped rather than
-   interpreted: `check-creates` refuses that shape on its own behalf, and
-   reading specs out of a payload whose shape is unestablished is how a
-   validator ends up reporting the wrong fault."
+   Operations whose `:creates` is not a sequence are skipped, not
+   interpreted. `check-creates` refuses that shape on its own behalf, and
+   reading specs out of a payload of unestablished shape reports the wrong
+   fault."
   [operations]
   (for [operation operations
         :let [creates (get operation :creates)]
@@ -117,7 +110,8 @@
 
 (defn ^{:stratum 0} validate-operation
   "Run `stages` against one operation in order, returning the first anomaly
-   or nil. `context` carries :role and :basis from the enclosing transaction."
+   or nil. `context` carries :role, :basis and :siblings from the enclosing
+   transaction; stages reading :siblings must tolerate its absence here."
   [workspace operation context stages]
   (some #(% workspace operation context) stages))
 
@@ -132,50 +126,31 @@
 (defn- ^{:stratum 1} check-creates
   "N14 §3.2 conformance for the objects an operation asks to create.
 
-   `object/new-object` throws IllegalArgumentException on an unknown type, a
-   blank statement, or malformed `:links`. That contract is right for a
-   programmer error, but `:creates` carries agent-supplied data and no stage
-   inspected it: a transaction cleared validation and then crashed the engine
-   partway through commit. Those conditions are agent-reachable input, so
-   they belong here as a routable rejection.
+   `:creates` carries agent-supplied data that `object/new-object` and
+   `insert-created` both treat as a programmer error, so every condition
+   they throw on is a routable rejection here instead.
 
-   `:creates` must be a sequence. A map is `coll?` too, and reducing over
-   one yields MapEntries: `insert-created` would then `assoc` onto a
-   MapEntry and die on a non-integer key, while the per-spec checks below
-   would read nil out of every entry and blame `:blank-id` — a reason that
-   misroutes, because the payload's shape is what is wrong.
+   `:creates` must be sequential. A map is `coll?` too, and `insert-created`
+   reducing over one would `assoc` onto a MapEntry and die on a non-integer
+   key. A set is refused for determinism: the per-spec scan below reports
+   the FIRST defect it finds, and a set has no first, so the `:reason`
+   routing dispatches on would vary between runs over identical input.
+   Sorting one into an order is not available — the ids are exactly what
+   may be missing or malformed in the payloads this describes.
 
-   A set is refused for a different reason. Its elements would construct
-   correctly, but the scan below reports the FIRST defect it finds, and a
-   set has no first: two malformed specs in one payload could be blamed on
-   either, so the `:reason` routing dispatches on would vary between runs
-   over identical input. Sorting them back into an order is not available
-   here either — the ids are exactly what may be missing or malformed in
-   the payloads this has to describe.
+   Two collision directions are refused, both because `insert-created`
+   writes with `assoc-in`: a create at an id that already exists replaces
+   the object outright, and every edge pointing there resolves to the new
+   one. Against `:workspace/objects`, and against every other create in the
+   same transaction — `commit` reduces all operations onto one accumulator,
+   so one `:creates` vector and two sibling operations collide alike.
 
-   The id collisions are the same gap without the crash. `insert-created`
-   writes with `assoc-in`, so a create at an id that already exists replaces
-   it outright — the previous type, status, statement and links are gone,
-   and every edge pointing at that id now resolves to the new object.
-
-   Two directions are refused, and the second reads the whole transaction
-   rather than this operation alone. `commit` reduces every operation onto
-   one accumulator, so two creates at one id overwrite each other whether
-   they sit in one `:creates` vector or in two operations of the same
-   transaction — one rule, not two. Reading only this operation would have
-   left the cross-operation half of an identical failure admitted.
-
-   Blaming one of the two operations was the objection to checking it, and
-   it does not survive contact: a rejected transaction is discarded whole
-   (§3.4), so no operation is being singled out for a penalty. What the
-   anomaly carries is where the pipeline noticed, and the message says the
-   transaction is at fault. `:tx/operations` is a vector, so which operation
-   notices is fixed by the payload rather than by iteration order.
-
-   Only specs the engine could construct are counted. A sibling carrying
-   two id-less specs would otherwise collide with itself at the id nil and
-   be reported as a duplicate, when the fault it will be rejected for on
-   its own turn is the missing id."
+   The transaction is what a collision faults, and it is discarded whole
+   (§3.4); `:op` records where the pipeline noticed. `:tx/operations` is a
+   vector, so which operation notices is fixed by the payload, and `:ids`
+   is ordered by first appearance. Only specs the engine could construct
+   are counted, so a sibling's id-less specs are its own `:blank-id`
+   rejection rather than a collision at nil."
   [workspace operation context]
   (let [creates (get operation :creates)
         known (objects-of workspace)]
@@ -213,23 +188,15 @@
 (defn- ^{:stratum 1} check-links
   "N14 §3.2 conformance for the edges an operation writes onto its targets.
 
-   `check-creates` covers the `:links` of the objects an operation CREATES.
-   Nothing covered the map the operation carries at its own top level, and
-   `commit/apply-links` reduces over exactly that map: an edge outside
-   `object/link-types` reached `object/add-link` and threw
-   IllegalArgumentException partway through commit, after earlier operations
-   in the same transaction had already been applied to the accumulator.
+   `commit/apply-links` reduces over the operation's own `:links`, so the
+   map is held to the same contract `check-creates` holds a spec's `:links`
+   to: `object/add-link` throws on an edge outside `object/link-types`, and
+   a scalar destination dies in the inner `reduce`. A string destination is
+   the case worth naming, since it would not crash at all — `reduce` walks
+   its characters and writes one edge per letter.
 
-   The destinations are walked as a collection, so a scalar there dies in
-   `reduce` instead. A string is the case worth naming: it is not `coll?`,
-   and left admitted it would not crash at all — `reduce` would walk its
-   characters and write one edge per letter. A non-map `:links` reaches
-   neither, since destructuring `[edge destinations]` out of it throws
-   first.
-
-   All of it is agent-supplied payload, so it belongs here as a routable
-   rejection rather than as an exception — the same contract #1851 restored
-   one layer down."
+   Agent-supplied payload, so a violation is a routable rejection rather
+   than an exception."
   [_workspace operation _context]
   (when-let [[reason data] (link-defect (:links operation))]
     (reject :invalid-input :anomalies.deliberation/invalid-links

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
@@ -170,6 +170,24 @@
     (is (= :conflict (:reason event)))
     (is (= "conflict-1" (:target event)) "the trigger must be auditable")))
 
+(deftest ^{:stratum 2} an-edge-the-engine-cannot-write-is-routed-not-thrown
+  (testing "the operation's own :links reach the event log as a subtype too"
+    (let [propose (fn [{:keys [role]}]
+                    (tx/new-transaction
+                     {:role role :activation "act-1" :basis 1
+                      :operations [{:op :assert-claim
+                                    :creates [{:id "claim-1" :type :claim
+                                               :statement "a claim"}]}
+                                   {:op :attach-evidence :targets #{"goal-1"}
+                                    :links {:bogus #{"evidence-1"}}}]}))
+          after (run/step (workspace) propose)]
+      (is (= [:anomalies.deliberation/invalid-links]
+             (mapv :reason (events-of after :transaction/rejected))))
+      (is (= 1 (:workspace/version after))
+          "a rejected transaction does not advance the clock")
+      (is (= #{"goal-1"} (set (keys (:workspace/objects after))))
+          "and the create in the operation before it is discarded with the rest"))))
+
 (deftest ^{:stratum 2} a-creation-the-engine-cannot-construct-is-routed-not-thrown
   (testing "the rejection reaches the event log as a subtype, like every other"
     (let [propose (fn [{:keys [role]}]

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
@@ -297,6 +297,51 @@
                                           :creates [{:type :claim :statement "s"}]}))
                :anomaly/data :reason)))))
 
+(deftest ^{:stratum 1} a-transaction-may-not-create-two-objects-at-one-id
+  (testing "commit reduces every operation onto one accumulator, so siblings collide too"
+    (let [rejection (validate-tx
+                     (workspace)
+                     (transaction :proposer 10
+                                  {:op :assert-claim
+                                   :creates [{:id "claim-1" :type :claim
+                                              :statement "first"}]}
+                                  {:op :add-question
+                                   :creates [{:id "claim-1" :type :question
+                                              :statement "second"}]}))]
+      (is (= :anomalies.deliberation/duplicate-object-id (subtype-of rejection)))
+      (is (= ["claim-1"] (:ids (:anomaly/data rejection))))))
+  (testing "distinct ids across sibling operations are fine"
+    (is (nil? (validate-tx
+               (workspace)
+               (transaction :proposer 10
+                            {:op :assert-claim
+                             :creates [{:id "claim-1" :type :claim
+                                        :statement "first"}]}
+                            {:op :add-question
+                             :creates [{:id "question-1" :type :question
+                                        :statement "second"}]})))))
+  (testing "id-less specs in a sibling are its own fault, not a collision at nil"
+    (is (= :blank-id
+           (-> (validate-tx (workspace)
+                            (transaction :proposer 10
+                                         {:op :assert-claim
+                                          :creates [{:id "claim-1" :type :claim
+                                                     :statement "s"}]}
+                                         {:op :add-question
+                                          :creates [{:type :question :statement "a"}
+                                                    {:type :question :statement "b"}]}))
+               :anomaly/data :reason))))
+  (testing "a sibling whose :creates has no usable shape is skipped, not guessed at"
+    (is (= :malformed-creates
+           (-> (validate-tx (workspace)
+                            (transaction :proposer 10
+                                         {:op :assert-claim :creates 5}
+                                         {:op :add-question
+                                          :creates [{:id "question-1" :type :question
+                                                     :statement "s"}]}))
+               :anomaly/data :reason))
+        "the shape fault is reported rather than a collision read out of it")))
+
 (deftest ^{:stratum 1} one-operation-may-not-create-two-objects-at-one-id
   (testing "insert-created reduces, so the later spec would overwrite the earlier"
     (is (= :anomalies.deliberation/duplicate-object-id

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
@@ -219,6 +219,58 @@
                                          :creates [{:id "claim-2" :type :claim
                                                     :statement "a second claim"}]}))))))
 
+(deftest ^{:stratum 1} operation-links-the-engine-cannot-write-are-refused
+  (testing "apply-links reduces over the operation's own :links, not just a spec's"
+    (doseq [[label links] [["unknown edge type" {:bogus #{"evidence-1"}}]
+                           ["scalar destination" {:supports :evidence-1}]
+                           ["string destination" {:supports "evidence-1"}]
+                           ["non-map links" [:supports "evidence-1"]]
+                           ["links as a scalar" :supports]]]
+      (is (= :anomalies.deliberation/invalid-links
+             (subtype-of (validate-tx
+                          (workspace (object-at "claim-1" 4))
+                          (transaction :proposer 10
+                                       {:op :attach-evidence :targets #{"claim-1"}
+                                        :links links}))))
+          label))))
+
+(deftest ^{:stratum 1} an-operation-link-rejection-carries-the-reason-it-failed
+  (testing "routing reads the reason without parsing the message"
+    (doseq [[reason links] [[:unknown-link-type {:bogus #{"evidence-1"}}]
+                            [:non-collection-links {:supports :evidence-1}]
+                            [:malformed-links [:supports "evidence-1"]]]]
+      (is (= reason
+             (-> (validate-tx (workspace (object-at "claim-1" 4))
+                              (transaction :proposer 10
+                                           {:op :attach-evidence
+                                            :targets #{"claim-1"}
+                                            :links links}))
+                 :anomaly/data :reason))))))
+
+(deftest ^{:stratum 1} well-formed-operation-links-pass
+  (testing "the stage refuses malformed edges, not linking itself"
+    (is (nil? (validate-tx
+               (workspace (object-at "claim-1" 4))
+               (transaction :proposer 10
+                            {:op :attach-evidence :targets #{"claim-1"}
+                             :links {:supports #{"evidence-1"}
+                                     :contradicts ["evidence-2"]}})))))
+  (testing "an operation that declares no edges is untouched by the stage"
+    (is (nil? (validate-tx (workspace (object-at "claim-1" 4))
+                           (transaction :proposer 10
+                                        {:op :attach-evidence
+                                         :targets #{"claim-1"}}))))))
+
+(deftest ^{:stratum 1} a-malformed-payload-outranks-a-missing-target
+  (testing "both payload stages run before the three that read the object graph"
+    (is (= :anomalies.deliberation/invalid-links
+           (subtype-of (validate-tx
+                        (workspace)
+                        (transaction :proposer 10
+                                     {:op :attach-evidence :targets #{"claim-404"}
+                                      :links {:bogus #{"evidence-1"}}}))))
+        "the ids check-targets would name come out of the same unvalidated payload")))
+
 (deftest ^{:stratum 1} an-unknown-operation-outranks-a-bad-creation
   (testing "payload conformance runs after schema, so the vocabulary is reported first"
     (is (= :anomalies.deliberation/unknown-operation

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
@@ -331,6 +331,21 @@
                                           :creates [{:type :question :statement "a"}
                                                     {:type :question :statement "b"}]}))
                :anomaly/data :reason))))
+  (testing "an unconstructable sibling spec is its own fault, whichever field is wrong"
+    (let [rejection (validate-tx
+                     (workspace)
+                     (transaction :proposer 10
+                                  {:op :assert-claim
+                                   :creates [{:id "claim-1" :type :claim
+                                              :statement "s"}]}
+                                  {:op :add-question
+                                   :creates [{:id "question-1" :type :question
+                                              :statement "a" :links {:bogus #{"x"}}}
+                                             {:id "question-1" :type :question
+                                              :statement "b" :links {:bogus #{"x"}}}]}))]
+      (is (= :anomalies.deliberation/invalid-creation (subtype-of rejection)))
+      (is (= :unknown-link-type (:reason (:anomaly/data rejection)))
+          "a spec that never reaches insert-created cannot collide with anything")))
   (testing "a sibling whose :creates has no usable shape is skipped, not guessed at"
     (is (= :malformed-creates
            (-> (validate-tx (workspace)

--- a/docs/pull-requests/2026-08-29-fix-n14-stage0-operation-links.md
+++ b/docs/pull-requests/2026-08-29-fix-n14-stage0-operation-links.md
@@ -11,10 +11,10 @@ three in the validation pipeline, as anomalies routed by subtype.
 
 [#1851](https://github.com/miniforge-ai/miniforge/pull/1851) added
 `check-creates`, which reads the `:creates` payload of an operation, and
-`assert-known-targets`, which fails fast on a target commit should never see.
-It deliberately left three gaps, all of the same class: input an activation
-controls, reaching the engine as an exception or as graph corruption instead of
-as a routable rejection.
+`assert-known-targets`, which fails fast on a target that commit should never
+see. It deliberately left three gaps, all of the same class: input that an
+activation controls, reaching the engine as an exception or as graph corruption
+rather than as a routable rejection.
 
 Reproduced on 2026-08-27 and again on 2026-08-29 against `f2b0382e0`:
 

--- a/docs/pull-requests/2026-08-29-fix-n14-stage0-operation-links.md
+++ b/docs/pull-requests/2026-08-29-fix-n14-stage0-operation-links.md
@@ -1,0 +1,138 @@
+# fix: validate an operation's own `:links`, and creates across a transaction
+
+## Overview
+
+Three agent-reachable defects in `components/deliberation-workspace` cleared
+`validation/validate` and then either crashed the engine partway through
+`commit/commit` or corrupted the object graph in silence. This PR refuses all
+three in the validation pipeline, as anomalies routed by subtype.
+
+## Motivation
+
+[#1851](https://github.com/miniforge-ai/miniforge/pull/1851) added
+`check-creates`, which reads the `:creates` payload of an operation, and
+`assert-known-targets`, which fails fast on a target commit should never see.
+It deliberately left three gaps, all of the same class: input an activation
+controls, reaching the engine as an exception or as graph corruption instead of
+as a routable rejection.
+
+Reproduced on 2026-08-27 and again on 2026-08-29 against `f2b0382e0`:
+
+| Payload | Before |
+|---|---|
+| `{:op :attach-evidence :targets #{"claim-1"} :links {:bogus #{"e-1"}}}` | validates, then `IllegalArgumentException: Unknown link type: :bogus` |
+| `{:op :attach-evidence :targets #{"claim-1"} :links {:supports :e-1}}` | validates, then `IllegalArgumentException: Don't know how to create ISeq from: clojure.lang.Keyword` |
+| `{:op :attach-evidence :targets #{"claim-1"} :links [:supports "e-1"]}` | validates, then `UnsupportedOperationException: nth not supported on this type: Keyword` |
+| two sibling operations creating `"claim-1"` | validates and commits; only the second object survives |
+
+The third of the originally-listed defects — a `:creates` spec with no `:id`,
+landing in `:workspace/objects` under a nil key — is already closed. #1851's
+review rounds added the `:blank-id` reason to `creation-defect` after the gap
+list was written. Verified, not assumed: the repro now returns
+`:anomalies.deliberation/invalid-creation` with `:reason :blank-id`.
+
+## Changes in Detail
+
+### `validation.clj`
+
+1. `link-defect` (Layer 0) — the one reading of a `:links` map for both
+   writers: `object/new-object` on a `:creates` spec, and
+   `commit/apply-links` on the map an operation carries itself. Extracted
+   from `creation-defect`, which previously held the only copy. Total over
+   arbitrary EDN, `keys` on a non-map included.
+2. `check-links` (Layer 1) — a new stage applying that reading to the
+   operation's own `:links`, rejecting as
+   `:anomalies.deliberation/invalid-links` with the specific `:reason` in
+   `:anomaly/data` for routing.
+3. `check-creates` — the duplicate-id check now reads the whole transaction
+   through `:siblings` rather than this operation alone, subsuming the
+   intra-operation case rather than sitting beside it. Two filters stand in
+   front of the count: siblings whose `:creates` is not a sequence are
+   skipped, and specs the engine could not construct are dropped.
+4. `concurrency-stages` — `check-links` runs after `check-creates`, so both
+   payload stages precede the three that read the object graph.
+
+`creation-defect` and `link-defect` are siblings at Layer 0 composed by
+`check-creates`, not one calling the other: chaining them added a fourth
+layer to the namespace, which SL003 refuses.
+
+### Why the sibling-collision check, after #1851 declined it
+
+That PR left cross-operation id collisions undetected on the grounds that
+blaming one of the two operations is arbitrary. The objection does not
+survive contact:
+
+- A rejected transaction is discarded whole (§3.4), so no operation is
+  singled out for a penalty. `:op` records where the pipeline noticed; the
+  message names the transaction as what is at fault.
+- `:tx/operations` is a vector, so which operation notices is fixed by the
+  payload rather than by iteration order. `:ids` is ordered by first
+  appearance for the same reason.
+- The failure is identical to the intra-operation one the same stage already
+  refuses. `commit` reduces every operation onto one accumulator, so two
+  creates at one id overwrite each other whichever operations carry them.
+
+Counting only constructable specs was found in self-review, not by a test: a
+sibling carrying two id-less specs would otherwise collide with itself at the
+id nil and be reported as a duplicate, when the fault it will be rejected for
+on its own turn is the missing id.
+
+### Documentation
+
+The docstrings this PR touches were trimmed to the current contract per
+`documentation/documentation-discipline` (600). The arrival story — what
+threw, when, and which PR left which gap — lives in this document, which is
+where that rule puts it.
+
+## Testing Plan
+
+Run from `components/deliberation-workspace`:
+
+```bash
+clojure -M:test -e "(require 'ai.miniforge.deliberation-workspace.validation-test) (clojure.test/run-tests 'ai.miniforge.deliberation-workspace.validation-test)"
+```
+
+Added:
+
+- `operation-links-the-engine-cannot-write-are-refused` — five payload shapes,
+  including the string destination that would not have crashed at all.
+- `an-operation-link-rejection-carries-the-reason-it-failed` — `:reason` is
+  readable without parsing the message.
+- `well-formed-operation-links-pass` — the stage refuses malformed edges, not
+  linking.
+- `a-malformed-payload-outranks-a-missing-target` — stage ordering.
+- `a-transaction-may-not-create-two-objects-at-one-id` — sibling collision,
+  the id-less-sibling misroute, and the non-sequential sibling.
+- `an-edge-the-engine-cannot-write-is-routed-not-thrown` (run_test) — the
+  rejection reaches the event log as `:transaction/rejected`, and a valid
+  create in an earlier operation of the same transaction is discarded with
+  it.
+
+All 107 tests / 318 assertions in the component pass. `bb commit-budget`,
+`bb lint:clj`, `bb lint:stratum` and the pre-commit suite pass on each commit.
+
+## Deployment Plan
+
+Library change inside one component; no migration, no configuration. Ships
+with the next merge to `main`.
+
+## Related Issues/PRs
+
+- [#1851](https://github.com/miniforge-ai/miniforge/pull/1851) — the
+  `check-creates` stage and `assert-known-targets`, whose out-of-scope gaps
+  this closes.
+- [#1841](https://github.com/miniforge-ai/miniforge/pull/1841) — the Stage 0
+  run loop the routing test asserts against.
+
+## Checklist
+
+- [x] All three reported defects reproduced before the fix
+- [x] Operation-level `:links` rejected for unknown edge type, scalar
+      destination, and non-map shape
+- [x] Predicates total over arbitrary EDN — a non-map `:links` is refused,
+      not thrown on
+- [x] Rejections carry an `:anomalies.deliberation/...` subtype and route
+      through `run/step`
+- [x] Cross-operation id collisions refused, with the blame question resolved
+- [x] Component test suite green
+- [x] Docstrings held to rule 600


### PR DESCRIPTION
## Overview

Three agent-reachable defects in `components/deliberation-workspace` cleared `validation/validate` and then either crashed the engine partway through `commit/commit` or corrupted the object graph in silence. All three are refused in the validation pipeline now, as anomalies routed by subtype.

Full write-up: [`docs/pull-requests/2026-08-29-fix-n14-stage0-operation-links.md`](docs/pull-requests/2026-08-29-fix-n14-stage0-operation-links.md).

## Motivation

#1851 added `check-creates` and `assert-known-targets`, and deliberately left these gaps. Reproduced against `f2b0382e0`:

| Payload | Before |
|---|---|
| `{:op :attach-evidence :targets #{"claim-1"} :links {:bogus #{"e-1"}}}` | validates, then `IllegalArgumentException: Unknown link type: :bogus` |
| `{:op :attach-evidence :targets #{"claim-1"} :links {:supports :e-1}}` | validates, then `IllegalArgumentException: Don't know how to create ISeq from: clojure.lang.Keyword` |
| `{:op :attach-evidence :targets #{"claim-1"} :links [:supports "e-1"]}` | validates, then `UnsupportedOperationException: nth not supported on this type: Keyword` |
| two sibling operations creating `"claim-1"` | validates and commits; only the second object survives |

The originally-reported third defect — a `:creates` spec with no `:id` landing under a nil key — is **already closed**. #1851's review rounds added the `:blank-id` reason after that gap list was written. Verified rather than assumed: the repro returns `:anomalies.deliberation/invalid-creation` with `:reason :blank-id`.

## Changes

1. **`link-defect`** (Layer 0) — the one reading of a `:links` map for both writers, `object/new-object` on a `:creates` spec and `commit/apply-links` on an operation's own map. Extracted from `creation-defect`, which held the only copy. Total over arbitrary EDN, `keys` on a non-map included.
2. **`check-links`** (Layer 1) — a new stage applying it to the operation's own `:links`, rejecting as `:anomalies.deliberation/invalid-links` with the specific `:reason` in `:anomaly/data`.
3. **`check-creates`** — the duplicate-id check reads the whole transaction through `:siblings` instead of one operation, subsuming the intra-operation case. Siblings whose `:creates` is not a sequence are skipped, and specs the engine could not construct are dropped.
4. **`concurrency-stages`** — both payload stages now precede the three that read the object graph.

`creation-defect` and `link-defect` are siblings at Layer 0 composed by `check-creates`, not one calling the other: chaining them added a fourth layer, which SL003 refuses.

### On the sibling-collision check #1851 declined

The stated objection was blame — naming one of two operations is arbitrary. It does not survive contact: a rejected transaction is discarded whole (§3.4), so nothing is singled out for a penalty; `:tx/operations` is a vector, so which operation notices is fixed by the payload; and the failure is identical to the intra-operation one the same stage already refuses. Counting only constructable specs came out of self-review — a sibling with two id-less specs would otherwise collide with itself at the id `nil` and misroute as a duplicate.

## Testing

107 tests / 318 assertions in the component pass. `bb commit-budget`, `bb lint:clj`, `bb lint:stratum` and the pre-commit suite pass on each of the four commits.

New coverage: five malformed operation-`:links` shapes (including the string destination that would not have crashed at all), the routed `:reason`, well-formed links passing, stage ordering against a missing target, the sibling collision plus its two skip cases, and a `run_test` assertion that the rejection reaches the event log as `:transaction/rejected` while a valid create in an earlier operation of the same transaction is discarded with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)