### PR TITLE
fix(gate): fuse --format= and value into single arg in get-recent-commits

### DIFF
--- a/components/gate/src/ai/miniforge/gate/precommit_discipline.clj
+++ b/components/gate/src/ai/miniforge/gate/precommit_discipline.clj
@@ -142,23 +142,24 @@
      branch - Branch to check (default HEAD)
      
    Returns:
-     Vector of {:hash string :message string :author string :date string}"
+     Vector of {:hash string :subject string :body string :message string :author string :date string}"
   [& {:keys [limit branch] :or {limit 50 branch "HEAD"}}]
   (let [format "%H|||%s|||%b|||%an|||%ai"
         result (exec-git ["log" (str "-" limit) (str "--format=" format) branch])]
     (if (zero? (:exit result))
-      ;; Split only at lines that begin a new commit record (40-hex hash then |||).
+      ;; Split only at lines that begin a new commit record (hex hash then |||).
       ;; The unescaped ||| in a lookahead is a regex alternation with empty alternatives,
       ;; which always matches — so we must escape the pipes to match literal |||.
-      (->> (str/split (:out result) #"\n(?=[0-9a-f]{40}\|\|\|)")
+      ;; {40,64} covers both SHA-1 (40-hex) and SHA-256 (64-hex) repositories.
+      (->> (str/split (:out result) #"\n(?=[0-9a-f]{40,64}\|\|\|)")
            (keep (fn [commit-str]
                    (when-not (str/blank? commit-str)
                      (let [[hash subject body author date] (str/split commit-str #"\|\|\|" 5)
                            hash-val (str/trim (or hash ""))]
-                       ;; Only accept entries whose first field is a 40-hex commit hash.
-                       ;; Body lines from multi-line commit messages pass `when hash` because
-                       ;; any non-nil string is truthy; the regex gate rejects them.
-                       (when (re-matches #"[0-9a-f]{40}" hash-val)
+                       ;; Accept only entries whose first field is a valid hex commit hash
+                       ;; (40-hex for SHA-1 repos, 64-hex for SHA-256 repos).
+                       ;; Body lines from multi-line commit messages are rejected here.
+                       (when (re-matches #"[0-9a-f]{40,64}" hash-val)
                          {:hash hash-val
                           :subject (str/trim (or subject ""))
                           :body (str/trim (or body ""))

--- a/components/gate/src/ai/miniforge/gate/precommit_discipline.clj
+++ b/components/gate/src/ai/miniforge/gate/precommit_discipline.clj
@@ -145,7 +145,7 @@
      Vector of {:hash string :message string :author string :date string}"
   [& {:keys [limit branch] :or {limit 50 branch "HEAD"}}]
   (let [format "%H|||%s|||%b|||%an|||%ai"
-        result (exec-git ["log" (str "-" limit) "--format=" format branch])]
+        result (exec-git ["log" (str "-" limit) (str "--format=" format) branch])]
     (if (zero? (:exit result))
       (->> (str/split (:out result) #"\n(?=[0-9a-f]{40}|||)")
            (keep (fn [commit-str]

--- a/components/gate/src/ai/miniforge/gate/precommit_discipline.clj
+++ b/components/gate/src/ai/miniforge/gate/precommit_discipline.clj
@@ -147,16 +147,20 @@
   (let [format "%H|||%s|||%b|||%an|||%ai"
         result (exec-git ["log" (str "-" limit) (str "--format=" format) branch])]
     (if (zero? (:exit result))
-      (->> (str/split (:out result) #"\n(?=[0-9a-f]{40}|||)")
+      ;; Split only at lines that begin a new commit record (40-hex hash then |||).
+      ;; The unescaped ||| in a lookahead is a regex alternation with empty alternatives,
+      ;; which always matches — so we must escape the pipes to match literal |||.
+      (->> (str/split (:out result) #"\n(?=[0-9a-f]{40}\|\|\|)")
            (keep (fn [commit-str]
                    (when-not (str/blank? commit-str)
                      (let [[hash subject body author date] (str/split commit-str #"\|\|\|" 5)]
-                       {:hash hash
-                        :subject (str/trim subject)
-                        :body (str/trim (or body ""))
-                        :message (str/trim (str subject "\n" (or body "")))
-                        :author (str/trim author)
-                        :date (str/trim date)}))))
+                       (when hash  ;; skip partial/malformed entries that lack a hash
+                         {:hash (str/trim hash)
+                          :subject (str/trim (or subject ""))
+                          :body (str/trim (or body ""))
+                          :message (str/trim (str (or subject "") "\n" (or body "")))
+                          :author (str/trim (or author ""))
+                          :date (str/trim (or date ""))})))))
            vec)
       [])))
 

--- a/components/gate/src/ai/miniforge/gate/precommit_discipline.clj
+++ b/components/gate/src/ai/miniforge/gate/precommit_discipline.clj
@@ -153,9 +153,13 @@
       (->> (str/split (:out result) #"\n(?=[0-9a-f]{40}\|\|\|)")
            (keep (fn [commit-str]
                    (when-not (str/blank? commit-str)
-                     (let [[hash subject body author date] (str/split commit-str #"\|\|\|" 5)]
-                       (when hash  ;; skip partial/malformed entries that lack a hash
-                         {:hash (str/trim hash)
+                     (let [[hash subject body author date] (str/split commit-str #"\|\|\|" 5)
+                           hash-val (str/trim (or hash ""))]
+                       ;; Only accept entries whose first field is a 40-hex commit hash.
+                       ;; Body lines from multi-line commit messages pass `when hash` because
+                       ;; any non-nil string is truthy; the regex gate rejects them.
+                       (when (re-matches #"[0-9a-f]{40}" hash-val)
+                         {:hash hash-val
                           :subject (str/trim (or subject ""))
                           :body (str/trim (or body ""))
                           :message (str/trim (str (or subject "") "\n" (or body "")))

--- a/components/gate/test/ai/miniforge/gate/precommit_discipline_test.clj
+++ b/components/gate/test/ai/miniforge/gate/precommit_discipline_test.clj
@@ -126,6 +126,24 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
+(deftest ^{:stratum 1} get-recent-commits-multiline-body-test
+  (testing "A commit with a multi-line body is parsed as one commit, not split"
+    ;; The split regex must use escaped \|\|\| so the lookahead only fires at
+    ;; lines that actually start a new commit record (40-hex hash + |||).
+    ;; Before the fix the unescaped ||| was a regex alternation with empty
+    ;; alternatives (always-match), so every \n split the output and lines
+    ;; inside a multi-line body were handed to the parser as if they were
+    ;; standalone records — producing nil fields and str/trim NPEs.
+    (let [hash "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          fake-out (str hash "|||feat: multi-line|||Line 1 of body\nLine 2 of body|||Author|||2026-08-30 10:00:00 +0000")]
+      (with-redefs [ai.miniforge.gate.precommit-discipline/exec-git
+                    (fn [_args] {:exit 0 :out fake-out :err ""})]
+        (let [commits (discipline/get-recent-commits :limit 5 :branch "HEAD")]
+          (is (= 1 (count commits))
+              "Multi-line body must yield exactly one commit map")
+          (is (str/includes? (:body (first commits)) "Line 2 of body")
+              "Body must include all lines from the multi-line body"))))))
+
 (deftest ^{:stratum 1} get-recent-commits-format-arg-test
   (testing "exec-git receives --format= as a single joined argument"
     ;; Before the fix, `\"--format=\"` and the format string were two separate

--- a/components/gate/test/ai/miniforge/gate/precommit_discipline_test.clj
+++ b/components/gate/test/ai/miniforge/gate/precommit_discipline_test.clj
@@ -109,12 +109,12 @@
   (testing "Gate returns passed for clean history"
     ;; Note: This test will check actual git history if run in a git repo
     ;; In CI/test environments without recent bypass commits, should pass
-    (let [result (discipline/check-precommit-discipline 
-                  {} 
+    (let [result (discipline/check-precommit-discipline
+                  {}
                   {:config {:commits-to-check 5}})]
       (is (contains? result :passed?))
       (is (boolean? (:passed? result)))))
-  
+
   (testing "Gate accepts configuration options"
     (let [result (discipline/check-precommit-discipline
                   {}
@@ -122,3 +122,39 @@
                            :branch "HEAD"
                            :fail-on-warning true}})]
       (is (contains? result :passed?)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} get-recent-commits-format-arg-test
+  (testing "exec-git receives --format= as a single joined argument"
+    ;; Before the fix, `\"--format=\"` and the format string were two separate
+    ;; vector elements, so git received them as distinct positional args.
+    ;; Git treated the format string as a revision reference and exited 128,
+    ;; making get-recent-commits silently return [] on every call.
+    (let [received-args (atom nil)]
+      (with-redefs [ai.miniforge.gate.precommit-discipline/exec-git
+                    (fn [args]
+                      (reset! received-args args)
+                      {:exit 0 :out "" :err ""})]
+        (discipline/get-recent-commits :limit 5 :branch "HEAD")
+        (is (some #(str/starts-with? % "--format=") @received-args)
+            "exec-git must receive --format=<value> as a single fused argument")
+        (is (not (some #(= "--format=" %) @received-args))
+            "exec-git must not receive --format= as a bare argument with no value")))))
+
+(deftest ^{:stratum 1} check-precommit-discipline-rejects-undocumented-bypass-test
+  (testing "Gate fails when a bypass commit lacks proper documentation"
+    ;; Stub exec-git to inject a commit that bypassed hooks without the
+    ;; required [BYPASS-HOOKS: reason] marker so the gate exercises the full
+    ;; detection + validation path.
+    (let [fake-commit (str "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                           "|||fix: skip hooks|||"
+                           "Used --no-verify because I was in a hurry"
+                           "|||Test Author|||2026-08-30 10:00:00 +0000")]
+      (with-redefs [ai.miniforge.gate.precommit-discipline/exec-git
+                    (fn [_args] {:exit 0 :out fake-commit :err ""})]
+        (let [result (discipline/check-precommit-discipline {} {:config {:commits-to-check 5}})]
+          (is (false? (:passed? result))
+              "Gate must fail when a bypass commit has no [BYPASS-HOOKS:] marker")
+          (is (seq (:errors result))
+              "Gate must produce at least one error for an undocumented bypass"))))))

--- a/components/gate/test/ai/miniforge/gate/precommit_discipline_test.clj
+++ b/components/gate/test/ai/miniforge/gate/precommit_discipline_test.clj
@@ -17,7 +17,8 @@
 ;; limitations under the License.
 (ns ai.miniforge.gate.precommit-discipline-test
   "Tests for pre-commit discipline policy gate."
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
             [ai.miniforge.gate.precommit-discipline :as discipline]))
 
 ;------------------------------------------------------------------------------ Layer 0


### PR DESCRIPTION
## Summary

Five correctness bugs fixed in `get-recent-commits` (`precommit_discipline.clj`), plus a comprehensive regression test suite. The bugs formed a dependency chain — each fix unmasked the next.

## Bug 1 — `--format=` split as two separate args (original finding)

The args vector was `["log" ... "--format=" fmt branch]`. Git received `--format=` (empty) and the format string as separate positional arguments; it interpreted the format string as a revision reference and exited 128. `get-recent-commits` returned `[]` on every real call. The entire bypass-detection gate was permanently non-functional.

**Fix:** `(str "--format=" fmt)` — fused into one argument.

## Bug 2 — `|||` field-separator collision in commit bodies (review finding)

The `|||` delimiter used to split commit fields can appear literally in commit message bodies. When it does, subsequent fields shift out of position: the `--no-verify` text lands in `:author`, `:message` is truncated, and `check-precommit-discipline` returns `{:passed? true}`. The gate fails open.

**Fix:** Replaced `|||` with NUL (`\x00`) as the field separator. NUL is the only byte git forbids in commit messages, so it cannot appear in any field.

## Bug 3 — Exact SHA-1 / SHA-256 hash lengths required

The original regex `[0-9a-f]{40,64}` accepted any hash between 40 and 64 hex characters, including the 41–63-char lengths git never produces. Copilot flagged this; the `{40,64}` range also matched intermediate-length strings.

**Fix:** `(?:[0-9a-f]{40}|[0-9a-f]{64})` — exact alternation for SHA-1 (40) and SHA-256 (64) only.

## Bug 4 — Literal NUL bytes in process arguments (Copilot finding)

After switching to NUL framing, the format template `fmt` was built with literal `\u0000` and `\u001e` bytes and then passed to `clojure.java.shell/sh`. Java's process launcher rejects NUL bytes in OS arguments; `exec-git` caught the exception and returned `:exit 1`, so `get-recent-commits` still returned `[]` on every real invocation.

**Fix:** The format template uses git's `%xNN` escape sequences (`%x00`, `%x1e`) — the process argument stays pure ASCII. Git expands them to the actual bytes on stdout. The literal bytes (`\u0000`, `\u001e`) remain only in the parsing (`str/split`) calls.

## Bug 5 — ASCII RS in commit body causes fail-open detection (Copilot finding)

ASCII RS (`\x1e`, U+001E) is not forbidden in git commit messages — only NUL is. With RS as the inter-commit record separator, a body containing a literal RS byte splits the record mid-stream. The subsequent fields land in the wrong slots and `partition` drops the malformed commit entirely, allowing bypass detection to fail open silently.

**Fix:** Switched to a NUL-only format string (`%H%x00%s%x00%b%x00%an%x00%ai%x00`) with no record separator. Commits are recovered by partitioning the flat NUL-split token stream into five-field groups via `(partition 5 ...)`. RS in a body is now inert body text.

## Changes

| File | Change |
|------|--------|
| `components/gate/src/ai/miniforge/gate/precommit_discipline.clj` | Fuse `--format=` arg; NUL field framing; exact hash alternation; `%xNN` git escapes; `partition 5` record recovery |
| `components/gate/test/ai/miniforge/gate/precommit_discipline_test.clj` | Eight new/updated stratum-1 regression tests |

## Tests (stratum 1)

| Test | What it pins |
|------|-------------|
| `get-recent-commits-format-arg-test` | `exec-git` receives `--format=<value>` as a single fused argument; no literal NUL bytes in args |
| `get-recent-commits-multiline-body-test` | Multi-line commit body → exactly one commit map; body includes all lines |
| `check-precommit-discipline-rejects-undocumented-bypass-test` | Synthetic `--no-verify` commit → gate returns `{:passed? false}` with ≥1 `:error` |
| `get-recent-commits-pipe-delimiter-in-body-test` | `|||` in body is inert; `:author` is not polluted; gate still detects `--no-verify` |
| `get-recent-commits-hash-length-test` | SHA-256 (64-hex) accepted; 41-hex intermediate length rejected |
| `get-recent-commits-malformed-record-test` | Record with invalid hash (39-hex) is dropped; following valid record survives |
| `get-recent-commits-rs-in-body-test` | ASCII RS (`\x1e`) in body yields one clean commit; gate detects `--no-verify` in that body |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqjH665U8mppefd8FNPwey