### PR TITLE
fix(deliberation-workspace): refuse operation payloads the validator cannot read

### DIFF
--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/guards.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/guards.clj
@@ -49,7 +49,12 @@
 (defn- ^{:stratum 0} backed?
   "N14 §3.5: a challenge must carry evidence, or ride in the same transaction
    as an experiment that discriminates what it challenges. Bare objections are
-   refused — that rule is what stops a skeptic looping forever."
+   refused — that rule is what stops a skeptic looping forever.
+
+   `:evidence` and a sibling's `:discriminates` are read unscreened.
+   `validation/concurrency-stages` establishes that both name object ids
+   before any guard runs, which is why the guards must be composed onto that
+   chain rather than run alone."
   [operation siblings]
   (let [targets (tx/touched-ids operation)
         discriminates? (fn [sibling]

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/transaction.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/transaction.clj
@@ -111,8 +111,8 @@
   "Operation fields that name object ids (N14 §3.2).
 
    `:targets` is read by [[touched-ids]]; `:evidence` and `:discriminates`
-   by the §3.5 backing check. Each is optional, and each reader `set`s the
-   field, so validation holds all three to one shape."
+   by the §3.5 backing check. Each is optional, and each reader hands the
+   field to `set` or `seq`, so validation holds all three to one shape."
   [:targets :evidence :discriminates])
 
 (defn ^{:stratum 0} touched-ids

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/transaction.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/transaction.clj
@@ -107,6 +107,14 @@
   "Operations every role may propose (N14 §5.3, final clause)."
   #{:assert-claim :add-question :declare-blocked})
 
+(def ^{:stratum 0} id-fields
+  "Operation fields that name object ids (N14 §3.2).
+
+   `:targets` is read by [[touched-ids]]; `:evidence` and `:discriminates`
+   by the §3.5 backing check. Each is optional, and each reader `set`s the
+   field, so validation holds all three to one shape."
+  [:targets :evidence :discriminates])
+
 (defn ^{:stratum 0} touched-ids
   "The object ids `operation` reads or writes. Every operation must declare
    these so the validator can check basis staleness without interpreting

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
@@ -183,11 +183,11 @@
    sibling's payload would describe a fault the named operation does not
    have."
   [_workspace operation context]
-  (some (fn [[op field value]]
+  (some (fn [[carrier field value]]
           (when-let [[reason data] (id-listing-defect value)]
             (reject :invalid-input :anomalies.deliberation/invalid-object-ids
                     "Operation field must name object ids the engine can look up"
-                    (merge {:op (:op op) :field field :reason reason} data))))
+                    (merge {:op (:op carrier) :field field :reason reason} data))))
         (id-listings (get context :siblings [operation]))))
 
 (defn- ^{:stratum 1} check-creates

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
@@ -110,13 +110,14 @@
 
 (defn- ^{:stratum 0} id-listing-defect
   "The first structural defect in an operation field that names object ids,
-   as `[reason data]`, or nil when the field's readers can `set` it and look
-   its elements up in the object graph.
+   as `[reason data]`, or nil when the field's readers can iterate it and
+   look its elements up in the object graph.
 
-   A scalar is refused because `set` throws on one. A string is refused for
-   the opposite reason — it is seqable, so `(set \"claim-1\")` yields seven
-   single-character ids and the operation is reported against ids no
-   activation named. A map is neither and is refused with the scalars.
+   A scalar is refused because `set` and `seq` both throw on one. A string
+   and a map throw on neither, and are refused for what they yield instead:
+   `(set \"claim-1\")` walks the string into seven single-character ids, so
+   the operation would be reported against ids no activation named, and a
+   map yields its entries, which are not ids either.
 
    Absent and nil are legal: every reader defaults the field to empty.
    Unusable elements are ordered by printed form. `:targets` is canonically
@@ -171,8 +172,9 @@
 (defn- ^{:stratum 1} check-id-fields
   "N14 §3.2 conformance for the operation fields that name object ids.
 
-   `tx/touched-ids` and the §3.5 backing check both `set` these fields, so a
-   scalar there throws out of `validate` itself. That is worse than a
+   `tx/touched-ids` `set`s `:targets`; the §3.5 backing check `seq`s
+   `:evidence` and `set`s a sibling's `:discriminates`. Both throw on a
+   scalar, so one there throws out of `validate` itself. That is worse than a
    commit-time throw: no stage returns, `run/step` never receives an
    anomaly, and there is nothing to route. This stage runs ahead of every
    reader.

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
@@ -143,13 +143,22 @@
    validating a challenge, so a stage reading only its own operation would
    reach a malformed field before the operation carrying it had a turn.
 
-   Operations that are not maps are skipped, not interpreted: `check-schema`
-   refuses one on its own turn, and `contains?` throws on a scalar — reading
-   fields out of a payload that is not one moves the crash rather than
-   removing it."
+   Two kinds of sibling are skipped rather than interpreted, both because
+   `check-schema` refuses them on their own turn and reporting a field of
+   theirs first would outrank it:
+
+   - operations that are not maps, on which `contains?` throws — reading
+     fields out of a payload that is not one moves the crash rather than
+     removing it;
+   - operations outside the §3.2 vocabulary, whose fields mean nothing.
+
+   Skipping the second leaves no reader unguarded. The only field any stage
+   reads from a SIBLING is `:discriminates`, and `guards/backed?` reaches it
+   only after `(= :propose-experiment (:op sibling))` — a vocabulary member,
+   so a scanned one."
   [operations]
   (for [operation operations
-        :when (map? operation)
+        :when (and (map? operation) (tx/known-operation? (:op operation)))
         field tx/id-fields
         :when (contains? operation field)]
     [operation field (get operation field)]))
@@ -353,9 +362,11 @@
    reported as an unknown operation, not as a bad creation.
 
    `check-id-fields` leads the payload stages, and is the one ordering
-   constraint that is not a preference: every stage after it — payload,
-   graph, and abuse guard alike — `set`s a field it establishes the shape
-   of, and would throw out of the validator rather than reject.
+   constraint that is not a preference: stages after it — payload, graph,
+   and abuse guard alike — hand a field it establishes the shape of to
+   `set` or `seq`, either of which throws on a scalar rather than rejecting.
+   It still runs after `check-schema`, and skips siblings outside the
+   vocabulary, so an unknown operation is never reported as a shape fault.
 
    The payload stages precede the three that read the object graph. A
    transaction can carry a malformed payload and a missing target at once,

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
@@ -108,6 +108,51 @@
         spec creates]
     spec))
 
+(defn- ^{:stratum 0} id-listing-defect
+  "The first structural defect in an operation field that names object ids,
+   as `[reason data]`, or nil when the field's readers can `set` it and look
+   its elements up in the object graph.
+
+   A scalar is refused because `set` throws on one. A string is refused for
+   the opposite reason — it is seqable, so `(set \"claim-1\")` yields seven
+   single-character ids and the operation is reported against ids no
+   activation named. A map is neither and is refused with the scalars.
+
+   Absent and nil are legal: every reader defaults the field to empty.
+   Unusable elements are ordered by printed form. `:targets` is canonically
+   a set, and what the anomaly reports must not vary between runs over
+   identical input."
+  [value]
+  (let [listed? (or (nil? value) (and (coll? value) (not (map? value))))
+        unusable (when listed?
+                   (seq (remove #(and (string? %) (not (str/blank? %))) value)))]
+    (cond
+      (not listed?)
+      [:non-collection-ids {:value value}]
+
+      unusable
+      [:unusable-id {:ids (vec (sort-by pr-str unusable))}])))
+
+(defn- ^{:stratum 0} id-listings
+  "Every id-naming field the operations of one transaction carry, as
+   `[operation field value]` in payload order.
+
+   Read across the whole transaction rather than one operation at a time:
+   the §3.5 backing check consults a SIBLING's `:discriminates` while
+   validating a challenge, so a stage reading only its own operation would
+   reach a malformed field before the operation carrying it had a turn.
+
+   Operations that are not maps are skipped, not interpreted: `check-schema`
+   refuses one on its own turn, and `contains?` throws on a scalar — reading
+   fields out of a payload that is not one moves the crash rather than
+   removing it."
+  [operations]
+  (for [operation operations
+        :when (map? operation)
+        field tx/id-fields
+        :when (contains? operation field)]
+    [operation field (get operation field)]))
+
 (defn ^{:stratum 0} validate-operation
   "Run `stages` against one operation in order, returning the first anomaly
    or nil. `context` carries :role, :basis and :siblings from the enclosing
@@ -122,6 +167,28 @@
     (reject :invalid-input :anomalies.deliberation/unknown-operation
             "Operation is outside the closed N14 §3.2 vocabulary"
             {:op (:op operation)})))
+
+(defn- ^{:stratum 1} check-id-fields
+  "N14 §3.2 conformance for the operation fields that name object ids.
+
+   `tx/touched-ids` and the §3.5 backing check both `set` these fields, so a
+   scalar there throws out of `validate` itself. That is worse than a
+   commit-time throw: no stage returns, `run/step` never receives an
+   anomaly, and there is nothing to route. This stage runs ahead of every
+   reader.
+
+   The offending operation is named rather than the one whose turn noticed.
+   The scan covers the whole transaction, `:tx/operations` is a vector so
+   the first defect is fixed by the payload, and pointing repair at a
+   sibling's payload would describe a fault the named operation does not
+   have."
+  [_workspace operation context]
+  (some (fn [[op field value]]
+          (when-let [[reason data] (id-listing-defect value)]
+            (reject :invalid-input :anomalies.deliberation/invalid-object-ids
+                    "Operation field must name object ids the engine can look up"
+                    (merge {:op (:op op) :field field :reason reason} data))))
+        (id-listings (get context :siblings [operation]))))
 
 (defn- ^{:stratum 1} check-creates
   "N14 §3.2 conformance for the objects an operation asks to create.
@@ -271,9 +338,14 @@
    for the same reason: an operation outside the vocabulary should be
    reported as an unknown operation, not as a bad creation.
 
-   Both payload stages precede the three that read the object graph. A
+   `check-id-fields` leads the payload stages, and is the one ordering
+   constraint that is not a preference: every stage after it — payload,
+   graph, and abuse guard alike — `set`s a field it establishes the shape
+   of, and would throw out of the validator rather than reject.
+
+   The payload stages precede the three that read the object graph. A
    transaction can carry a malformed payload and a missing target at once,
    and the payload is the more basic fault: the ids a graph stage would
    report come out of the same payload whose shape is not yet established."
-  [check-schema check-creates check-links
+  [check-schema check-id-fields check-creates check-links
    check-targets check-permission check-basis])

--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
@@ -322,13 +322,25 @@
    workspace in a state no activation ever proposed.
 
    Stages are supplied by the caller rather than defaulted, so the abuse
-   guards extend the chain without reopening this namespace."
+   guards extend the chain without reopening this namespace.
+
+   `:tx/operations` is held to a shape here rather than by a stage, because
+   a stage cannot run until this function has iterated it. `run/step` hands
+   an activation's return value straight in, so a scalar there would throw
+   out of the validator with no anomaly for the caller to route. Sequential
+   for the reason `check-creates` requires it of `:creates`: a set has no
+   first operation, so which one the pipeline reported would vary between
+   runs over identical input."
   [workspace transaction stages]
   (let [operations (:tx/operations transaction)
         context {:role (:tx/role transaction)
                  :basis (:tx/basis transaction)
                  :siblings operations}]
-    (some #(validate-operation workspace % context stages) operations)))
+    (if (or (nil? operations) (sequential? operations))
+      (some #(validate-operation workspace % context stages) operations)
+      (reject :invalid-input :anomalies.deliberation/invalid-transaction
+              "Transaction :tx/operations must be a sequence of operations"
+              {:operations operations}))))
 
 ;------------------------------------------------------------------------------ Layer 2
 

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/guards_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/guards_test.clj
@@ -145,7 +145,7 @@
                                  {:op :not-an-op :targets #{"constraint-1"}}))))))
 
 (deftest ^{:stratum 2} the-fields-the-backing-check-reads-are-routed-not-thrown
-  (testing "backed? sets :evidence and a sibling's :discriminates; both would throw"
+  (testing "backed? seqs :evidence and sets a sibling's :discriminates; both would throw"
     (doseq [[label operations]
             [["scalar :evidence"
               [{:op :challenge :targets #{"claim-1"} :evidence :evidence-4}]]

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/guards_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/guards_test.clj
@@ -143,3 +143,23 @@
            (subtype-of (validate (workspace [(hard-constraint "constraint-1")])
                                  :proposer
                                  {:op :not-an-op :targets #{"constraint-1"}}))))))
+
+(deftest ^{:stratum 2} the-fields-the-backing-check-reads-are-routed-not-thrown
+  (testing "backed? sets :evidence and a sibling's :discriminates; both would throw"
+    (doseq [[label operations]
+            [["scalar :evidence"
+              [{:op :challenge :targets #{"claim-1"} :evidence :evidence-4}]]
+             ["scalar :discriminates on a sibling"
+              [{:op :challenge :targets #{"claim-1"}}
+               {:op :propose-experiment :discriminates :claim-1}]]]]
+      (is (= :anomalies.deliberation/invalid-object-ids
+             (subtype-of (apply validate (workspace [(claim-object "claim-1")])
+                                :skeptic operations)))
+          label)))
+  (testing "the shape fault outranks the bare challenge read out of it"
+    (is (not= :anomalies.deliberation/bare-challenge
+              (subtype-of (validate (workspace [(claim-object "claim-1")]) :skeptic
+                                    {:op :challenge :targets #{"claim-1"}}
+                                    {:op :propose-experiment
+                                     :discriminates :claim-1})))
+        "an experiment whose :discriminates is unreadable never backed anything")))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
@@ -203,3 +203,20 @@
           "a rejected transaction does not advance the clock")
       (is (= #{"goal-1"} (set (keys (:workspace/objects after))))
           "and leaves no half-created object behind"))))
+
+(deftest ^{:stratum 2} an-unreadable-id-field-is-routed-not-thrown
+  (testing "a scalar :targets threw out of validate itself, so step saw no anomaly"
+    (let [propose (fn [{:keys [role]}]
+                    (tx/new-transaction
+                     {:role role :activation "act-1" :basis 1
+                      :operations [{:op :assert-claim
+                                    :creates [{:id "claim-1" :type :claim
+                                               :statement "a claim"}]}
+                                   {:op :refine-claim :targets :goal-1}]}))
+          after (run/step (workspace) propose)]
+      (is (= [:anomalies.deliberation/invalid-object-ids]
+             (mapv :reason (events-of after :transaction/rejected))))
+      (is (= 1 (:workspace/version after))
+          "a rejected transaction does not advance the clock")
+      (is (= #{"goal-1"} (set (keys (:workspace/objects after))))
+          "and the create in the operation before it is discarded with the rest"))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
@@ -220,3 +220,10 @@
           "a rejected transaction does not advance the clock")
       (is (= #{"goal-1"} (set (keys (:workspace/objects after))))
           "and the create in the operation before it is discarded with the rest"))))
+
+(deftest ^{:stratum 2} an-activation-returning-a-malformed-transaction-is-routed
+  (testing "step hands the activation's return straight to validate"
+    (let [after (run/step (workspace) (fn [_] {:tx/role :proposer :tx/basis 1
+                                               :tx/operations :assert-claim}))]
+      (is (= [:anomalies.deliberation/invalid-transaction]
+             (mapv :reason (events-of after :transaction/rejected)))))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
@@ -463,3 +463,20 @@
                                     (transaction :proposer 10
                                                  {:op :assert-claim} 42))))
         "the sibling scan skips it; its own turn refuses it by vocabulary")))
+
+(deftest ^{:stratum 1} a-transaction-whose-operations-are-not-a-sequence-is-refused
+  (testing "no stage can run until validate has iterated :tx/operations"
+    (doseq [[label operations] [["a scalar" :assert-claim]
+                                ["a map" {:op :assert-claim}]
+                                ["a set" #{{:op :assert-claim}}]]]
+      (is (= :anomalies.deliberation/invalid-transaction
+             (subtype-of (validation/validate
+                          (workspace)
+                          {:tx/role :proposer :tx/basis 10
+                           :tx/operations operations}
+                          validation/concurrency-stages)))
+          label)))
+  (testing "a transaction proposing nothing is empty, not malformed"
+    (is (nil? (validation/validate (workspace)
+                                   {:tx/role :proposer :tx/basis 10}
+                                   validation/concurrency-stages)))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
@@ -378,7 +378,7 @@
                                                     :statement "second"}]}))))))
 
 (deftest ^{:stratum 1} id-fields-that-are-not-collections-of-ids-are-refused
-  (testing "every reader sets these fields, so a scalar throws out of validate itself"
+  (testing "set and seq both throw on a scalar, out of validate itself"
     (doseq [[label operation] [["scalar :targets"
                                 {:op :refine-claim :targets :claim-1}]
                                ["scalar :evidence"
@@ -480,3 +480,18 @@
     (is (nil? (validation/validate (workspace)
                                    {:tx/role :proposer :tx/basis 10}
                                    validation/concurrency-stages)))))
+
+(deftest ^{:stratum 1} an-unknown-sibling-operation-outranks-its-own-id-fields
+  (testing "the sibling scan must not report a shape fault ahead of schema"
+    (is (= :anomalies.deliberation/unknown-operation
+           (subtype-of (validate-tx (workspace)
+                                    (transaction :proposer 10
+                                                 {:op :assert-claim}
+                                                 {:op :rewrite-history :targets :x}))))
+        "an operation outside the vocabulary has no fields worth reporting"))
+  (testing "a known sibling's malformed field is still reported"
+    (is (= :anomalies.deliberation/invalid-object-ids
+           (subtype-of (validate-tx (workspace)
+                                    (transaction :proposer 10
+                                                 {:op :assert-claim}
+                                                 {:op :refine-claim :targets :x})))))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
@@ -376,3 +376,90 @@
                                                     :statement "first"}
                                                    {:id "claim-2" :type :claim
                                                     :statement "second"}]}))))))
+
+(deftest ^{:stratum 1} id-fields-that-are-not-collections-of-ids-are-refused
+  (testing "every reader sets these fields, so a scalar throws out of validate itself"
+    (doseq [[label operation] [["scalar :targets"
+                                {:op :refine-claim :targets :claim-1}]
+                               ["scalar :evidence"
+                                {:op :challenge :targets #{"claim-1"} :evidence :e-1}]
+                               ["scalar :discriminates"
+                                {:op :propose-experiment :discriminates :h-1}]
+                               ["numeric :targets"
+                                {:op :refine-claim :targets 7}]
+                               ["map :targets"
+                                {:op :refine-claim :targets {:claim-1 true}}]]]
+      (is (= :anomalies.deliberation/invalid-object-ids
+             (subtype-of (validate-tx (workspace (object-at "claim-1" 4))
+                                      (transaction :proposer 10 operation))))
+          label))))
+
+(deftest ^{:stratum 1} a-string-of-ids-is-refused-rather-than-walked
+  (testing "a string is seqable, so set would yield one id per character"
+    (let [rejection (validate-tx
+                     (workspace (object-at "claim-1" 4))
+                     (transaction :proposer 10
+                                  {:op :refine-claim :targets "claim-1"}))]
+      (is (= :anomalies.deliberation/invalid-object-ids (subtype-of rejection)))
+      (is (= :non-collection-ids (:reason (:anomaly/data rejection)))
+          "reported as the shape fault it is, not as seven missing targets"))))
+
+(deftest ^{:stratum 1} an-id-field-rejection-names-the-field-and-the-reason
+  (testing "routing reads the field and reason without parsing the message"
+    (doseq [[field reason operation]
+            [[:targets :non-collection-ids {:op :refine-claim :targets :claim-1}]
+             [:targets :unusable-id {:op :refine-claim :targets #{""}}]
+             [:evidence :unusable-id
+              {:op :challenge :targets #{"claim-1"} :evidence [:e-1]}]
+             [:discriminates :non-collection-ids
+              {:op :propose-experiment :discriminates "h-1"}]]]
+      (let [data (:anomaly/data (validate-tx
+                                 (workspace (object-at "claim-1" 4))
+                                 (transaction :proposer 10 operation)))]
+        (is (= field (:field data)))
+        (is (= reason (:reason data)))))))
+
+(deftest ^{:stratum 1} a-malformed-id-field-is-blamed-on-the-operation-carrying-it
+  (testing "the backing check reads a sibling, so the scan covers the transaction"
+    (let [data (:anomaly/data
+                (validate-tx (workspace (object-at "claim-1" 4))
+                             (transaction :proposer 10
+                                          {:op :challenge :targets #{"claim-1"}}
+                                          {:op :propose-experiment
+                                           :discriminates :h-1})))]
+      (is (= :propose-experiment (:op data))
+          "not :challenge, whose turn noticed and whose own payload is fine")
+      (is (= :discriminates (:field data))))))
+
+(deftest ^{:stratum 1} well-formed-id-fields-pass
+  (testing "the stage refuses malformed listings, not the fields themselves"
+    (is (nil? (validate-tx
+               (workspace (object-at "claim-1" 4))
+               (transaction :proposer 10
+                            {:op :challenge :targets #{"claim-1"}
+                             :evidence ["evidence-1"]}
+                            {:op :propose-experiment
+                             :discriminates '("claim-1")})))))
+  (testing "absent and explicitly nil fields are legal — readers default to empty"
+    (is (nil? (validate-tx (workspace)
+                           (transaction :proposer 10
+                                        {:op :assert-claim :targets nil}))))
+    (is (nil? (validate-tx (workspace)
+                           (transaction :proposer 10 {:op :assert-claim}))))))
+
+(deftest ^{:stratum 1} an-unusable-id-outranks-the-targets-it-would-be-looked-up-as
+  (testing "shape is established before any stage reads the object graph"
+    (is (= :anomalies.deliberation/invalid-object-ids
+           (subtype-of (validate-tx
+                        (workspace)
+                        (transaction :proposer 10
+                                     {:op :refine-claim :targets #{"claim-404" 7}}))))
+        "check-targets would otherwise report 7 as a missing object")))
+
+(deftest ^{:stratum 1} an-operation-that-is-not-a-map-is-left-to-schema-conformance
+  (testing "reading id fields out of a scalar sibling would move the crash"
+    (is (= :anomalies.deliberation/unknown-operation
+           (subtype-of (validate-tx (workspace)
+                                    (transaction :proposer 10
+                                                 {:op :assert-claim} 42))))
+        "the sibling scan skips it; its own turn refuses it by vocabulary")))

--- a/docs/pull-requests/2026-09-02-fix-n14-stage0-id-field-shapes.md
+++ b/docs/pull-requests/2026-09-02-fix-n14-stage0-id-field-shapes.md
@@ -1,0 +1,188 @@
+# fix: refuse operation payloads the validator cannot read
+
+## Overview
+
+Four agent-reachable payload shapes threw `IllegalArgumentException` out of
+`validation/validate` itself, and a fifth was accepted and misrouted. This PR
+refuses all five as anomalies carrying an `:anomalies.deliberation/...`
+subtype, so `run/step` records a `:transaction/rejected` event instead of
+dying.
+
+## Motivation
+
+[#1852](https://github.com/miniforge-ai/miniforge/pull/1852) closed the
+operation-level `:links` gaps and the cross-transaction duplicate creates.
+The defects here are the same class — activation-controlled input reaching the
+engine as an exception rather than as a routable rejection — but they fail
+harder. A commit-time throw at least happens after `validate` returned, so a
+stage could in principle have caught the payload. These throw from inside the
+validation pipeline: no stage returns, `run/step` never receives an anomaly,
+and there is nothing for the scheduler to route or log.
+
+Reproduced on 2026-08-29 and again on 2026-09-02 against `798d53b7b`, with
+the full stage list `(into validation/concurrency-stages guards/guard-stages)`:
+
+| Payload | Before |
+|---|---|
+| `{:op :refine-claim :targets :claim-1}` | `IllegalArgumentException: Don't know how to create ISeq from: clojure.lang.Keyword`, thrown out of `validate` |
+| `{:op :challenge :targets #{"claim-1"} :evidence :e-1}` | same throw, from the guard stage |
+| a sibling `{:op :propose-experiment :discriminates :h-1}` | same throw, while the *challenge* was being validated |
+| `{:tx/operations :assert-claim}` | same throw, before any stage ran |
+| `{:op :refine-claim :targets "claim-1"}` | validated, then rejected as `:unknown-target` with `:missing #{\a \c \i \l \- \m \1}` |
+
+The last row is the string-walking hazard #1852 named for `:links`
+destinations, in the field that decides which objects an operation touches. A
+string is seqable, so `(set "claim-1")` yields seven single-character ids and
+the operation is reported against ids no activation named.
+
+The fourth row was found in self-review of the fix for the first three, not
+in the original report. `run/step` hands an activation's return value straight
+to `validate`, which iterates `:tx/operations` with `some`.
+
+## Changes in Detail
+
+### `transaction.clj`
+
+`id-fields` names the three operation fields that carry object ids —
+`:targets`, `:evidence`, `:discriminates`. It lives beside `touched-ids`,
+which reads the first of them, in the namespace that already holds the rest of
+the §3.2 payload vocabulary.
+
+### `validation.clj`
+
+1. `id-listing-defect` (Layer 0) — the one reading of an id-naming field, as
+   `[reason data]` or nil. Legal is absent, nil, or a collection of non-blank
+   strings. A scalar and a map are refused as `:non-collection-ids`; a
+   collection holding anything that is not a usable id is `:unusable-id`. A
+   string falls in the first case, which is the point: it is refused for its
+   shape rather than walked into characters. Total over arbitrary EDN.
+2. `id-listings` (Layer 0) — enumerates `[operation field value]` across a
+   whole transaction. Operations that are not maps are skipped rather than
+   interpreted, for the reason `proposed-specs` skips a non-sequential
+   `:creates`: `contains?` throws on a scalar, and reading fields out of a
+   payload that is not a map moves the crash rather than removing it.
+3. `check-id-fields` (Layer 1) — the stage, leading the payload stages.
+4. `validate` — `:tx/operations` must be nil or sequential.
+5. `concurrency-stages` — `check-id-fields` runs immediately after
+   `check-schema`.
+
+`id-listing-defect` and `id-listings` are siblings at Layer 0 composed by the
+Layer 1 stage, not one calling the other. Chaining them would add a fourth
+layer to the namespace, which SL003 refuses — the same constraint #1852 hit
+with `creation-defect` and `link-defect`.
+
+### `guards.clj`
+
+Docstring only. `backed?` reads `:evidence` and a sibling's `:discriminates`
+unscreened, and now says why that is safe: the concurrency stages establish
+the shape before any guard runs, which is why the guards must be composed onto
+that chain rather than run alone.
+
+### Why the whole transaction is scanned, and why the sibling is blamed
+
+`backed?` consults a *sibling's* `:discriminates` while validating a
+challenge. Stages run operation-major — every stage for operation 1, then
+every stage for operation 2 — so a stage reading only its own operation would
+reach a malformed sibling field before the operation carrying it had a turn.
+The scan therefore covers `:siblings`, as `check-creates` already does for
+duplicate ids.
+
+This inverts #1852's blame convention, deliberately. There, `:op` records
+where the pipeline *noticed*, because a duplicate id is a property of the
+transaction and not of either operation. Here the malformed field belongs to
+one operation, `:tx/operations` is a vector so which one is fixed by the
+payload, and naming the operation that noticed would describe a fault it does
+not have: for the third repro row above, `:challenge` would be blamed for
+`:propose-experiment`'s `:discriminates`.
+
+Left unfixed, the alternative — skipping the unreadable sibling and letting
+`backed?` return false — reports `:bare-challenge`, which is true but useless:
+it does not say that the experiment meant to back the challenge was
+unreadable.
+
+### Why the transaction-level check is not a stage
+
+No stage can run until `validate` has iterated `:tx/operations`, so the check
+sits in `validate` itself. Sequential rather than merely a collection, for the
+reason `check-creates` requires it of `:creates`: a set has no first
+operation, so which one the pipeline reported would vary between runs over
+identical input. A transaction with no `:tx/operations` at all is empty, not
+malformed, and still validates clean.
+
+### Scope of the `:evidence` tightening
+
+No reader requires `:evidence` to name ids — `backed?` only tests it for
+non-emptiness. Holding it to the same shape as `:targets` is a tightening
+beyond what is needed to stop the crash. It is kept because the field names
+evidence objects in every existing use, and because `:evidence [nil]` would
+otherwise back a challenge with nothing.
+
+## Testing Plan
+
+Run from `components/deliberation-workspace`:
+
+```bash
+clojure -M:test -e "(require 'ai.miniforge.deliberation-workspace.validation-test) (clojure.test/run-tests 'ai.miniforge.deliberation-workspace.validation-test)"
+```
+
+Added to `validation_test.clj`:
+
+- `id-fields-that-are-not-collections-of-ids-are-refused` — the three
+  reported scalars plus a number and a map.
+- `a-string-of-ids-is-refused-rather-than-walked` — the misroute, asserted on
+  the reason rather than the message.
+- `an-id-field-rejection-names-the-field-and-the-reason` — routing reads both
+  without parsing prose.
+- `a-malformed-id-field-is-blamed-on-the-operation-carrying-it` — the sibling
+  case, asserting `:propose-experiment` and not `:challenge`.
+- `well-formed-id-fields-pass` — sets, vectors, lists, absent, and nil.
+- `an-unusable-id-outranks-the-targets-it-would-be-looked-up-as` — ordering
+  against `check-targets`.
+- `an-operation-that-is-not-a-map-is-left-to-schema-conformance` — the
+  regression the sibling scan introduced and this fixes.
+- `a-transaction-whose-operations-are-not-a-sequence-is-refused` — scalar,
+  map and set, plus the empty transaction that stays legal.
+
+Added to `guards_test.clj`:
+
+- `the-fields-the-backing-check-reads-are-routed-not-thrown` — both guard-side
+  shapes over the composed pipeline, and that the shape fault outranks the
+  `:bare-challenge` that would be read out of it.
+
+Added to `run_test.clj`:
+
+- `an-unreadable-id-field-is-routed-not-thrown` — the rejection reaches the
+  event log as `:transaction/rejected`, the clock does not advance, and a
+  valid create in an earlier operation is discarded with it.
+- `an-activation-returning-a-malformed-transaction-is-routed` — the same for
+  the transaction-level shape.
+
+All 118 tests / 368 assertions in the component pass. `bb commit-budget`,
+`bb lint:clj`, `bb lint:stratum` and the full pre-commit suite pass on each of
+the two commits.
+
+## Deployment Plan
+
+Library change inside one component; no migration, no configuration. Ships
+with the next merge to `main`.
+
+## Related Issues/PRs
+
+- [#1852](https://github.com/miniforge-ai/miniforge/pull/1852) — operation
+  `:links` and cross-transaction duplicate creates, whose blame convention and
+  string-walking hazard this builds on.
+- [#1851](https://github.com/miniforge-ai/miniforge/pull/1851) — the
+  `check-creates` stage this one is ordered against.
+- [#1841](https://github.com/miniforge-ai/miniforge/pull/1841) — the Stage 0
+  run loop the routing tests assert against.
+
+## Checklist
+
+- [x] All five payload shapes reproduced before the fix, and re-checked after
+- [x] `:targets`, `:evidence` and `:discriminates` held to one shape
+- [x] Predicates total over arbitrary EDN, non-map operations included
+- [x] Rejections carry an `:anomalies.deliberation/...` subtype and reach the
+      event log through `run/step`
+- [x] Blame lands on the operation carrying the malformed field
+- [x] `validation.clj` still at 3 strata (SL003)
+- [x] Component test suite green

--- a/docs/pull-requests/2026-09-02-fix-n14-stage0-id-field-shapes.md
+++ b/docs/pull-requests/2026-09-02-fix-n14-stage0-id-field-shapes.md
@@ -158,8 +158,8 @@ Added to `run_test.clj`:
   the transaction-level shape.
 
 All 118 tests / 368 assertions in the component pass. `bb commit-budget`,
-`bb lint:clj`, `bb lint:stratum` and the full pre-commit suite pass on each of
-the two commits.
+`bb lint:clj`, `bb lint:stratum` and the full pre-commit suite pass on every
+commit.
 
 ## Deployment Plan
 


### PR DESCRIPTION
## Overview

Four agent-reachable payload shapes threw `IllegalArgumentException` out of `validation/validate` itself, and a fifth was accepted and misrouted. This PR refuses all five as anomalies carrying an `:anomalies.deliberation/...` subtype, so `run/step` records a `:transaction/rejected` event instead of dying.

Full write-up: [docs/pull-requests/2026-09-02-fix-n14-stage0-id-field-shapes.md](docs/pull-requests/2026-09-02-fix-n14-stage0-id-field-shapes.md)

## Motivation

#1852 closed the operation-level `:links` gaps and the cross-transaction duplicate creates. These are the same class — activation-controlled input reaching the engine as an exception rather than as a routable rejection — but they fail harder. A commit-time throw at least happens after `validate` returned. These throw from inside the pipeline: no stage returns, `run/step` never receives an anomaly, and there is nothing to route or log.

Reproduced on 2026-08-29 and again on 2026-09-02 against `798d53b7b`, with the full stage list `(into validation/concurrency-stages guards/guard-stages)`:

| Payload | Before |
|---|---|
| `{:op :refine-claim :targets :claim-1}` | `IllegalArgumentException: Don't know how to create ISeq from: clojure.lang.Keyword`, out of `validate` |
| `{:op :challenge :targets #{"claim-1"} :evidence :e-1}` | same throw, from the guard stage |
| a sibling `{:op :propose-experiment :discriminates :h-1}` | same throw, while the *challenge* was being validated |
| `{:tx/operations :assert-claim}` | same throw, before any stage ran |
| `{:op :refine-claim :targets "claim-1"}` | validated, then rejected as `:unknown-target` with `:missing #{\a \c \i \l \- \m \1}` |

The last row is the string-walking hazard #1852 named for `:links` destinations, in the field that decides which objects an operation touches. The fourth was found in self-review of the fix for the first three: `run/step` hands an activation's return value straight to `validate`, which iterates `:tx/operations` with `some`.

## Changes

- `transaction.clj` — `id-fields` names the three id-carrying operation fields, beside `touched-ids` which reads one of them.
- `validation.clj` — `id-listing-defect` and `id-listings` at Layer 0, `check-id-fields` at Layer 1 leading the payload stages, and a `:tx/operations` shape guard in `validate` itself.
- `guards.clj` — docstring only: `backed?` now says why it may read `:evidence` and a sibling's `:discriminates` unscreened.

Legal for an id field is absent, nil, or a collection of non-blank strings. A scalar, string or map is `:non-collection-ids`; a collection holding a non-id is `:unusable-id`.

Two design points worth review, argued in full in the PR doc:

1. **The scan covers the whole transaction.** `backed?` consults a *sibling's* `:discriminates`, and stages run operation-major, so a stage reading only its own operation would reach a malformed sibling field before that operation had a turn.
2. **Blame lands on the operation carrying the field**, inverting #1852's convention. There, `:op` recorded where the pipeline noticed, because a duplicate id is a property of the transaction. Here the fault belongs to one operation, and naming the noticing one would blame `:challenge` for `:propose-experiment`'s payload.

`id-listing-defect` and `id-listings` are Layer 0 siblings composed by the Layer 1 stage, not one calling the other — chaining them would push the namespace to a fourth layer, which SL003 refuses.

## Testing

118 tests / 368 assertions in the component pass. `bb commit-budget`, `bb lint:clj`, `bb lint:stratum` and the full pre-commit suite pass on every commit.

New coverage in `validation_test.clj` (shapes, reasons, sibling blame, stage ordering, non-map operations, transaction-level shape), `guards_test.clj` (both guard-side fields over the composed pipeline, and that the shape fault outranks the `:bare-challenge` read out of it), and `run_test.clj` (the rejection reaches the event log, the clock does not advance, an earlier valid create is discarded with it).

## Related

- #1852 — operation `:links` and cross-transaction duplicate creates
- #1851 — the `check-creates` stage this is ordered against
- #1841 — the Stage 0 run loop the routing tests assert against

🤖 Generated with [Claude Code](https://claude.com/claude-code)
