### PR TITLE
fix(workflow): honor FSM self-transitions whose guarded actions ran

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -25,6 +25,7 @@
             [clojure.string :as str]
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.event-stream.interface :as events]
+            [ai.miniforge.fsm.interface :as fsm]
             [ai.miniforge.gate.interface :as gate]
             [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.response.interface :as response]
@@ -547,6 +548,18 @@
       (not= prior-current-state
             (workflow-fsm/current-state (:execution/fsm-state next-ctx))) next-ctx
       (= :phase/retry event) next-ctx
+      ;; A SELF-transition is legitimate exactly when a guarded branch's
+      ;; action ran: the redirect/infra counters in the statechart
+      ;; context moved. Inferring validity from the state-id delta alone
+      ;; silently killed both self-targeting branches of the guarded
+      ;; :phase/fail array — on-fail self-repair (:repair-requested with
+      ;; :on-fail :implement died terminal, observed live in the
+      ;; trap-bench repair demonstration) and the infra-retry branch
+      ;; (:verify/timeout never consulted its budget).
+      (not= (select-keys (fsm/context (:execution/fsm-state ctx))
+                         [:redirect-count :infra-retry-count])
+            (select-keys (fsm/context (:execution/fsm-state next-ctx))
+                         [:redirect-count :infra-retry-count])) next-ctx
       :else (fail))))
 
 (defn- ^{:stratum 2} summarize-error

--- a/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
@@ -258,6 +258,36 @@
    :pack/name  "Test Pack"
    :pack/rules [(policy-rule)]})
 
+(deftest ^{:stratum 1} apply-phase-transition-self-redirect-is-a-valid-transition
+  (testing "on-fail self-repair: a guarded :phase/fail whose redirect
+            branch targets the CURRENT phase must return the advanced ctx,
+            not route to failure — the state id is unchanged but the
+            statechart context's redirect counter moved. Observed live in
+            the trap-bench repair demonstration: :repair-requested with
+            :on-fail :implement died terminal because validity was
+            inferred from the state-id delta alone (which also disabled
+            the infra-retry self-branch)."
+    (let [wf {:workflow/id :self-redirect-test
+              :workflow/version "1.0.0"
+              :workflow/pipeline [{:phase :implement :on-fail :implement}]}
+          machine (workflow-fsm/compile-execution-machine wf)
+          state (->> (workflow-fsm/initialize-execution machine)
+                     (workflow-fsm/start-execution machine))
+          ctx {:execution/fsm-machine machine
+               :execution/fsm-state state
+               :execution/redirect-count 0
+               :execution/errors []
+               :execution/response-chain {:operation :self-redirect-test
+                                          :responses []}}
+          out (exec/apply-phase-transition
+               ctx {:type :phase/fail :phase/verdict :repair-requested}
+               [] identity always-fail)]
+      (is (nil? (:test/transition-to-failed-called? out))
+          "self-redirect must NOT route to transition-to-failed-fn")
+      (is (= 1 (:execution/redirect-count out))
+          "the redirect counter must have moved — that is what proves the
+           guarded branch ran rather than a swallowed no-op"))))
+
 ;------------------------------------------------------------------------------ Layer 2
 
 ;; Phase 4b removed `apply-phase-transition-redirect-over-budget-

--- a/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/phase_transitions_test.clj
@@ -286,7 +286,41 @@
           "self-redirect must NOT route to transition-to-failed-fn")
       (is (= 1 (:execution/redirect-count out))
           "the redirect counter must have moved — that is what proves the
-           guarded branch ran rather than a swallowed no-op"))))
+           guarded branch ran rather than a swallowed no-op")
+      (is (= (workflow-fsm/current-state (:execution/fsm-state ctx))
+             (workflow-fsm/current-state (:execution/fsm-state out)))
+          "the state id is UNCHANGED — this is the same-state case the
+           validity rule exists for; a state-changing redirect would not
+           exercise it"))))
+
+(deftest ^{:stratum 1} apply-phase-transition-infra-self-retry-is-a-valid-transition
+  (testing "the infra-retry self-branch goes through the same wrapper:
+            an infrastructure verdict must return the advanced ctx with
+            the infra counter moved, not route to failure — this branch
+            was equally dead under the state-id-delta rule"
+    (let [wf {:workflow/id :infra-self-retry-test
+              :workflow/version "1.0.0"
+              :workflow/pipeline [{:phase :implement}]}
+          machine (workflow-fsm/compile-execution-machine wf)
+          state (->> (workflow-fsm/initialize-execution machine)
+                     (workflow-fsm/start-execution machine))
+          ctx {:execution/fsm-machine machine
+               :execution/fsm-state state
+               :execution/redirect-count 0
+               :execution/errors []
+               :execution/response-chain {:operation :infra-self-retry-test
+                                          :responses []}}
+          out (exec/apply-phase-transition
+               ctx {:type :phase/fail :phase/verdict :verify/timeout}
+               [] identity always-fail)]
+      (is (nil? (:test/transition-to-failed-called? out))
+          "infra self-retry must NOT route to transition-to-failed-fn")
+      (is (= (workflow-fsm/current-state (:execution/fsm-state ctx))
+             (workflow-fsm/current-state (:execution/fsm-state out)))
+          "same state — retry-same-phase")
+      (is (= 1 (get (fsm/context (:execution/fsm-state out))
+                    :infra-retry-count))
+          "the infra counter moved — the guarded branch ran"))))
 
 ;------------------------------------------------------------------------------ Layer 2
 


### PR DESCRIPTION
Found live by the trap-bench repair demonstration (RUNSHEET, REPAIR DEMONSTRATION SERIES, pin f4627f1fa): the #1853 repair path routed correctly inside the FSM — verdict :repair-requested, redirect branch matched, self-transition applied — but apply-phase-transition treats any same-state outcome as an invalid transition (only bare :phase/retry whitelisted) and routed the run to terminal failure. The same defect silently disabled the infra-retry self-branch: :verify/timeout and friends failed terminally through this wrapper without ever consulting the infra budget.

Fix: a third acceptance condition — the transition is valid when the statechart context's redirect/infra counters moved, which is precisely the evidence that a guarded branch's action ran rather than the event being swallowed. Test drives the real compiled machine with a self-targeting on-fail and asserts next-ctx with the counter at 1 instead of failure routing.

Full bb test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)