### PR TITLE
feat(workflow): repair iteration for gate-denied implements

### DIFF
--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -151,6 +151,20 @@
        (when-let [test-output (:test-output verify-failures)]
          (str "\n\n" (messages/t :prompt/test-output-label) "\n" test-output))))
 
+(defn- ^{:stratum 0} format-gate-failures-section
+  "Format a prior attempt's gate denial as an imperative repair section.
+   These are DETERMINISTIC checks: the same change resubmitted unchanged
+   is denied again, so the section leads and reads as instructions."
+  [gate-failures]
+  (str "\n\n## " (messages/t :prompt/gate-failures-header) "\n\n"
+       (messages/t :prompt/gate-failures-intro) "\n\n"
+       (str/join "\n"
+                 (for [{:keys [gate errors]} gate-failures
+                       error errors]
+                   (str "- [" (name (or gate :unknown)) "] "
+                        (or (:message error) (pr-str error)))))
+       "\n"))
+
 (defn- ^{:stratum 0} format-prior-attempts-section
   "Format prior attempt context as a prominent warning section."
   [{:keys [attempt-number prior-error instruction]}]
@@ -664,10 +678,13 @@
                       phase-handoff (:task/phase-handoff task)
                       review-feedback (:task/review-feedback task)
                       verify-failures (:task/verify-failures task)
+                      gate-failures (:task/gate-failures task)
                       prior-attempts (:task/prior-attempts task)
                       parts (cond-> []
                               prior-attempts
                               (conj (format-prior-attempts-section prior-attempts))
+                              (seq gate-failures)
+                              (conj (format-gate-failures-section gate-failures))
                               phase-handoff
                               (conj (format-phase-handoff-section phase-handoff))
                               desc

--- a/components/agent/test/ai/miniforge/agent/implementer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_test.clj
@@ -376,6 +376,41 @@
               (implementer/task->text {:task/description "x"})
               "Gate denial")))))
 
+(deftest ^{:stratum 0} invoke-worktree-metadata-already-implemented-test
+  (testing "worktree metadata artifact is canonical for already-implemented outcomes"
+    (let [[logger _] (log/collecting-logger {:min-level :trace})
+          response {:success false
+                    :content "Plan submitted but no final artifact text"
+                    :tokens 7
+                    :cost-usd 0.01
+                    :error {:type "cli_error"
+                            :message "artifact file not found"}}
+          result (with-redefs [artifact-session/with-session
+                               (fn [_context body-fn]
+                                 {:llm-result (body-fn {})
+                                  :artifact nil
+                                  :worktree-artifacts {:implement {:status :already-implemented
+                                                                   :summary "found in worktree metadata"}}
+                                  :context-misses nil
+                                  :pre-session-snapshot {:untracked #{}
+                                                         :modified #{}
+                                                         :deleted #{}
+                                                         :added #{}}
+                                  :session-mode :host})
+                               budget/resolve-cost-budget-usd
+                               (fn [& _] 1.0)
+                               llm/chat
+                               (fn [& _] response)
+                               file-artifacts/collect-written-files
+                               (fn [_ _] nil)
+                               file-artifacts/collect-worktree-files
+                               (fn [_ _] nil)]
+                   (@#'implementer/invoke-with-llm
+                    nil "prompt" "system" {} {} nil logger [] {}))]
+      (is (= :already-implemented (:status result)))
+      (is (= "found in worktree metadata" (:summary result)))
+      (is (= [] (get-in result [:output :code/files]))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 ;; Invoke tests
@@ -677,40 +712,6 @@
       (is (map? (:actions summary)))
       (is (string? (:language summary)))
       (is (boolean? (:tests-needed? summary))))))
-
-(testing "worktree metadata artifact is canonical for already-implemented outcomes"
-    (let [[logger _] (log/collecting-logger {:min-level :trace})
-          response {:success false
-                    :content "Plan submitted but no final artifact text"
-                    :tokens 7
-                    :cost-usd 0.01
-                    :error {:type "cli_error"
-                            :message "artifact file not found"}}
-          result (with-redefs [artifact-session/with-session
-                               (fn [_context body-fn]
-                                 {:llm-result (body-fn {})
-                                  :artifact nil
-                                  :worktree-artifacts {:implement {:status :already-implemented
-                                                                   :summary "found in worktree metadata"}}
-                                  :context-misses nil
-                                  :pre-session-snapshot {:untracked #{}
-                                                         :modified #{}
-                                                         :deleted #{}
-                                                         :added #{}}
-                                  :session-mode :host})
-                               budget/resolve-cost-budget-usd
-                               (fn [& _] 1.0)
-                               llm/chat
-                               (fn [& _] response)
-                               file-artifacts/collect-written-files
-                               (fn [_ _] nil)
-                               file-artifacts/collect-worktree-files
-                               (fn [_ _] nil)]
-                   (@#'implementer/invoke-with-llm
-                    nil "prompt" "system" {} {} nil logger [] {}))]
-      (is (= :already-implemented (:status result)))
-      (is (= "found in worktree metadata" (:summary result)))
-      (is (= [] (get-in result [:output :code/files])))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/test/ai/miniforge/agent/implementer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.agent.implementer-test
   "Tests for the Implementer agent."
   (:require
@@ -33,9 +32,9 @@
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures
 
-(def valid-code-artifact
+;; Test fixtures
+(def ^{:stratum 0} valid-code-artifact
   {:code/id (random-uuid)
    :code/files [{:path "src/example/core.clj"
                  :content "(ns example.core)\n\n(defn hello [] \"world\")"
@@ -45,13 +44,13 @@
    :code/language "clojure"
    :code/summary "Added example core"})
 
-(def minimal-code-artifact
+(def ^{:stratum 0} minimal-code-artifact
   {:code/id (random-uuid)
    :code/files [{:path "src/minimal.clj"
                  :content "(ns minimal)"
                  :action :create}]})
 
-(defn- llm-response
+(defn- ^{:stratum 0} llm-response
   "Create a mock successful LLM response."
   [& {:keys [content tokens cost-usd tools-called]
       :or {content ""
@@ -64,7 +63,7 @@
    :cost-usd cost-usd
    :tools-called tools-called})
 
-(defn- session-map
+(defn- ^{:stratum 0} session-map
   "Create an artifact session map for tests."
   [& {:keys [pre-session-snapshot]
       :or {pre-session-snapshot {:untracked #{}
@@ -76,15 +75,13 @@
    :artifact-path "/tmp/miniforge-artifact-test/artifact.edn"
    :pre-session-snapshot pre-session-snapshot})
 
-(defn- find-log-entry
+(defn- ^{:stratum 0} find-log-entry
   "Find a specific event in collected log entries."
   [entries event]
   (some #(when (= event (:log/event %)) %) @entries))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Agent creation tests
-
-(deftest create-implementer-test
+(deftest ^{:stratum 0} create-implementer-test
   (testing "creates implementer with default config"
     (let [agent (implementer/create-implementer)]
       (is (some? agent))
@@ -102,10 +99,287 @@
           agent (implementer/create-implementer {:logger logger})]
       (is (some? (:logger agent))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Invoke tests
+;------------------------------------------------------------------------------ Layer 3b
+;; Session checkpoint — iter-24 regression
+(deftest ^{:stratum 0} session-checkpoint-is-stored-under-gitignored-directory
+  (testing "the checkpoint lives under .miniforge/, not at the worktree root"
+    ;; Iter-24 receipt: the old `.miniforge-session-id` path at the worktree
+    ;; root was committed into git, so every fresh sub-workflow worktree
+    ;; inherited a stale UUID. Passing `--resume <stale>` to Claude CLI
+    ;; killed the session in ~5s with no output. Parent `.miniforge/` is
+    ;; already gitignored in this repo, so moving the file there decouples
+    ;; the runtime checkpoint from source control automatically.
+    (let [write! @#'implementer/write-session-checkpoint!
+          read  @#'implementer/read-session-checkpoint
+          tmp   (java.io.File/createTempFile "mf-wt-" "")]
+      (.delete tmp) (.mkdirs tmp)
+      (try
+        (let [wt (.getPath tmp)]
+          (is (nil? (read wt))
+              "a fresh worktree with no checkpoint reads nil")
+          (write! wt "sess-123")
+          (is (.exists (io/file wt ".miniforge" "session-id"))
+              "the checkpoint MUST be written under .miniforge/ (gitignored)")
+          (is (not (.exists (io/file wt ".miniforge-session-id")))
+              "the legacy root path MUST NOT be used — it gets committed")
+          (is (= "sess-123" (read wt))
+              "round-trip: write then read returns the session id"))
+        (finally
+          (io/delete-file
+            (io/file tmp ".miniforge" "session-id") true)
+          (io/delete-file
+            (io/file tmp ".miniforge") true)
+          (.delete tmp))))))
 
-(deftest implementer-invoke-test
+(deftest ^{:stratum 0} read-session-checkpoint-tolerates-garbage
+  (testing "blank content and read errors produce nil, not a bad --resume id"
+    (let [write! @#'implementer/write-session-checkpoint!
+          read  @#'implementer/read-session-checkpoint
+          tmp   (java.io.File/createTempFile "mf-wt-" "")]
+      (.delete tmp) (.mkdirs tmp)
+      (try
+        (write! (.getPath tmp) "   \n  ")
+        (is (nil? (read (.getPath tmp)))
+            "blank/whitespace content must read as nil — never fed to --resume")
+        (finally
+          (io/delete-file
+            (io/file tmp ".miniforge" "session-id") true)
+          (io/delete-file
+            (io/file tmp ".miniforge") true)
+          (.delete tmp))))))
+
+(deftest ^{:stratum 0} base-ref-candidates-avoid-ambiguous-branch-names
+  (testing "bare branch names are not used as diff bases"
+    (let [candidates (@#'implementer/base-ref-candidates
+                      {:execution/environment-metadata {:base-sha "abc123"
+                                                        :base-branch "main"}})]
+      (is (= ["abc123"
+              "refs/remotes/origin/main"
+              "origin/main"
+              "refs/heads/main"]
+             candidates))
+      (is (not (contains? (set candidates) "main"))))))
+
+(deftest ^{:stratum 0} base-ref-candidates-use-resume-merge-base-ranges
+  (testing "resumed workspaces compare the original spec base to restored HEAD"
+    (let [candidates (@#'implementer/base-ref-candidates
+                      {:execution/environment-metadata {:base-sha "task-sha"
+                                                        :base-branch "task-restored"}
+                       :execution/opts {:resume-workspace {:branch "task-restored"}}
+                       :execution/input {:context {:git-commit "spec-sha"
+                                                   :git-branch "dogfood/source"}}})]
+      (is (= ["spec-sha...HEAD"
+              "refs/remotes/origin/dogfood/source...HEAD"
+              "origin/dogfood/source...HEAD"
+              "refs/heads/dogfood/source...HEAD"
+              "task-sha"
+              "refs/remotes/origin/task-restored"
+              "origin/task-restored"
+              "refs/heads/task-restored"]
+             candidates)))))
+
+(deftest ^{:stratum 0} files-by-action-test
+  (testing "groups files by action"
+    (let [artifact {:code/files [{:path "a.clj" :content "" :action :create}
+                                 {:path "b.clj" :content "" :action :modify}
+                                 {:path "c.clj" :content "" :action :create}]}
+          grouped (implementer/files-by-action artifact)]
+      (is (= 2 (count (:create grouped))))
+      (is (= 1 (count (:modify grouped)))))))
+
+(deftest ^{:stratum 0} total-lines-test
+  (testing "counts total lines of code"
+    (let [artifact {:code/files [{:path "a.clj"
+                                  :content "line1\nline2\nline3"
+                                  :action :create}
+                                 {:path "b.clj"
+                                  :content "line1\nline2"
+                                  :action :modify}]}
+          lines (implementer/total-lines artifact)]
+      (is (= 5 lines))))
+
+  (testing "excludes deleted files from count"
+    (let [artifact {:code/files [{:path "a.clj"
+                                  :content "line1\nline2"
+                                  :action :create}
+                                 {:path "b.clj"
+                                  :content "should not count"
+                                  :action :delete}]}
+          lines (implementer/total-lines artifact)]
+      (is (= 2 lines)))))
+
+;; task->text tests
+(deftest ^{:stratum 0} task->text-basic-test
+  (testing "string task passes through"
+    (is (= "hello" (implementer/task->text "hello"))))
+
+  (testing "map task uses :task/description"
+    (is (= "Implement login"
+           (implementer/task->text {:task/description "Implement login"}))))
+
+  (testing "includes plan when present"
+    (let [text (implementer/task->text {:task/description "Do thing"
+                                        :task/plan "Step 1: foo\nStep 2: bar"})]
+      (is (str/includes? text "Do thing"))
+      (is (str/includes? text "## Plan"))
+      (is (str/includes? text "Step 1: foo"))))
+
+  (testing "includes intent when present"
+    (let [text (implementer/task->text {:task/description "Do thing"
+                                        :task/intent {:scope ["src/core.clj"]}})]
+      (is (str/includes? text "## Intent"))
+      (is (str/includes? text "src/core.clj")))))
+
+(deftest ^{:stratum 0} task->text-review-feedback-test
+  (testing "includes review feedback as string"
+    (let [text (implementer/task->text {:task/description "Fix it"
+                                        :task/review-feedback "Missing error handling in login"})]
+      (is (str/includes? text "## Review Feedback (MUST FIX)"))
+      (is (str/includes? text "Missing error handling in login"))))
+
+  (testing "includes review feedback as map"
+    (let [text (implementer/task->text {:task/description "Fix it"
+                                        :task/review-feedback {:issues ["no validation" "no tests"]}})]
+      (is (str/includes? text "## Review Feedback (MUST FIX)"))
+      (is (str/includes? text "no validation")))))
+
+(deftest ^{:stratum 0} task->text-phase-handoff-test
+  (testing "includes phase handoff before review feedback"
+    (let [phase-handoff-header (str "## " (messages/t :prompt/phase-handoff-header))
+          review-feedback-header (str "## " (messages/t :prompt/review-feedback-header))
+          missing-group-summary "GROUP 3 missing"
+          missing-group-id "GROUP 3"
+          fallback-feedback "Fallback feedback"
+          task-description "Fix it"
+          handoff {:frame/kind :repair-request
+                   :frame/body {:repair/findings
+                                [{:finding/summary missing-group-summary
+                                  :finding/group-id missing-group-id
+                                  :finding/severity :blocking}]}}
+          text (implementer/task->text {:task/description task-description
+                                        :task/phase-handoff handoff
+                                        :task/review-feedback fallback-feedback})]
+      (is (str/includes? text phase-handoff-header))
+      (is (str/includes? text missing-group-summary))
+      (is (str/includes? text (messages/t :prompt/phase-handoff-group-label)))
+      (is (not (str/includes? text ":frame/kind")))
+      (is (< (str/index-of text phase-handoff-header)
+             (str/index-of text review-feedback-header))))))
+
+(deftest ^{:stratum 0} task->text-verify-failures-test
+  (testing "includes verify failures with test-results"
+    (let [text (implementer/task->text
+                 {:task/description "Fix failing tests"
+                  :task/verify-failures
+                  {:test-results {:passed? false
+                                  :test-count 5
+                                  :fail-count 2
+                                  :error-count 0}
+                   :test-output "FAIL in (login-test)\nexpected: 200\n  actual: 401"}})]
+      (is (str/includes? text "## Test Failures (MUST FIX)"))
+      (is (str/includes? text "Test results:"))
+      (is (str/includes? text ":fail-count 2"))
+      (is (str/includes? text "FAIL in (login-test)"))
+      (is (str/includes? text "expected: 200"))))
+
+  (testing "includes verify failures without test-results"
+    (let [text (implementer/task->text
+                 {:task/description "Fix it"
+                  :task/verify-failures
+                  {:error "Verification timed out"}})]
+      (is (str/includes? text "## Test Failures (MUST FIX)"))
+      (is (str/includes? text "Verify failure details:"))
+      (is (str/includes? text "Verification timed out"))))
+
+  (testing "includes both review feedback and verify failures"
+    (let [text (implementer/task->text
+                 {:task/description "Fix everything"
+                  :task/review-feedback "Add input validation"
+                  :task/verify-failures
+                  {:test-results {:passed? false :fail-count 1}}})]
+      (is (str/includes? text "## Review Feedback (MUST FIX)"))
+      (is (str/includes? text "Add input validation"))
+      (is (str/includes? text "## Test Failures (MUST FIX)"))
+      (is (str/includes? text ":fail-count 1"))))
+
+  (testing "no verify section when verify-failures is nil"
+    (let [text (implementer/task->text {:task/description "Normal task"})]
+      (is (not (str/includes? text "Test Failures"))))))
+
+;; Repair tests
+(deftest ^{:stratum 0} implementer-repair-test
+  (testing "repairs missing ID"
+    (let [agent (implementer/create-implementer)
+          bad-artifact {:code/files [{:path "src/test.clj"
+                                      :content "(ns test)"
+                                      :action :create}]}
+          result (core/repair agent bad-artifact {:code/id ["required"]} {})]
+      (is (response/success? result))
+      (is (uuid? (get-in result [:output :code/id])))))
+
+  (testing "adds content to empty :create files"
+    (let [agent (implementer/create-implementer)
+          bad-artifact {:code/id (random-uuid)
+                        :code/files [{:path "src/empty.clj"
+                                      :content ""
+                                      :action :create}]}
+          result (core/repair agent bad-artifact {:files ["empty content"]} {})]
+      (is (response/success? result))
+      (is (seq (get-in result [:output :code/files 0 :content])))
+      (is (:valid? (implementer/validate-code-artifact (:output result)))))))
+
+;; Full cycle tests
+(deftest ^{:stratum 0} implementer-cycle-test
+  (testing "full invoke-validate cycle fails without LLM (no silent fallback)"
+    (let [agent (implementer/create-implementer)
+          result (core/cycle-agent agent {} {:task/description "Create a helper function"
+                                              :task/type :implement})]
+      (is (= :error (:status result))))))
+
+;; Tool-disallow-list — role-scoped restriction forcing the implementer onto
+;; the MCP context cache (Fable #4 context side). Mirrors planner/tester.
+(deftest ^{:stratum 0} implementer-disallowed-tools-contents-test
+  (testing "names the native read/search tools (forced onto context_*)"
+    (let [dt @#'implementer/implementer-disallowed-tools]
+      (doseq [t ["Read" "Grep" "Glob" "LS" "Agent"]]
+        (is (some #{t} dt) (str "expected " t " in disallowed-tools")))))
+
+  (testing "does NOT include the write tools — the implementer's whole job"
+    (let [dt @#'implementer/implementer-disallowed-tools]
+      (doseq [t ["Write" "Edit" "MultiEdit"]]
+        (is (nil? (some #{t} dt)) (str t " must stay allowed")))))
+
+  (testing "does NOT include the MCP context tools"
+    (let [dt @#'implementer/implementer-disallowed-tools]
+      (doseq [t ["context_read" "context_grep" "context_glob"]]
+        (is (nil? (some #{t} dt)) (str "MCP tool " t " must NOT be disallowed")))))
+
+  (testing "does NOT (yet) include Bash — kept for build/git; tighten if dogfood
+            shows cat/rg-via-Bash cache evasion"
+    (is (nil? (some #{"Bash"} @#'implementer/implementer-disallowed-tools)))))
+
+(deftest ^{:stratum 0} task->text-gate-failures-test
+  (testing "a prior gate denial renders as an imperative repair section,
+            one line per error, gate-tagged"
+    (let [text (implementer/task->text
+                {:task/description "Rename the key"
+                 :task/gate-failures
+                 [{:gate :stale-references
+                   :errors [{:message "':skipped' was removed by this change but is still referenced by: bb.edn"}
+                            {:message "'read-ledger' was removed by this change but is still referenced by: tasks/report.clj"}]}]})]
+      (is (str/includes? text "Gate denial"))
+      (is (str/includes? text "[stale-references] ':skipped'"))
+      (is (str/includes? text "tasks/report.clj"))
+      (is (str/includes? text "DENIED by deterministic gates"))))
+  (testing "absent gate failures render nothing"
+    (is (not (str/includes?
+              (implementer/task->text {:task/description "x"})
+              "Gate denial")))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Invoke tests
+(deftest ^{:stratum 1} implementer-invoke-test
   (testing "fails explicitly without LLM backend (no silent fallback)"
     (let [agent (implementer/create-implementer)
           result (core/invoke agent
@@ -359,44 +633,8 @@
       (is (= "done" (:summary result)))
       (is (= [] (get-in result [:output :code/files]))))))
 
-  (testing "worktree metadata artifact is canonical for already-implemented outcomes"
-    (let [[logger _] (log/collecting-logger {:min-level :trace})
-          response {:success false
-                    :content "Plan submitted but no final artifact text"
-                    :tokens 7
-                    :cost-usd 0.01
-                    :error {:type "cli_error"
-                            :message "artifact file not found"}}
-          result (with-redefs [artifact-session/with-session
-                               (fn [_context body-fn]
-                                 {:llm-result (body-fn {})
-                                  :artifact nil
-                                  :worktree-artifacts {:implement {:status :already-implemented
-                                                                   :summary "found in worktree metadata"}}
-                                  :context-misses nil
-                                  :pre-session-snapshot {:untracked #{}
-                                                         :modified #{}
-                                                         :deleted #{}
-                                                         :added #{}}
-                                  :session-mode :host})
-                               budget/resolve-cost-budget-usd
-                               (fn [& _] 1.0)
-                               llm/chat
-                               (fn [& _] response)
-                               file-artifacts/collect-written-files
-                               (fn [_ _] nil)
-                               file-artifacts/collect-worktree-files
-                               (fn [_ _] nil)]
-                   (@#'implementer/invoke-with-llm
-                    nil "prompt" "system" {} {} nil logger [] {}))]
-      (is (= :already-implemented (:status result)))
-      (is (= "found in worktree metadata" (:summary result)))
-      (is (= [] (get-in result [:output :code/files])))))
-
-;------------------------------------------------------------------------------ Layer 3
 ;; Validation tests
-
-(deftest validate-code-artifact-test
+(deftest ^{:stratum 1} validate-code-artifact-test
   (testing "valid artifact passes validation"
     (let [result (implementer/validate-code-artifact valid-code-artifact)]
       (is (:valid? result))
@@ -430,90 +668,8 @@
           result (implementer/validate-code-artifact bad-artifact)]
       (is (not (:valid? result))))))
 
-;------------------------------------------------------------------------------ Layer 3b
-;; Session checkpoint — iter-24 regression
-
-(deftest session-checkpoint-is-stored-under-gitignored-directory
-  (testing "the checkpoint lives under .miniforge/, not at the worktree root"
-    ;; Iter-24 receipt: the old `.miniforge-session-id` path at the worktree
-    ;; root was committed into git, so every fresh sub-workflow worktree
-    ;; inherited a stale UUID. Passing `--resume <stale>` to Claude CLI
-    ;; killed the session in ~5s with no output. Parent `.miniforge/` is
-    ;; already gitignored in this repo, so moving the file there decouples
-    ;; the runtime checkpoint from source control automatically.
-    (let [write! @#'implementer/write-session-checkpoint!
-          read  @#'implementer/read-session-checkpoint
-          tmp   (java.io.File/createTempFile "mf-wt-" "")]
-      (.delete tmp) (.mkdirs tmp)
-      (try
-        (let [wt (.getPath tmp)]
-          (is (nil? (read wt))
-              "a fresh worktree with no checkpoint reads nil")
-          (write! wt "sess-123")
-          (is (.exists (io/file wt ".miniforge" "session-id"))
-              "the checkpoint MUST be written under .miniforge/ (gitignored)")
-          (is (not (.exists (io/file wt ".miniforge-session-id")))
-              "the legacy root path MUST NOT be used — it gets committed")
-          (is (= "sess-123" (read wt))
-              "round-trip: write then read returns the session id"))
-        (finally
-          (io/delete-file
-            (io/file tmp ".miniforge" "session-id") true)
-          (io/delete-file
-            (io/file tmp ".miniforge") true)
-          (.delete tmp))))))
-
-(deftest read-session-checkpoint-tolerates-garbage
-  (testing "blank content and read errors produce nil, not a bad --resume id"
-    (let [write! @#'implementer/write-session-checkpoint!
-          read  @#'implementer/read-session-checkpoint
-          tmp   (java.io.File/createTempFile "mf-wt-" "")]
-      (.delete tmp) (.mkdirs tmp)
-      (try
-        (write! (.getPath tmp) "   \n  ")
-        (is (nil? (read (.getPath tmp)))
-            "blank/whitespace content must read as nil — never fed to --resume")
-        (finally
-          (io/delete-file
-            (io/file tmp ".miniforge" "session-id") true)
-          (io/delete-file
-            (io/file tmp ".miniforge") true)
-          (.delete tmp))))))
-
-(deftest base-ref-candidates-avoid-ambiguous-branch-names
-  (testing "bare branch names are not used as diff bases"
-    (let [candidates (@#'implementer/base-ref-candidates
-                      {:execution/environment-metadata {:base-sha "abc123"
-                                                        :base-branch "main"}})]
-      (is (= ["abc123"
-              "refs/remotes/origin/main"
-              "origin/main"
-              "refs/heads/main"]
-             candidates))
-      (is (not (contains? (set candidates) "main"))))))
-
-(deftest base-ref-candidates-use-resume-merge-base-ranges
-  (testing "resumed workspaces compare the original spec base to restored HEAD"
-    (let [candidates (@#'implementer/base-ref-candidates
-                      {:execution/environment-metadata {:base-sha "task-sha"
-                                                        :base-branch "task-restored"}
-                       :execution/opts {:resume-workspace {:branch "task-restored"}}
-                       :execution/input {:context {:git-commit "spec-sha"
-                                                   :git-branch "dogfood/source"}}})]
-      (is (= ["spec-sha...HEAD"
-              "refs/remotes/origin/dogfood/source...HEAD"
-              "origin/dogfood/source...HEAD"
-              "refs/heads/dogfood/source...HEAD"
-              "task-sha"
-              "refs/remotes/origin/task-restored"
-              "origin/task-restored"
-              "refs/heads/task-restored"]
-             candidates)))))
-
-;------------------------------------------------------------------------------ Layer 4
 ;; Utility tests
-
-(deftest code-summary-test
+(deftest ^{:stratum 1} code-summary-test
   (testing "returns code summary"
     (let [summary (implementer/code-summary valid-code-artifact)]
       (is (uuid? (:id summary)))
@@ -522,192 +678,39 @@
       (is (string? (:language summary)))
       (is (boolean? (:tests-needed? summary))))))
 
-(deftest files-by-action-test
-  (testing "groups files by action"
-    (let [artifact {:code/files [{:path "a.clj" :content "" :action :create}
-                                 {:path "b.clj" :content "" :action :modify}
-                                 {:path "c.clj" :content "" :action :create}]}
-          grouped (implementer/files-by-action artifact)]
-      (is (= 2 (count (:create grouped))))
-      (is (= 1 (count (:modify grouped)))))))
-
-(deftest total-lines-test
-  (testing "counts total lines of code"
-    (let [artifact {:code/files [{:path "a.clj"
-                                  :content "line1\nline2\nline3"
-                                  :action :create}
-                                 {:path "b.clj"
-                                  :content "line1\nline2"
-                                  :action :modify}]}
-          lines (implementer/total-lines artifact)]
-      (is (= 5 lines))))
-
-  (testing "excludes deleted files from count"
-    (let [artifact {:code/files [{:path "a.clj"
-                                  :content "line1\nline2"
-                                  :action :create}
-                                 {:path "b.clj"
-                                  :content "should not count"
-                                  :action :delete}]}
-          lines (implementer/total-lines artifact)]
-      (is (= 2 lines)))))
-
-;------------------------------------------------------------------------------ Layer 5
-;; task->text tests
-
-(deftest task->text-basic-test
-  (testing "string task passes through"
-    (is (= "hello" (implementer/task->text "hello"))))
-
-  (testing "map task uses :task/description"
-    (is (= "Implement login"
-           (implementer/task->text {:task/description "Implement login"}))))
-
-  (testing "includes plan when present"
-    (let [text (implementer/task->text {:task/description "Do thing"
-                                        :task/plan "Step 1: foo\nStep 2: bar"})]
-      (is (str/includes? text "Do thing"))
-      (is (str/includes? text "## Plan"))
-      (is (str/includes? text "Step 1: foo"))))
-
-  (testing "includes intent when present"
-    (let [text (implementer/task->text {:task/description "Do thing"
-                                        :task/intent {:scope ["src/core.clj"]}})]
-      (is (str/includes? text "## Intent"))
-      (is (str/includes? text "src/core.clj")))))
-
-(deftest task->text-review-feedback-test
-  (testing "includes review feedback as string"
-    (let [text (implementer/task->text {:task/description "Fix it"
-                                        :task/review-feedback "Missing error handling in login"})]
-      (is (str/includes? text "## Review Feedback (MUST FIX)"))
-      (is (str/includes? text "Missing error handling in login"))))
-
-  (testing "includes review feedback as map"
-    (let [text (implementer/task->text {:task/description "Fix it"
-                                        :task/review-feedback {:issues ["no validation" "no tests"]}})]
-      (is (str/includes? text "## Review Feedback (MUST FIX)"))
-      (is (str/includes? text "no validation")))))
-
-(deftest task->text-phase-handoff-test
-  (testing "includes phase handoff before review feedback"
-    (let [phase-handoff-header (str "## " (messages/t :prompt/phase-handoff-header))
-          review-feedback-header (str "## " (messages/t :prompt/review-feedback-header))
-          missing-group-summary "GROUP 3 missing"
-          missing-group-id "GROUP 3"
-          fallback-feedback "Fallback feedback"
-          task-description "Fix it"
-          handoff {:frame/kind :repair-request
-                   :frame/body {:repair/findings
-                                [{:finding/summary missing-group-summary
-                                  :finding/group-id missing-group-id
-                                  :finding/severity :blocking}]}}
-          text (implementer/task->text {:task/description task-description
-                                        :task/phase-handoff handoff
-                                        :task/review-feedback fallback-feedback})]
-      (is (str/includes? text phase-handoff-header))
-      (is (str/includes? text missing-group-summary))
-      (is (str/includes? text (messages/t :prompt/phase-handoff-group-label)))
-      (is (not (str/includes? text ":frame/kind")))
-      (is (< (str/index-of text phase-handoff-header)
-             (str/index-of text review-feedback-header))))))
-
-(deftest task->text-verify-failures-test
-  (testing "includes verify failures with test-results"
-    (let [text (implementer/task->text
-                 {:task/description "Fix failing tests"
-                  :task/verify-failures
-                  {:test-results {:passed? false
-                                  :test-count 5
-                                  :fail-count 2
-                                  :error-count 0}
-                   :test-output "FAIL in (login-test)\nexpected: 200\n  actual: 401"}})]
-      (is (str/includes? text "## Test Failures (MUST FIX)"))
-      (is (str/includes? text "Test results:"))
-      (is (str/includes? text ":fail-count 2"))
-      (is (str/includes? text "FAIL in (login-test)"))
-      (is (str/includes? text "expected: 200"))))
-
-  (testing "includes verify failures without test-results"
-    (let [text (implementer/task->text
-                 {:task/description "Fix it"
-                  :task/verify-failures
-                  {:error "Verification timed out"}})]
-      (is (str/includes? text "## Test Failures (MUST FIX)"))
-      (is (str/includes? text "Verify failure details:"))
-      (is (str/includes? text "Verification timed out"))))
-
-  (testing "includes both review feedback and verify failures"
-    (let [text (implementer/task->text
-                 {:task/description "Fix everything"
-                  :task/review-feedback "Add input validation"
-                  :task/verify-failures
-                  {:test-results {:passed? false :fail-count 1}}})]
-      (is (str/includes? text "## Review Feedback (MUST FIX)"))
-      (is (str/includes? text "Add input validation"))
-      (is (str/includes? text "## Test Failures (MUST FIX)"))
-      (is (str/includes? text ":fail-count 1"))))
-
-  (testing "no verify section when verify-failures is nil"
-    (let [text (implementer/task->text {:task/description "Normal task"})]
-      (is (not (str/includes? text "Test Failures"))))))
-
-;------------------------------------------------------------------------------ Layer 6
-;; Repair tests
-
-(deftest implementer-repair-test
-  (testing "repairs missing ID"
-    (let [agent (implementer/create-implementer)
-          bad-artifact {:code/files [{:path "src/test.clj"
-                                      :content "(ns test)"
-                                      :action :create}]}
-          result (core/repair agent bad-artifact {:code/id ["required"]} {})]
-      (is (response/success? result))
-      (is (uuid? (get-in result [:output :code/id])))))
-
-  (testing "adds content to empty :create files"
-    (let [agent (implementer/create-implementer)
-          bad-artifact {:code/id (random-uuid)
-                        :code/files [{:path "src/empty.clj"
-                                      :content ""
-                                      :action :create}]}
-          result (core/repair agent bad-artifact {:files ["empty content"]} {})]
-      (is (response/success? result))
-      (is (seq (get-in result [:output :code/files 0 :content])))
-      (is (:valid? (implementer/validate-code-artifact (:output result)))))))
-
-;------------------------------------------------------------------------------ Layer 6
-;; Full cycle tests
-
-(deftest implementer-cycle-test
-  (testing "full invoke-validate cycle fails without LLM (no silent fallback)"
-    (let [agent (implementer/create-implementer)
-          result (core/cycle-agent agent {} {:task/description "Create a helper function"
-                                              :task/type :implement})]
-      (is (= :error (:status result))))))
-
-;; Tool-disallow-list — role-scoped restriction forcing the implementer onto
-;; the MCP context cache (Fable #4 context side). Mirrors planner/tester.
-
-(deftest implementer-disallowed-tools-contents-test
-  (testing "names the native read/search tools (forced onto context_*)"
-    (let [dt @#'implementer/implementer-disallowed-tools]
-      (doseq [t ["Read" "Grep" "Glob" "LS" "Agent"]]
-        (is (some #{t} dt) (str "expected " t " in disallowed-tools")))))
-
-  (testing "does NOT include the write tools — the implementer's whole job"
-    (let [dt @#'implementer/implementer-disallowed-tools]
-      (doseq [t ["Write" "Edit" "MultiEdit"]]
-        (is (nil? (some #{t} dt)) (str t " must stay allowed")))))
-
-  (testing "does NOT include the MCP context tools"
-    (let [dt @#'implementer/implementer-disallowed-tools]
-      (doseq [t ["context_read" "context_grep" "context_glob"]]
-        (is (nil? (some #{t} dt)) (str "MCP tool " t " must NOT be disallowed")))))
-
-  (testing "does NOT (yet) include Bash — kept for build/git; tighten if dogfood
-            shows cat/rg-via-Bash cache evasion"
-    (is (nil? (some #{"Bash"} @#'implementer/implementer-disallowed-tools)))))
+(testing "worktree metadata artifact is canonical for already-implemented outcomes"
+    (let [[logger _] (log/collecting-logger {:min-level :trace})
+          response {:success false
+                    :content "Plan submitted but no final artifact text"
+                    :tokens 7
+                    :cost-usd 0.01
+                    :error {:type "cli_error"
+                            :message "artifact file not found"}}
+          result (with-redefs [artifact-session/with-session
+                               (fn [_context body-fn]
+                                 {:llm-result (body-fn {})
+                                  :artifact nil
+                                  :worktree-artifacts {:implement {:status :already-implemented
+                                                                   :summary "found in worktree metadata"}}
+                                  :context-misses nil
+                                  :pre-session-snapshot {:untracked #{}
+                                                         :modified #{}
+                                                         :deleted #{}
+                                                         :added #{}}
+                                  :session-mode :host})
+                               budget/resolve-cost-budget-usd
+                               (fn [& _] 1.0)
+                               llm/chat
+                               (fn [& _] response)
+                               file-artifacts/collect-written-files
+                               (fn [_ _] nil)
+                               file-artifacts/collect-worktree-files
+                               (fn [_ _] nil)]
+                   (@#'implementer/invoke-with-llm
+                    nil "prompt" "system" {} {} nil logger [] {}))]
+      (is (= :already-implemented (:status result)))
+      (is (= "found in worktree metadata" (:summary result)))
+      (is (= [] (get-in result [:output :code/files])))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/gate/src/ai/miniforge/gate/decide.clj
+++ b/components/gate/src/ai/miniforge/gate/decide.clj
@@ -51,14 +51,20 @@
   [envelope]
   (not= :deny (:envelope/decision envelope)))
 
-(defn- ^{:stratum 0} mechanical-failure-reason
+(defn- ^{:stratum 0} mechanical-failure-reasons
+  "One Reason PER ERROR, not per gate — a gate that found five stale
+   references used to surface only the first, and a repair loop cannot
+   fix what the record never named."
   [result]
   (let [gate (name (get result :gate :unknown))
-        error (first (:errors result))
-        detail (or (:message error) (msg/system-t :decide/check-failed))]
-    (reason/create :reason/gate-check-failed
-                   (msg/system-t :decide/gate-failed
-                                 {:gate gate :message detail}))))
+        errors (or (seq (:errors result)) [nil])]
+    (mapv (fn [error]
+            (reason/create :reason/gate-check-failed
+                          (msg/system-t :decide/gate-failed
+                                        {:gate gate
+                                         :message (or (:message error)
+                                                      (msg/system-t :decide/check-failed))})))
+          errors)))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -99,7 +105,7 @@
                   :pins/event-watermark nil})]
     (env/envelope
      (concat (mapcat :envelope/reasons gate-envs)
-             (map mechanical-failure-reason mech-failures)
+             (mapcat mechanical-failure-reasons mech-failures)
              (when artifact-nil? [(missing-artifact-reason)]))
      (mapcat :envelope/obligations gate-envs)
      pins)))

--- a/components/gate/test/ai/miniforge/gate/decide_test.clj
+++ b/components/gate/test/ai/miniforge/gate/decide_test.clj
@@ -191,6 +191,21 @@
       (is (= [:reason/rule-violation]
              (mapv :reason/code (:envelope/reasons phase-env))))
       (is (= "test@1" (get-in phase-env [:envelope/pins :pins/pack-revision])))))
+  (testing "a mechanical gate with several errors contributes one Reason
+            PER ERROR — a repair loop cannot fix what the record never
+            named (first-error-only was the old collapse)"
+    (let [phase-env (decide/gates->envelope
+                     {:results [{:passed? false :gate :stale-references
+                                 :errors [{:message "':skipped' still referenced by: bb.edn"}
+                                          {:message "'read-ledger' still referenced by: tasks/x.clj"}]}]}
+                     false)]
+      (is (= 2 (count (:envelope/reasons phase-env))))
+      (is (every? #(= :reason/gate-check-failed (:reason/code %))
+                  (:envelope/reasons phase-env)))
+      (is (some #(clojure.string/includes? (:reason/detail %) ":skipped")
+                (:envelope/reasons phase-env)))
+      (is (some #(clojure.string/includes? (:reason/detail %) "read-ledger")
+                (:envelope/reasons phase-env)))))
   (testing "a mechanical failure contributes :reason/gate-check-failed"
     (let [phase-env (decide/gates->envelope
                      {:results [{:passed? false :gate :lint

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -504,6 +504,13 @@
                             :implement {:task {:task/intent (:intent input)}})
         review-feedback (resolve-review-feedback ctx)
         phase-handoff (resolve-phase-handoff ctx)
+        ;; A prior implement attempt DENIED by gates: its structured gate
+        ;; errors ride :execution/phase-results (the [:phase ...] channel
+        ;; is cleared before every step). This is what turns a gate from
+        ;; a wall into a repair instruction — deny, retry with the
+        ;; evidence, fix, pass.
+        gate-failures (seq (get-in ctx [:execution/phase-results
+                                        :implement :phase/gate-failures]))
         {:keys [formatted manifest]} (kb-helpers/inject-with-manifest
                                        (:knowledge-store ctx) :implementer (get input :tags []))
         base-task (assoc-optional-task-fields
@@ -522,6 +529,8 @@
         task (cond-> base-task
                verify-failure
                (assoc :task/verify-failures (build-verify-failures verify-failure))
+               gate-failures
+               (assoc :task/gate-failures (vec gate-failures))
                review-feedback
                (assoc :task/review-feedback review-feedback)
                phase-handoff

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -1008,6 +1008,21 @@
         (is (true? (get-in final-result [:phase :error :rate-limited?]))
             "rate-limit classifier reads through the normalized shape")))))
 
+(deftest ^{:stratum 2} build-implement-task-threads-gate-failures-test
+  (testing "a prior denied attempt's structured gate errors reach the new
+            task via :execution/phase-results (the [:phase ...] channel is
+            cleared every step and must not be relied on)"
+    (let [failures [{:gate :stale-references
+                     :errors [{:message "':skipped' still referenced by: bb.edn"}]}]
+          ctx (-> (create-base-context)
+                  (assoc-in [:execution/phase-results :implement :phase/gate-failures]
+                            failures))
+          {:keys [task]} (implement/build-implement-task ctx)]
+      (is (= failures (:task/gate-failures task)))))
+  (testing "no prior denial -> key absent"
+    (let [{:keys [task]} (implement/build-implement-task (create-base-context))]
+      (is (not (contains? task :task/gate-failures))))))
+
 (use-fixtures :each
   (fn [f]
     (phase/reset-phase-loader!)

--- a/components/repo-index/resources/config/repo-index/messages/en-US.edn
+++ b/components/repo-index/resources/config/repo-index/messages/en-US.edn
@@ -24,7 +24,7 @@
   "Gate denial — fix before resubmitting"
 
   :prompt/gate-failures-intro
-  "Your previous attempt was DENIED by deterministic gates. The same change resubmitted unchanged will be denied again. Fix every item below (grep the whole repo when a stale reference is named), then resubmit:"
+  "Your previous attempt was DENIED by deterministic gates. The same change resubmitted unchanged will be denied again. Fix every item below (search the whole repo when a stale reference is named), then resubmit:"
 
   ;; task->text section headers
   :prompt/plan-header             "Plan"

--- a/components/repo-index/resources/config/repo-index/messages/en-US.edn
+++ b/components/repo-index/resources/config/repo-index/messages/en-US.edn
@@ -19,6 +19,13 @@
   :prompt/already-impl-template
   "```clojure\n{:status :already-implemented\n :summary \"Brief explanation of why no changes are needed\"}\n```"
 
+  ;; Implementer prompt — prior attempt denied by deterministic gates
+  :prompt/gate-failures-header
+  "Gate denial — fix before resubmitting"
+
+  :prompt/gate-failures-intro
+  "Your previous attempt was DENIED by deterministic gates. The same change resubmitted unchanged will be denied again. Fix every item below (grep the whole repo when a stale reference is named), then resubmit:"
+
   ;; task->text section headers
   :prompt/plan-header             "Plan"
   :prompt/intent-header           "Intent"

--- a/components/workflow-software-factory/resources/workflows/canonical-sdlc-v2.0.0.edn
+++ b/components/workflow-software-factory/resources/workflows/canonical-sdlc-v2.0.0.edn
@@ -35,6 +35,11 @@
   {:phase :plan}
   {:phase :implement
    :gates [:syntax :lint :no-secrets]
+   ;; Self-repair on failure: a gate-denied implement re-enters with the
+   ;; denial's structured errors in its prompt instead of dying
+   ;; :exhausted. Bounded by max-consecutive-phase-retries (3) before
+   ;; max-redirects (5) — a self-redirect never changes the active phase.
+   :on-fail :implement
    :budget {:tokens 50000}}
   {:phase :verify
    :on-fail :implement}

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -37,7 +37,7 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;------------------------------------------------------------------------------ Layer 0: Atomic operations
+;; Atomic operations
 (defn- ^{:stratum 0} enter-error-record
   "Build the canonical entry recorded against `:execution/errors` for a
    phase-enter exception. Used uniformly whether or not the interceptor
@@ -476,7 +476,15 @@
                    :phase/decision-envelope envelope
                    :phase/gate-errors (if envelope
                                         (vec (:envelope/reasons envelope))
-                                        (vec (:failed-gates gate-result))))))
+                                        (vec (:failed-gates gate-result)))
+                   ;; The envelope's Reasons are schema-bound strings; the
+                   ;; repair loop needs the gates' STRUCTURED errors (which
+                   ;; gate, which token, which files). This rides the phase
+                   ;; result into :execution/phase-results, the one channel
+                   ;; a redirect re-entry can still read.
+                   :phase/gate-failures (->> (:results gate-result)
+                                             (remove :passed?)
+                                             (mapv #(select-keys % [:gate :errors]))))))
         phase-result))))
 
 (defn ^{:stratum 2} update-response-chain
@@ -562,7 +570,7 @@
 
 ;------------------------------------------------------------------------------ Layer 3
 
-;------------------------------------------------------------------------------ Layer 1: Composition
+;; Composition
 (defn ^{:stratum 3} execute-phase-lifecycle
   "Execute phase enter -> gates -> leave lifecycle.
 
@@ -713,7 +721,7 @@
 
 ;------------------------------------------------------------------------------ Layer 5
 
-;------------------------------------------------------------------------------ Layer 2: Phase step execution
+;; Phase step execution
 (defn ^{:stratum 5} execute-phase-step
   "Execute a single phase step and return updated context.
 

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -482,9 +482,12 @@
                    ;; gate, which token, which files). This rides the phase
                    ;; result into :execution/phase-results, the one channel
                    ;; a redirect re-entry can still read.
+                   ;; gate/passed? handles response-shaped results too;
+                   ;; a bare (remove :passed?) would misfile them.
                    :phase/gate-failures (->> (:results gate-result)
-                                             (remove :passed?)
-                                             (mapv #(select-keys % [:gate :errors]))))))
+                                             (remove gate/passed?)
+                                             (mapv #(-> (select-keys % [:gate :errors])
+                                                        (update :errors (fnil vec []))))))))
         phase-result))))
 
 (defn ^{:stratum 2} update-response-chain

--- a/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
@@ -178,6 +178,13 @@
       (is (= :allow (get-in out [:phase/decision-envelope :envelope/decision])))
       (is (not (contains? out :phase/status)))
       (is (not (contains? out :phase/gate-errors)))))
+  (testing "deny also attaches the STRUCTURED :phase/gate-failures the
+            repair loop reads (Reasons are schema-bound strings)"
+    (let [out (exec/apply-gate-validation {:config {:gates [:review-approved]}}
+                                          {:result {}} {})]
+      (is (vector? (:phase/gate-failures out)))
+      (is (= [:review-approved] (mapv :gate (:phase/gate-failures out))))
+      (is (every? #(contains? % :errors) (:phase/gate-failures out)))))
   (testing "no gates configured → unchanged (nothing to validate)"
     (let [pr {:result {}}]
       (is (= pr (exec/apply-gate-validation {:config {:gates []}} pr {}))))))


### PR DESCRIPTION
## What

Closes the gap the gate-demonstration runs exposed (eval/codex-traps RUNSHEET, GATE DEMONSTRATION RESULTS): the stale-references gate blocks the contract-drift trap, but a denied implement dies `:exhausted` at iteration 1 — a shield, not a teacher. This wires deny → retry-with-evidence → fix → pass:

1. `apply-gate-validation` now also attaches `:phase/gate-failures` — the failing gates' structured errors (`[:gate :errors]`) — because envelope Reasons are schema-closed strings. It rides `:execution/phase-results`, the only channel a redirect re-entry can read (`[:phase ...]` is dissoc'd before every step, which is also why the existing `:task/prior-attempts` section never fires in production; not fixed here, noted for the record).
2. `gates->envelope` emits one Reason per error instead of collapsing to the first error of each gate.
3. `build-implement-task` threads the prior attempt's `:phase/gate-failures` into `:task/gate-failures`; `task->text` renders it as an imperative "Gate denial — fix before resubmitting" section at the top, one gate-tagged line per error. Prose through the message catalog.
4. canonical-sdlc's implement entry gains `:on-fail :implement`. Self-targeting on-fail is FSM-legal (compiles to the guarded redirect array), unprecedented but validated by the existing guards: terminal verdicts still exit, `max-consecutive-phase-retries` (3) bounds the loop before `max-redirects` (5). Blast radius: only the generic-failure tail of the verdict cond flips from `:exhausted` to `:repair-requested`.

## Verification

Full `bb test` green. New tests: one-Reason-per-error (decide), `:phase/gate-failures` attachment on deny (phase transitions), threading via `:execution/phase-results` (implement task build), prompt rendering incl. absent-case (task->text). End-to-end validation is the next trap-bench demonstration rerun: with this merged, a denied run should retry and finish `:caught` — the detector verdict the whole arc has been building toward.

T2 §6.2: drains `:unheeded` — the warning is now an enforced instruction with a feedback loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

MINIFORGE_PR_BUDGET_OVERRIDE: 810 of 892 reportable lines are stratum-lint autofix output on implementer_test.clj (annotations plus section reordering), generated mechanically by the commit hook when the file was first touched; the hand-written delta across the PR is ~120 lines. Restoring the file to evade the count would just be re-churned by the same hook on the next commit.
