### PR TITLE
fix(reporting): delete two #_-commented-out dead functions

### DIFF
--- a/components/reporting/src/ai/miniforge/reporting/core.clj
+++ b/components/reporting/src/ai/miniforge/reporting/core.clj
@@ -49,11 +49,6 @@
   [workflows status]
   (count (filter #(= status (:workflow/status %)) workflows)))
 
-;; Note: Keep for future phase-based filtering
-#_(defn count-by-phase
-    "Count workflows by phase."
-    [workflows phase]
-    (count (filter #(= phase (:workflow/phase %)) workflows)))
 ;; Subscription management (polling-based for BB compatibility)
 (defn ^{:stratum 0} create-subscription
   "Create a new subscription record."
@@ -88,13 +83,6 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-;; Note: Keep for future event broadcasting support
-#_(defn add-event-to-subscriptions
-    "Add event to relevant subscriptions."
-    [subscriptions event]
-    (doseq [[_id sub] @subscriptions]
-      (when (contains? (:subscription/topics sub) (:event/topic event))
-        (swap! (:subscription/event-queue sub) conj event))))
 ;; System status aggregation
 (defn ^{:stratum 1} aggregate-workflow-stats
   "Aggregate workflow statistics."

--- a/docs/pull-requests/2026-08-30-fix-reporting-dead-code.md
+++ b/docs/pull-requests/2026-08-30-fix-reporting-dead-code.md
@@ -1,0 +1,41 @@
+# fix(reporting): delete two #_-commented-out dead functions
+
+## Branch
+
+`fix/reporting-dead-code`
+
+## Summary
+
+Removes two `#_`-commented-out function definitions from
+`reporting/core.clj` that violated rule 008 (No Dead Code).
+
+## What was deleted
+
+- `count-by-phase` — commented out with "Note: Keep for future
+  phase-based filtering". No callsites anywhere in the workspace;
+  the live equivalent `count-by-status` already covers the
+  generalised case.
+
+- `add-event-to-subscriptions` — commented out with "Note: Keep for
+  future event broadcasting support". No callsites anywhere in the
+  workspace; the subscription machinery it would have touched is
+  polling-based (not push), making the function structurally
+  incompatible with current design.
+
+## Why it matters
+
+Dead code with "keep for future" guard-comments is the pattern rule
+008 explicitly prohibits. Left in, it:
+
+- Misleads readers about the component's live surface
+- Generates stale grep hits when searching for symbol definitions
+- Grows silently stale as surrounding types evolve, making any
+  future attempt to un-comment it a guaranteed source of bugs
+
+Git history preserves the removed code if it is ever needed.
+
+## Testing
+
+No callers reference the deleted symbols (confirmed by codebase-wide
+grep). The two functions were never callable (guarded by `#_`), so
+no runtime behaviour changes and no test updates are required.


### PR DESCRIPTION
## Summary

- Remove `count-by-phase` from `reporting/core.clj` — commented out with a "Note: Keep for future phase-based filtering" guard, no callsites anywhere in the workspace.
- Remove `add-event-to-subscriptions` from `reporting/core.clj` — commented out with a "Note: Keep for future event broadcasting support" guard, no callsites anywhere in the workspace.

## Motivation

Both functions were guarded by `#_` outside any rich comment block, with "Note: Keep for future" comments — exactly the pattern rule 008 (No Dead Code) prohibits. Dead code with keep-for-future guards misleads readers about the live surface, generates stale grep hits, and silently drifts out of alignment with surrounding types. Git history preserves the removed code if it is ever needed.

## Changes

| File/Area | Change |
|-----------|--------|
| `components/reporting/src/ai/miniforge/reporting/core.clj` | Delete `count-by-phase` (lines 52–56) and `add-event-to-subscriptions` (lines 91–97), plus their preceding "Note: Keep for future" comments |
| `docs/pull-requests/2026-08-30-fix-reporting-dead-code.md` | PR documentation |

## Testing

- No callsites reference either deleted symbol (confirmed by workspace-wide grep).
- Both functions were never callable (guarded by `#_`), so no runtime behaviour changes and no test updates are required.

## Checklist

### Required

- [x] All tests pass — no executable code changed; deleted symbols have no callsites
- [x] Pre-commit validation passes (no `--no-verify`)
- [x] No commented-out tests
- [x] No giant functions
- [x] Functions are small and composable
- [x] New behaviour has tests — N/A (deletion only)

### Best Practices

- [x] Code follows development guidelines
- [x] PR doc created in `docs/pull-requests/2026-08-30-fix-reporting-dead-code.md`
- [x] Focused PR (single concern: rule 008 dead-code removal)

## Related

- Rule 008: No Dead Code (`standards/miniforge/foundations/no-dead-code.mdc`)

---
_Generated by [Claude Code](https://claude.ai/code/session_013rSqZFj9LR88Q6peCEjbbV)_