### PR TITLE
fix(gate): cumulative-diff stale-reference gating; implementer prompt-section telemetry

### DIFF
--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -309,6 +309,20 @@
        (map #(count (str/split-lines %)))
        (reduce + 0)))
 
+(defn ^{:stratum 0} task-sections
+  "The evidence sections `task->text` will actually render for `task`,
+   in render order — the ONE place the render predicates live, so the
+   prompt-section telemetry can only ever claim what was rendered.
+   :task/gate-failures renders on non-empty; the others on presence."
+  [task]
+  (when (map? task)
+    (cond-> []
+      (:task/prior-attempts task) (conj :task/prior-attempts)
+      (seq (:task/gate-failures task)) (conj :task/gate-failures)
+      (:task/phase-handoff task) (conj :task/phase-handoff)
+      (:task/review-feedback task) (conj :task/review-feedback)
+      (:task/verify-failures task) (conj :task/verify-failures))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (def ^{:stratum 1} CodeArtifact
@@ -680,10 +694,11 @@
                       verify-failures (:task/verify-failures task)
                       gate-failures (:task/gate-failures task)
                       prior-attempts (:task/prior-attempts task)
+                      sections (set (task-sections task))
                       parts (cond-> []
-                              prior-attempts
+                              (sections :task/prior-attempts)
                               (conj (format-prior-attempts-section prior-attempts))
-                              (seq gate-failures)
+                              (sections :task/gate-failures)
                               (conj (format-gate-failures-section gate-failures))
                               phase-handoff
                               (conj (format-phase-handoff-section phase-handoff))
@@ -974,12 +989,7 @@
           ;; retry's prompt contents were unverifiable from the record.
           (when logger
             (log/info logger :implementer :implementer/prompt-sections
-                      {:data {:sections (filterv #(contains? input %)
-                                                 [:task/prior-attempts
-                                                  :task/gate-failures
-                                                  :task/phase-handoff
-                                                  :task/review-feedback
-                                                  :task/verify-failures])
+                      {:data {:sections (task-sections input)
                               :prompt-chars (count user-prompt)}}))
           (if llm-client
             (invoke-with-llm llm-client user-prompt effective-system-prompt

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -700,7 +700,7 @@
                               (conj (format-prior-attempts-section prior-attempts))
                               (sections :task/gate-failures)
                               (conj (format-gate-failures-section gate-failures))
-                              phase-handoff
+                              (sections :task/phase-handoff)
                               (conj (format-phase-handoff-section phase-handoff))
                               desc
                               (conj desc)
@@ -708,9 +708,9 @@
                               (conj (format-plan-section plan))
                               (and intent (map? intent))
                               (conj (format-intent-section intent))
-                              review-feedback
+                              (sections :task/review-feedback)
                               (conj (format-review-section review-feedback))
-                              verify-failures
+                              (sections :task/verify-failures)
                               (conj (format-verify-section verify-failures)))]
                   (if (seq parts)
                     (str/join "" parts)

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -969,6 +969,18 @@
               task-text (task->text input)
               effective-system-prompt (build-effective-system-prompt input)
               user-prompt (build-user-prompt task-text input)]
+          ;; Ground truth for which evidence sections this prompt carried —
+          ;; stream dumps record the model's OUTPUT, not its input, so a
+          ;; retry's prompt contents were unverifiable from the record.
+          (when logger
+            (log/info logger :implementer :implementer/prompt-sections
+                      {:data {:sections (filterv #(contains? input %)
+                                                 [:task/prior-attempts
+                                                  :task/gate-failures
+                                                  :task/phase-handoff
+                                                  :task/review-feedback
+                                                  :task/verify-failures])
+                              :prompt-chars (count user-prompt)}}))
           (if llm-client
             (invoke-with-llm llm-client user-prompt effective-system-prompt
                              config context on-chunk logger

--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -15,13 +15,13 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.agent.interface
   "Canonical public boundary for the agent component.
    Public API groups are decomposed into ai.miniforge.agent.interface.* namespaces,
    while this namespace remains the Polylith entrypoint."
   (:require
    [ai.miniforge.agent.file-artifacts :as file-artifacts]
+   [ai.miniforge.agent.implementer :as implementer]
    [ai.miniforge.agent.interface.classification :as classification]
    [ai.miniforge.agent.interface.llm :as llm]
    [ai.miniforge.agent.interface.memory :as memory]
@@ -36,80 +36,92 @@
    [ai.miniforge.agent.tool-supervisor :as tool-supervisor]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Protocols and configuration
 
-(def Agent
+;; Protocols and configuration
+(def ^{:stratum 0} Agent
   "Protocol: agent behavior and lifecycle. Methods invoke/validate/repair.
    Implement to define a custom agent that processes tasks into
    artifacts/decisions/signals."
   protocols/Agent)
-(def AgentLifecycle
+
+(def ^{:stratum 0} AgentLifecycle
   "Protocol: agent lifecycle management (init/status/shutdown/abort).
    Implement to control how an agent is initialized and torn down."
   protocols/AgentLifecycle)
-(def AgentExecutor
+
+(def ^{:stratum 0} AgentExecutor
   "Protocol: runs an agent on a task through the full
    init->invoke->validate->repair->complete lifecycle. Implement to
    customize execution orchestration."
   protocols/AgentExecutor)
-(def LLMBackend
+
+(def ^{:stratum 0} LLMBackend
   "Protocol: LLM interaction (single method complete). Implement to swap
    or mock the language-model backend."
   protocols/LLMBackend)
-(def Memory
+
+(def ^{:stratum 0} Memory
   "Protocol: agent memory storage and retrieval (add-message, get-messages,
    get-window, clear-messages, get-metadata). Implement for a custom store."
   protocols/Memory)
-(def MemoryStore
+
+(def ^{:stratum 0} MemoryStore
   "Protocol: managing multiple agent memories (get/save/delete/list).
    Implement to back memory persistence with a custom store."
   protocols/MemoryStore)
-(def InterAgentMessaging
+
+(def ^{:stratum 0} InterAgentMessaging
   "Protocol: send/receive/respond messages between agents during execution.
    Implement to customize how an agent exchanges messages."
   protocols/InterAgentMessaging)
-(def MessageRouter
+
+(def ^{:stratum 0} MessageRouter
   "Protocol: routes and queues messages between agents
    (route-message, get-messages-for-agent, get-messages-by-workflow,
    clear-messages). Implement for a custom delivery mechanism."
   protocols/MessageRouter)
-(def MessageValidator
+
+(def ^{:stratum 0} MessageValidator
   "Protocol: validates message structure against schema (validate-message).
    Implement to plug in custom message validation."
   protocols/MessageValidator)
-(def default-role-configs
+
+(def ^{:stratum 0} default-role-configs
   "Map of agent role keyword -> default config map. Each config carries
    static fields (temperature, max-tokens, budget) from
    role-defaults.edn plus a dynamically selected :model."
   protocols/default-role-configs)
-(def role-capabilities
+
+(def ^{:stratum 0} role-capabilities
   "Map of agent role keyword -> set of capability keywords
    (e.g. :planner -> #{:plan :decompose :estimate})."
   protocols/role-capabilities)
-(def role-system-prompts
+
+(def ^{:stratum 0} role-system-prompts
   "Map of agent role keyword -> system-prompt string for that role."
   protocols/role-system-prompts)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Runtime and memory API
-
-(def create-agent
+(def ^{:stratum 0} create-agent
   "Create an agent by role with optional config overrides. Args: role
    (keyword e.g. :planner :implementer), optional opts map (:model
    :temperature :max-tokens :budget :phase :privacy-required etc.).
    Returns a BaseAgent record satisfying the Agent protocol."
   runtime/create-agent)
-(def create-agent-map
+
+(def ^{:stratum 0} create-agent-map
   "Create an agent and return it as a plain map conforming to the Agent
    schema (useful for serialization/storage). Args: role, optional opts.
    Returns a map with :agent/* keys."
   runtime/create-agent-map)
-(def create-executor
+
+(def ^{:stratum 0} create-executor
   "Create an agent executor. Arg (optional): config map (e.g.
    {:memory-store ...}). Returns a value satisfying the AgentExecutor
    protocol."
   runtime/create-executor)
-(def execute
+
+(def ^{:stratum 0} execute
   "Run an agent on a task through the full lifecycle. Args: executor, agent,
    task, context. Thin delegate to the AgentExecutor protocol: returns the
    executor's result map, which is the agent's invoke result (commonly the
@@ -117,469 +129,574 @@
    metadata (:metrics :tool/invocations :agent-id :task-id :executed-at).
    Exact keys depend on the agent and executor implementations."
   runtime/execute)
-(def invoke
+
+(def ^{:stratum 0} invoke
   "Invoke an agent's main logic on a task, with supervisory projection
    wrapping. Args: agent, task, context. Thin delegate to the Agent protocol's
    invoke: returns the agent's result map (commonly the canonical
    {:status :success|:error :output ...}, optionally augmented by the
    supervisory projection). Exact keys depend on the agent implementation."
   runtime/invoke)
-(def validate
+
+(def ^{:stratum 0} validate
   "Check whether agent output meets requirements. Args: agent, output,
    context. Returns {:valid? bool :errors [...] :warnings [...]}."
   runtime/validate)
-(def repair
+
+(def ^{:stratum 0} repair
   "Attempt to fix validation failures. Args: agent, output, errors, context.
    Thin delegate to the Agent protocol's repair: returns the agent's repair
    result map (commonly the canonical {:status :success|:error :output ...}).
    Exact keys depend on the agent implementation."
   runtime/repair)
-(def init
+
+(def ^{:stratum 0} init
   "Initialize an agent with configuration. Args: agent, config. Returns the
    initialized agent instance."
   runtime/init)
-(def agent-status
+
+(def ^{:stratum 0} agent-status
   "Return an agent's current status. Arg: agent. Returns
    {:state keyword :metrics {...} :last-activity inst}."
   runtime/agent-status)
-(def shutdown
+
+(def ^{:stratum 0} shutdown
   "Clean up agent resources. Arg: agent. Returns {:success bool}."
   runtime/shutdown)
 
-(def create-memory
+(def ^{:stratum 0} create-memory
   "Create a new agent memory. Arg (optional): {:scope :scope-id :metadata};
    :scope defaults to :task. Returns an AgentMemory (a Memory) with an
    empty message list."
   memory/create-memory)
-(def add-to-memory
+
+(def ^{:stratum 0} add-to-memory
   "Append a message to memory under the given role. Args: memory, role
    (keyword), content. Returns the updated memory."
   memory/add-to-memory)
-(def add-system-message
+
+(def ^{:stratum 0} add-system-message
   "Append a :system message to memory. Args: memory, content (string).
    Returns the updated memory."
   memory/add-system-message)
-(def add-user-message
+
+(def ^{:stratum 0} add-user-message
   "Append a :user message to memory. Args: memory, content (string).
    Returns the updated memory."
   memory/add-user-message)
-(def add-assistant-message
+
+(def ^{:stratum 0} add-assistant-message
   "Append an :assistant message to memory. Args: memory, content (string),
    optional :tokens. Returns the updated memory."
   memory/add-assistant-message)
-(def get-messages
+
+(def ^{:stratum 0} get-messages
   "Return all messages in memory in chronological order (a sequence of
    message maps). Arg: memory."
   memory/get-messages)
-(def get-memory-window
+
+(def ^{:stratum 0} get-memory-window
   "Return the most recent messages fitting within token-limit. Args: memory,
    token-limit (int). Returns {:messages [...] :total-tokens int
    :trimmed-count int}; system messages are always preserved."
   memory/get-memory-window)
-(def clear-memory
+
+(def ^{:stratum 0} clear-memory
   "Remove all messages from memory. Arg: memory. Returns the emptied memory."
   memory/clear-memory)
-(def memory-metadata
+
+(def ^{:stratum 0} memory-metadata
   "Return memory metadata. Arg: memory. Returns a map merging stored
    metadata with :memory/id :memory/scope :memory/message-count
    :memory/total-tokens."
   memory/memory-metadata)
-(def create-memory-store
+
+(def ^{:stratum 0} create-memory-store
   "Create an in-memory MemoryStore backed by an atom. No args.
    Returns an InMemoryStore (a MemoryStore)."
   memory/create-memory-store)
-(def get-memory
+
+(def ^{:stratum 0} get-memory
   "Retrieve a memory from a store by id. Args: store, memory-id.
    Returns the memory, or nil if absent."
   memory/get-memory)
-(def save-memory
+
+(def ^{:stratum 0} save-memory
   "Save/update a memory in a store. Args: store, memory. Returns the memory."
   memory/save-memory)
-(def delete-memory
+
+(def ^{:stratum 0} delete-memory
   "Delete a memory from a store by id. Args: store, memory-id. Returns nil."
   memory/delete-memory)
-(def list-memories
+
+(def ^{:stratum 0} list-memories
   "List memories in a store matching a scope. Args: store, scope, scope-id.
    Returns a sequence of memories."
   memory/list-memories)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Messaging, utilities, specialized agents, and meta-operations
-
-(def create-message-router
+(def ^{:stratum 0} create-message-router
   "Create a message router. No args. Returns a MessageRouter record backed by
    atoms for per-workflow messages and per-agent inboxes."
   messaging/create-message-router)
-(def create-agent-messaging
+
+(def ^{:stratum 0} create-agent-messaging
   "Create messaging capability for an agent. Args: agent-id (keyword),
    instance-id (uuid), workflow-id (uuid), router, optional event-stream.
    Returns an AgentMessaging record (an InterAgentMessaging)."
   messaging/create-agent-messaging)
-(def send-message
+
+(def ^{:stratum 0} send-message
   "Send a message from agent-messaging to the target specified in message-data.
    Event emission is handled by the impl layer."
   messaging/send-message)
-(def receive-messages
+
+(def ^{:stratum 0} receive-messages
   "Return all messages received by this agent. Arg: agent-messaging.
    Returns a sequence of message maps."
   messaging/receive-messages)
-(def respond-to-message
+
+(def ^{:stratum 0} respond-to-message
   "Respond to a message. Event emission is handled by the impl layer."
   messaging/respond-to-message)
-(def send-clarification-request
+
+(def ^{:stratum 0} send-clarification-request
   "Send a :clarification-request to another agent. Args: agent-messaging,
    to-agent (keyword), content (string). Returns {:message map :event map}."
   messaging/send-clarification-request)
-(def send-concern
+
+(def ^{:stratum 0} send-concern
   "Send a :concern to another agent. Args: agent-messaging, to-agent
    (keyword), content (string). Returns {:message map :event map}."
   messaging/send-concern)
-(def send-suggestion
+
+(def ^{:stratum 0} send-suggestion
   "Send a :suggestion to another agent. Args: agent-messaging, to-agent
    (keyword), content (string). Returns {:message map :event map}."
   messaging/send-suggestion)
-(def get-clarification-requests
+
+(def ^{:stratum 0} get-clarification-requests
   "Return received messages of type :clarification-request. Arg:
    agent-messaging. Returns a sequence of message maps."
   messaging/get-clarification-requests)
-(def get-concerns
+
+(def ^{:stratum 0} get-concerns
   "Return received messages of type :concern. Arg: agent-messaging.
    Returns a sequence of message maps."
   messaging/get-concerns)
-(def get-suggestions
+
+(def ^{:stratum 0} get-suggestions
   "Return received messages of type :suggestion. Arg: agent-messaging.
    Returns a sequence of message maps."
   messaging/get-suggestions)
-(def route-message
+
+(def ^{:stratum 0} route-message
   "Route a message to its recipient."
   messaging/route-message)
-(def get-messages-for-agent
+
+(def ^{:stratum 0} get-messages-for-agent
   "Return messages for a specific agent in a workflow. Args: router, agent-id,
    workflow-id. Returns a sequence of message maps (the agent's inbox)."
   messaging/get-messages-for-agent)
-(def get-messages-by-workflow
+
+(def ^{:stratum 0} get-messages-by-workflow
   "Return all messages in a workflow, ordered by timestamp. Args: router,
    workflow-id. Returns a sequence of message maps."
   messaging/get-messages-by-workflow)
-(def clear-workflow-messages
+
+(def ^{:stratum 0} clear-workflow-messages
   "Clear all messages for a workflow. Args: router, workflow-id. Returns nil."
   messaging/clear-workflow-messages)
-(def validate-message
+
+(def ^{:stratum 0} validate-message
   "Validate a message map against the Message schema. Arg: message.
    Returns {:valid? boolean :errors [...]}."
   messaging/validate-message)
-(def Message
+
+(def ^{:stratum 0} Message
   "Malli schema (a [:map ...] vector) for an inter-agent message, per N1
    §6.2.2. Required keys include :message/id :message/type :message/from-agent
    :message/to-agent :message/workflow-id :message/content :message/timestamp."
   messaging/Message)
-(def MessageType
+
+(def ^{:stratum 0} MessageType
   "Malli schema (a [:enum ...] vector) of valid message types:
    :clarification-request :clarification-response :concern :suggestion."
   messaging/MessageType)
 
-(def estimate-tokens
+(def ^{:stratum 0} estimate-tokens
   "Estimate token count for message content. Arg: content (any). Returns an
    int: for strings, max(1, chars/4); 100 for non-string content."
   llm/estimate-tokens)
-(def estimate-cost
+
+(def ^{:stratum 0} estimate-cost
   "Estimate cost in USD for token usage. Args: input-tokens, output-tokens,
    model (string). Returns a double; unknown/unpriced models return 0.0."
   llm/estimate-cost)
-(def create-mock-llm
+
+(def ^{:stratum 0} create-mock-llm
   "Create a mock LLMBackend record for testing. Arg (optional): a single
    response map or a sequence of them; defaults to a canned response.
    Returns a value satisfying the LLMBackend protocol."
   llm/create-mock-llm)
 
-(def create-base-agent
+(def ^{:stratum 0} create-base-agent
   "Create a base (functional) agent from callbacks. Arg: options map requiring
    :role :system-prompt :invoke-fn :validate-fn :repair-fn, with optional
    :config :logger. Returns a FunctionalAgent record (an Agent)."
   specialized/create-base-agent)
-(def make-validator
+
+(def ^{:stratum 0} make-validator
   "Build a validate-fn from a Malli schema. Arg: malli-schema. Returns a fn of
    output -> {:valid? bool :errors nil-or-explanation}."
   specialized/make-validator)
-(def cycle-agent
+
+(def ^{:stratum 0} cycle-agent
   "Run an invoke->validate->repair cycle on a specialized agent. Args: agent,
    context, input, optional :max-iterations (default 3). Returns the final
    result map after repair attempts."
   specialized/cycle-agent)
-(def create-planner
+
+(def ^{:stratum 0} create-planner
   "Create a Planner agent. Arg (optional): options map (:config :logger
    :llm-backend). Returns a FunctionalAgent record (an Agent)."
   specialized/create-planner)
-(def create-implementer
+
+(def ^{:stratum 0} create-implementer
   "Create an Implementer agent. Arg (optional): options map. Returns a
    FunctionalAgent record (an Agent)."
   specialized/create-implementer)
-(def create-tester
+
+(def ^{:stratum 0} implementer-task->text
+  "Render an implementer task map to the user-prompt text the LLM sees —
+   the seam evidence sections (gate denial, verify failures, review
+   feedback) must survive through. Arg: task map. Returns a string."
+  implementer/task->text)
+
+(def ^{:stratum 0} create-tester
   "Create a Tester agent. Arg (optional): options map. Returns a
    FunctionalAgent record (an Agent)."
   specialized/create-tester)
-(def create-reviewer
+
+(def ^{:stratum 0} create-reviewer
   "Create a Reviewer agent (LLM-backed review + deterministic gates, falling
    back to gate-only without an LLM). Arg (optional): options map
    (:gates :strict :logger :llm-backend :config). Returns a FunctionalAgent
    record (an Agent)."
   specialized/create-reviewer)
-(def create-releaser
+
+(def ^{:stratum 0} create-releaser
   "Create a Releaser agent. Arg (optional): options map. Returns a
    FunctionalAgent record (an Agent)."
   specialized/create-releaser)
-(def curate
+
+(def ^{:stratum 0} curate
   "Curator entry point (a multimethod dispatching on :curator/kind). Arg:
    input map. Returns a response map whose :output is a CuratedArtifact on
    success, or an error response. Dispatch: :implement (default) and
    :merge-resolution."
   specialized/curate)
-(def curate-implement-output
+
+(def ^{:stratum 0} curate-implement-output
   "Curate an implementer's result + environment state into a CuratedArtifact.
    Arg: input map (requires :implementer-result, :worktree-path; see impl for
    capsule-mode keys). Returns a success response with :output a
    CuratedArtifact, or an error response when no files were written. Thin
    wrapper over (curate (assoc input :curator/kind :implement))."
   specialized/curate-implement-output)
-(def CuratedArtifact
+
+(def ^{:stratum 0} CuratedArtifact
   "Malli schema (a [:map ...] vector) for the curator's structured output,
    consumed by verify/review/release/PR-doc phases. Keys include :code/id
    :code/files :code/summary :code/tests-added? :code/scope-deviations
    :code/breaking-change? :code/curated-at :code/curator-source."
   specialized/CuratedArtifact)
-(def CuratedFileEntry
+
+(def ^{:stratum 0} CuratedFileEntry
   "Malli schema (a [:map ...] vector) for one file in a CuratedArtifact:
    :path (string) :content (string) :action (:create|:modify|:delete)."
   specialized/CuratedFileEntry)
-(def validate-curated-artifact
+
+(def ^{:stratum 0} validate-curated-artifact
   "Validate a CuratedArtifact against its schema. Arg: artifact. Returns a
    validation result (schema/valid or schema/invalid map)."
   specialized/validate-curated-artifact)
-(def substantive-file?
+
+(def ^{:stratum 0} substantive-file?
   "True when a file entry represents real implementer work, not a
    runtime/session side-effect. Arg: file-entry map. Returns boolean."
   specialized/substantive-file?)
-(def non-substantive-paths
+
+(def ^{:stratum 0} non-substantive-paths
   "Set of file paths the curator drops before assessing 'files written'
    (runtime/session markers). A set of strings (currently
    #{\".miniforge-session-id\"}), not a vector."
   specialized/non-substantive-paths)
-(def Plan
+
+(def ^{:stratum 0} Plan
   "Malli schema (a [:map ...] vector) for a planner's output: :plan/id
    :plan/name :plan/tasks (vector of PlanTask) plus optional complexity,
    risks, assumptions."
   specialized/Plan)
-(def PlanTask
+
+(def ^{:stratum 0} PlanTask
   "Malli schema (a [:map ...] vector) for one task in a Plan: :task/id
    :task/description :task/type plus optional dependencies, acceptance
    criteria, effort, component, stratum, merge-strategy."
   specialized/PlanTask)
-(def CodeArtifact
+
+(def ^{:stratum 0} CodeArtifact
   "Malli schema (a [:map ...] vector) for the implementer's output: :code/id
    :code/files (vector of CodeFile) plus optional dependencies-added,
    tests-needed?, language, summary."
   specialized/CodeArtifact)
-(def CodeFile
+
+(def ^{:stratum 0} CodeFile
   "Malli schema (a [:map ...] vector) for one code file: :path :content
    :action (:create|:modify|:delete)."
   specialized/CodeFile)
-(def TestArtifact
+
+(def ^{:stratum 0} TestArtifact
   "Malli schema (a [:map ...] vector) for the tester's output: :test/id
    :test/files (vector of TestFile) :test/type plus optional coverage,
    framework, assertions/cases counts, summary."
   specialized/TestArtifact)
-(def TestFile
+
+(def ^{:stratum 0} TestFile
   "Malli schema (a [:map ...] vector) for one test file: :path :content."
   specialized/TestFile)
-(def Coverage
+
+(def ^{:stratum 0} Coverage
   "Malli schema (a [:map ...] vector) for test coverage: optional :lines
    :branches :functions, each a double 0.0-100.0."
   specialized/Coverage)
-(def ReviewArtifact
+
+(def ^{:stratum 0} ReviewArtifact
   "Malli schema (a [:map ...] vector) for the reviewer's output: :review/id
    :review/decision (enum) :review/gate-results :review/summary plus gate
    counts and optional blocking-issues, warnings, recommendations, issues,
    strengths."
   specialized/ReviewArtifact)
-(def ReviewIssue
+
+(def ^{:stratum 0} ReviewIssue
   "Malli schema (a [:map ...] vector) for a single review issue: :severity
    (:blocking|:warning|:nit) :description plus optional :file :line
    :suggestion (each nil-tolerant)."
   specialized/ReviewIssue)
-(def GateFeedback
+
+(def ^{:stratum 0} GateFeedback
   "Malli schema (a [:map ...] vector) for feedback from one gate: :gate-id
    :gate-type :passed? plus optional errors, warnings, duration-ms."
   specialized/GateFeedback)
-(def ReleaseArtifact
+
+(def ^{:stratum 0} ReleaseArtifact
   "Malli schema (a [:map ...] vector) for the releaser's output:
    :release/id :release/branch-name :release/commit-message :release/pr-title
    :release/pr-description plus optional files-summary."
   specialized/ReleaseArtifact)
-(def plan-summary
+
+(def ^{:stratum 0} plan-summary
   "Summarize a plan for logging/display. Arg: plan. Returns a map
    {:id :name :task-count :complexity :risk-count}."
   specialized/plan-summary)
-(def task-dependency-order
+
+(def ^{:stratum 0} task-dependency-order
   "Topologically sort a plan's tasks (dependency-free first). Arg: plan.
    Returns a vector of task maps; on a cycle, remaining tasks are appended."
   specialized/task-dependency-order)
-(def validate-plan
+
+(def ^{:stratum 0} validate-plan
   "Validate a plan against the Plan schema and check structural issues
    (invalid/circular deps). Arg: plan. Returns {:valid? bool :errors ...}."
   specialized/validate-plan)
-(def code-summary
+
+(def ^{:stratum 0} code-summary
   "Summarize a code artifact for logging/display. Arg: artifact. Returns a
    map {:id :file-count :actions :language :tests-needed? :dependencies-added}."
   specialized/code-summary)
-(def files-by-action
+
+(def ^{:stratum 0} files-by-action
   "Group a code artifact's files by :action. Arg: artifact. Returns a map of
    action keyword -> vector of file maps."
   specialized/files-by-action)
-(def total-lines
+
+(def ^{:stratum 0} total-lines
   "Count total lines of code in an artifact (excluding :delete files). Arg:
    artifact. Returns an int."
   specialized/total-lines)
-(def validate-code-artifact
+
+(def ^{:stratum 0} validate-code-artifact
   "Validate a code artifact against the schema and check for issues (empty
    creates, duplicate paths). Arg: artifact. Returns a validation result
    (schema/valid or schema/invalid map)."
   specialized/validate-code-artifact)
-(def test-summary
+
+(def ^{:stratum 0} test-summary
   "Summarize a test artifact for logging/display. Arg: artifact. Returns a
    map {:id :file-count :type :framework :assertions :cases :coverage}."
   specialized/test-summary)
-(def coverage-meets-threshold?
+
+(def ^{:stratum 0} coverage-meets-threshold?
   "Check whether an artifact's coverage meets thresholds. Args: artifact,
    optional :lines :branches :functions (defaults 80/70/80). Returns boolean."
   specialized/coverage-meets-threshold?)
-(def tests-by-path
+
+(def ^{:stratum 0} tests-by-path
   "Map a test artifact's file paths to their content. Arg: artifact. Returns
    a map of path string -> content string."
   specialized/tests-by-path)
-(def validate-test-artifact
+
+(def ^{:stratum 0} validate-test-artifact
   "Validate a test artifact against the schema and check for issues (naming
    convention, missing assertions). Arg: artifact. Returns
    {:valid? bool :errors ...}."
   specialized/validate-test-artifact)
-(def review-summary
+
+(def ^{:stratum 0} review-summary
   "Summarize a review artifact for logging/display. Arg: artifact. Returns a
    map {:id :decision :gates-passed :gates-failed :gates-total
    :blocking-issues-count :warnings-count :llm-issues-count}."
   specialized/review-summary)
-(def approved?
+
+(def ^{:stratum 0} approved?
   "True when a review artifact's :review/decision is :approved. Arg: artifact.
    Returns boolean."
   specialized/approved?)
-(def rejected?
+
+(def ^{:stratum 0} rejected?
   "True when a review artifact's :review/decision is :rejected. Arg: artifact.
    Returns boolean."
   specialized/rejected?)
-(def conditionally-approved?
+
+(def ^{:stratum 0} conditionally-approved?
   "True when a review artifact's :review/decision is :conditionally-approved.
    Arg: artifact. Returns boolean."
   specialized/conditionally-approved?)
-(def get-blocking-issues
+
+(def ^{:stratum 0} get-blocking-issues
   "Extract blocking issues from a review artifact. Arg: artifact. Returns a
    vector of strings (empty if none)."
   specialized/get-blocking-issues)
-(def get-review-warnings
+
+(def ^{:stratum 0} get-review-warnings
   "Extract warnings from a review artifact. Arg: artifact. Returns a vector of
    strings (empty if none)."
   specialized/get-review-warnings)
-(def get-recommendations
+
+(def ^{:stratum 0} get-recommendations
   "Extract recommendations from a review artifact. Arg: artifact. Returns a
    vector of strings (empty if none)."
   specialized/get-recommendations)
-(def changes-requested?
+
+(def ^{:stratum 0} changes-requested?
   "True when a review artifact's :review/decision is :changes-requested. Arg:
    artifact. Returns boolean."
   specialized/changes-requested?)
-(def get-review-issues
+
+(def ^{:stratum 0} get-review-issues
   "Extract LLM review issues from a review artifact. Arg: artifact. Returns a
    vector of ReviewIssue maps (empty if none)."
   specialized/get-review-issues)
-(def get-review-strengths
+
+(def ^{:stratum 0} get-review-strengths
   "Extract strengths noted by the LLM from a review artifact. Arg: artifact.
    Returns a vector of strings (empty if none)."
   specialized/get-review-strengths)
-(def validate-review-artifact
+
+(def ^{:stratum 0} validate-review-artifact
   "Validate a review artifact against the schema and check gate-count
    consistency. Arg: artifact. Returns {:valid? bool :errors ...}."
   specialized/validate-review-artifact)
-(def rejection-warnings-only?
+
+(def ^{:stratum 0} rejection-warnings-only?
   "True when a review is a rejection driven solely by warnings (no blocking
    issues). Arg: artifact. Returns boolean."
   specialized/rejection-warnings-only?)
-(def review-fingerprint
+
+(def ^{:stratum 0} review-fingerprint
   "Reduce a review artifact to a stable, comparable fingerprint of its
    actionable items. Arg: review. Returns a sorted vector of
    [severity file line description] tuples (empty when nothing is actionable)."
   specialized/review-fingerprint)
-(def review-stagnated?
+
+(def ^{:stratum 0} review-stagnated?
   "True when a review's fingerprint exactly matches the prior one (repair
    loop made no actionable change). Args: prior (may be nil), current.
    Returns boolean; false on first iteration or empty current fingerprint."
   specialized/review-stagnated?)
-(def release-summary
+
+(def ^{:stratum 0} release-summary
   "Summarize a release artifact for logging/display. Arg: artifact. Returns a
    map {:id :branch :pr-title :files-summary}."
   specialized/release-summary)
-(def validate-release-artifact
+
+(def ^{:stratum 0} validate-release-artifact
   "Validate a release artifact against the schema and check for issues (branch
    name spaces, PR-title length, empty commit first line). Arg: artifact.
    Returns {:valid? bool :errors ...}."
   specialized/validate-release-artifact)
 
-(def create-progress-monitor-agent
+(def ^{:stratum 0} create-progress-monitor-agent
   "Create a Progress Monitor meta-agent. Arg (optional): options map
    (:check-interval-ms :priority :stagnation-threshold-ms :max-total-ms).
    Returns a meta-agent suitable for a meta coordinator."
   meta/create-progress-monitor-agent)
-(def create-meta-coordinator
+
+(def ^{:stratum 0} create-meta-coordinator
   "Create a meta-agent coordinator over a set of meta-agents. Arg: vector of
    meta-agent instances. Returns a MetaCoordinator record."
   meta/create-meta-coordinator)
-(def check-all-meta-agents
+
+(def ^{:stratum 0} check-all-meta-agents
   "Run due health checks across all enabled meta-agents. Args: coordinator,
    workflow-state. Returns {:status :healthy|:warning|:halt :checks [...]}
    with :halt-reason/:halting-agent when status is :halt."
   meta/check-all-meta-agents)
-(def reset-all-meta-agents!
+
+(def ^{:stratum 0} reset-all-meta-agents!
   "Reset all meta-agent state (on workflow restart). Arg: coordinator.
    Returns the coordinator."
   meta/reset-all-meta-agents!)
-(def get-meta-check-history
+
+(def ^{:stratum 0} get-meta-check-history
   "Return recent meta-agent health-check history. Args: coordinator, optional
    {:limit :agent-id :status}. Returns a sequence of check-record maps."
   meta/get-meta-check-history)
-(def get-meta-agent-stats
+
+(def ^{:stratum 0} get-meta-agent-stats
   "Return per-meta-agent statistics. Arg: coordinator. Returns
    {:agents [{:id :name :checks-run :last-check :last-status
               :halt-count :warning-count ...}]}."
   meta/get-meta-agent-stats)
-(def create-supervision-coordinator
+
+(def ^{:stratum 0} create-supervision-coordinator
   "Create a supervision coordinator over a set of supervisor agents. Arg:
    vector of meta-agent instances. Returns a MetaCoordinator record."
   supervision/create-supervision-coordinator)
-(def check-all-supervisors
+
+(def ^{:stratum 0} check-all-supervisors
   "Run due health checks across all enabled supervisors. Args: coordinator,
    workflow-state. Returns {:status :healthy|:warning|:halt :checks [...]}
    with :halt-reason/:halting-agent when status is :halt."
   supervision/check-all-supervisors)
-(def reset-all-supervisors!
+
+(def ^{:stratum 0} reset-all-supervisors!
   "Reset all supervisor agent state (on workflow restart). Arg: coordinator.
    Returns the coordinator."
   supervision/reset-all-supervisors!)
-(def get-supervision-check-history
+
+(def ^{:stratum 0} get-supervision-check-history
   "Return recent supervisor health-check history. Args: coordinator, optional
    {:limit :agent-id :status}. Returns a sequence of check-record maps."
   supervision/get-supervision-check-history)
-(def get-supervisor-stats
+
+(def ^{:stratum 0} get-supervisor-stats
   "Return per-supervisor statistics. Arg: coordinator. Returns
    {:agents [{:id :name :checks-run :last-check :last-status
               :halt-count :warning-count ...}]}."
   supervision/get-supervisor-stats)
-(def run-meta-loop-cycle!
+
+(def ^{:stratum 0} run-meta-loop-cycle!
   "Execute one meta-loop learning cycle.
 
    Orchestrates: reliability compute → degradation eval → diagnosis → improvement proposals.
@@ -591,7 +708,8 @@
    Returns: {:cycle/sli-count :cycle/breach-count :cycle/signal-count
              :cycle/diagnosis-count :cycle/proposal-count :cycle/degradation-mode ...}"
   meta/run-meta-loop-cycle!)
-(def create-meta-loop-context
+
+(def ^{:stratum 0} create-meta-loop-context
   "Create a MetaLoopContext bundling reliability engine, degradation manager,
    improvement pipeline, and metrics store.
 
@@ -599,7 +717,8 @@
      event-stream - event stream atom
      config       - optional {:reliability {} :degradation {}}"
   meta/create-meta-loop-context)
-(def record-workflow-outcome!
+
+(def ^{:stratum 0} record-workflow-outcome!
   "Record a workflow completion for use in the next meta-loop cycle.
 
    Arguments:
@@ -608,7 +727,8 @@
      status        - :completed | :failed | :escalated
      failure-class - optional :failure.class/* keyword"
   meta/record-workflow-outcome!)
-(def run-cycle-from-context!
+
+(def ^{:stratum 0} run-cycle-from-context!
   "Run one meta-loop cycle using the accumulated metrics in ctx.
 
    Arguments:
@@ -618,7 +738,7 @@
    Returns: cycle result map."
   meta/run-cycle-from-context!)
 
-(def classify-task
+(def ^{:stratum 0} classify-task
   "Classify a task to pick an optimal model type.
    Arg: task map with optional :phase :agent-type :description :title and
    sizing/privacy/cost hints. Returns a map
@@ -626,47 +746,43 @@
     :alternative-types [keyword] :all-reasons [string]}; never nil
    (defaults to :execution-focused at 0.5 confidence)."
   classification/classify-task)
-(def get-task-characteristics
+
+(def ^{:stratum 0} get-task-characteristics
   "Extract the features used during classification, for debugging/transparency.
    Arg: task map. Returns a map
    {:phase :agent-type :keywords #{kw} :context-size int
     :privacy-required truthy-or-nil :cost-constrained truthy-or-nil}."
   classification/get-task-characteristics)
 
-;------------------------------------------------------------------------------ Layer 3
 ;; File artifacts — working tree snapshot and fallback artifact collection
-
-(def empty-snapshot
+(def ^{:stratum 0} empty-snapshot
   "Return an empty working tree snapshot."
   file-artifacts/empty-snapshot)
 
-(def collect-written-files
+(def ^{:stratum 0} collect-written-files
   "Collect files written during the agent session into a synthetic code artifact."
   file-artifacts/collect-written-files)
 
-(def collect-worktree-files
+(def ^{:stratum 0} collect-worktree-files
   "Collect the promoted task artifact from the current worktree."
   file-artifacts/collect-worktree-files)
 
-(def rehydrate-files
+(def ^{:stratum 0} rehydrate-files
   "Reconstitute :code/files from recorded paths by reading the worktree.
    Used by downstream phases when the implement phase persisted only
    paths-as-metadata and the worktree has since been committed clean."
   file-artifacts/rehydrate-files)
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Tool supervision
-
-(def evaluate-tool-use
+(def ^{:stratum 0} evaluate-tool-use
   "Evaluate a tool use request against policy.
    Returns {:decision \"allow\"} or {:decision \"deny\" :reason string}."
   tool-supervisor/evaluate-tool-use)
 
-(def hook-eval-stdin!
+(def ^{:stratum 0} hook-eval-stdin!
   "CLI entry point for tool-use evaluation from stdin."
   tool-supervisor/hook-eval-stdin!)
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Stream-gap watchdog
 ;;
 ;; Note on naming: functions exported from the watchdog sub-interface
@@ -678,49 +794,56 @@
 ;; capture-watchdog-session-id!, get-watchdog-session-id). Callers that
 ;; need only watchdog functionality should depend on
 ;; ai.miniforge.agent.interface.watchdog directly to avoid the prefix.
-
-(def resolve-gap-threshold
+(def ^{:stratum 0} resolve-gap-threshold
   "Resolve the stream-gap threshold (ms) for a backend.
    See `ai.miniforge.agent.stream-watchdog/resolve-gap-threshold`."
   watchdog/resolve-gap-threshold)
-(def default-gap-threshold-ms
+
+(def ^{:stratum 0} default-gap-threshold-ms
   "Default stream-gap threshold in ms (90 000)."
   watchdog/default-gap-threshold-ms)
-(def default-check-interval-ms
+
+(def ^{:stratum 0} default-check-interval-ms
   "Default watchdog check interval in ms (5 000)."
   watchdog/default-check-interval-ms)
-(def create-watchdog
+
+(def ^{:stratum 0} create-watchdog
   "Create and start a stream-gap watchdog.
    See `ai.miniforge.agent.stream-watchdog/create-watchdog`."
   watchdog/create-watchdog)
-(def ping-watchdog!
+
+(def ^{:stratum 0} ping-watchdog!
   "Record a new agent event, resetting the gap timer.
    Named ping! (not reset!) to avoid shadowing clojure.core/reset!.
    See `ai.miniforge.agent.stream-watchdog/ping!`."
   watchdog/ping!)
-(def stop-watchdog!
+
+(def ^{:stratum 0} stop-watchdog!
   "Gracefully shut down the watchdog scheduler.
    See `ai.miniforge.agent.stream-watchdog/stop!`."
   watchdog/stop!)
-(def watchdog-stalled?
+
+(def ^{:stratum 0} watchdog-stalled?
   "Return true if the watchdog fired and killed the agent subprocess.
    See `ai.miniforge.agent.stream-watchdog/stalled?`."
   watchdog/stalled?)
-(def watchdog-stall-gap-ms
+
+(def ^{:stratum 0} watchdog-stall-gap-ms
   "Return the measured stream gap (ms) at the moment the watchdog fired, or nil.
    See `ai.miniforge.agent.stream-watchdog/stall-gap-ms`."
   watchdog/stall-gap-ms)
-(def capture-watchdog-session-id!
+
+(def ^{:stratum 0} capture-watchdog-session-id!
   "Parse and persist the session ID from the initial agent handshake event.
    Emits :agent/session-captured via event-stream.
    See `ai.miniforge.agent.stream-watchdog/capture-session-id!`."
   watchdog/capture-session-id!)
-(def get-watchdog-session-id
+
+(def ^{:stratum 0} get-watchdog-session-id
   "Return the captured session ID string, or nil if not yet captured.
    See `ai.miniforge.agent.stream-watchdog/get-session-id`."
   watchdog/get-session-id)
 
-;------------------------------------------------------------------------------ Layer 6
 ;; Phase-result-level timeout predicates
 ;;
 ;; `stream-idle-error?` / `network-drop-error?` / `backend-timeout-error?` read
@@ -739,8 +862,7 @@
 ;; a false `:rejected`. The phase-result predicates here catch that path at the
 ;; role boundary BEFORE any parse attempt, routing infra timeouts to
 ;; `timeout-only-error-result` (infra exit) instead of a synthesized rejection.
-
-(def stream-idle-in-result?
+(def ^{:stratum 0} stream-idle-in-result?
   "True when a phase result map (output of a role's invoke-fn, NOT a
    normalized boundary) carries a stream-idle indicator.
 
@@ -761,7 +883,7 @@
    Symmetric twin of `network-drop-in-result?`."
   result-boundary/stream-idle-in-result?)
 
-(def network-drop-in-result?
+(def ^{:stratum 0} network-drop-in-result?
   "True when a phase result map (output of a role's invoke-fn, NOT a
    normalized boundary) carries a network-drop indicator.
 

--- a/components/agent/test/ai/miniforge/agent/implementer_task_sections_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_task_sections_test.clj
@@ -1,0 +1,39 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.agent.implementer-task-sections-test
+  "task-sections is the one predicate list behind both prompt rendering
+   and the :implementer/prompt-sections telemetry — so the log can only
+   claim what task->text actually rendered."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.agent.implementer :as implementer]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} task-sections-mirror-what-renders-test
+  (testing "an EMPTY :task/gate-failures is neither rendered nor claimed"
+    (let [task {:task/description "x" :task/gate-failures []}]
+      (is (= [] (implementer/task-sections task)))
+      (is (not (str/includes? (implementer/task->text task) "Gate denial")))))
+  (testing "a non-empty denial is both rendered and claimed, in render order"
+    (let [task {:task/description "x"
+                :task/verify-failures {:test-results {:fail-count 1}}
+                :task/gate-failures [{:gate :g :errors [{:message "m"}]}]}]
+      (is (= [:task/gate-failures :task/verify-failures]
+             (implementer/task-sections task)))
+      (is (str/includes? (implementer/task->text task) "Gate denial")))))

--- a/components/gate/src/ai/miniforge/gate/stale_references.clj
+++ b/components/gate/src/ai/miniforge/gate/stale_references.clj
@@ -103,6 +103,24 @@
   [worktree path]
   (git worktree "show" (str "HEAD:" path)))
 
+(defn- ^{:stratum 1} worktree-changed-paths
+  "Every path the worktree has changed against HEAD — tracked
+   modifications AND untracked files — regardless of which implement
+   attempt produced them. A retry that changes nothing must still be
+   judged on the state the previous attempt left behind; judging only
+   the attempt's own artifact let an empty-diff retry pass vacuously
+   while the stale rename persisted (trap-bench REPAIR DEMONSTRATION,
+   reps rq1-rq3: every run's final iteration was decision :allow on
+   zero files)."
+  [worktree]
+  (let [tracked (str (git worktree "diff" "--name-only" "HEAD" "--"))
+        untracked (str (git worktree "ls-files" "--others" "--exclude-standard"))]
+    (->> (concat (str/split-lines tracked) (str/split-lines untracked))
+         (map str/trim)
+         (remove str/blank?)
+         distinct
+         vec)))
+
 (defn- ^{:stratum 1} stale-files
   "Repo files outside `changed-paths` still referencing `token`."
   [worktree changed-paths token]
@@ -146,15 +164,20 @@
   [artifact ctx]
   (let [worktree (get ctx :execution/worktree-path)
         files (:code/files artifact)
-        paths (or (seq (keep :path files)) (:code/file-paths artifact))
         git-ok? (and worktree (some? (git worktree "rev-parse" "--git-dir")))
+        artifact-paths (or (seq (keep :path files)) (:code/file-paths artifact))
+        ;; CUMULATIVE: the attempt's artifact plus everything the worktree
+        ;; already carries against HEAD — see worktree-changed-paths.
+        paths (vec (distinct (concat artifact-paths
+                                     (when git-ok? (worktree-changed-paths worktree)))))
+        artifact-content (into {} (map (juxt :path :content)) files)
         befores (when (and git-ok? (seq paths)) (keep #(before-content worktree %) paths))
         afters (when (seq paths)
-                 (if (seq files)
-                   (keep :content files)
-                   (keep #(try (slurp (str worktree "/" %))
-                               (catch Exception _ nil))
-                         paths)))
+                 (keep (fn [path]
+                         (or (get artifact-content path)
+                             (try (slurp (str worktree "/" path))
+                                  (catch Exception _ nil))))
+                       paths))
         stale (into []
                     (keep (fn [token]
                             (let [hits (stale-files worktree paths token)]

--- a/components/gate/test/ai/miniforge/gate/stale_references_test.clj
+++ b/components/gate/test/ai/miniforge/gate/stale_references_test.clj
@@ -139,3 +139,19 @@
                               {:path consumer :content new-consumer :action :modify}]}
                 {:execution/worktree-path dir})]
     (is (true? (:passed? result)))))
+
+(deftest ^{:stratum 1} check-judges-cumulative-worktree-diff-not-just-the-artifact
+  (testing "an EMPTY-artifact retry is still denied when the worktree
+            carries a prior attempt's stale rename — the vacuous-pass
+            escape every repair-demonstration run took"
+    (let [producer "src/producer.clj"
+          consumer "tasks/report.clj"
+          dir (temp-git-repo
+               {producer "(ns producer)\n(defn read-ledger [] {:skipped 0})"
+                consumer "(ns report)\n(get {} :skipped)"})
+          _ (spit (str dir "/" producer) "(ns producer)\n(defn read-ledger [] {:torn-lines 0})")
+          result (stale/check-stale-references
+                  {:code/files []}
+                  {:execution/worktree-path dir})]
+      (is (false? (:passed? result)))
+      (is (= [":skipped"] (mapv :token (:errors result)))))))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -1023,6 +1023,21 @@
     (let [{:keys [task]} (implement/build-implement-task (create-base-context))]
       (is (not (contains? task :task/gate-failures))))))
 
+(deftest ^{:stratum 2} gate-denial-evidence-reaches-the-rendered-prompt-test
+  (testing "end to end: a stored denied attempt -> build-implement-task ->
+            agent task->text renders the gate-denial section with the
+            token and file — the chain the repair loop depends on"
+    (let [failures [{:gate :stale-references
+                     :errors [{:message "':skipped' was removed by this change but is still referenced by: bb.edn"}]}]
+          ctx (-> (create-base-context)
+                  (assoc-in [:execution/phase-results :implement :phase/gate-failures]
+                            failures))
+          {:keys [task]} (implement/build-implement-task ctx)
+          text (agent/implementer-task->text task)]
+      (is (clojure.string/includes? text "Gate denial"))
+      (is (clojure.string/includes? text "[stale-references]"))
+      (is (clojure.string/includes? text "bb.edn")))))
+
 (use-fixtures :each
   (fn [f]
     (phase/reset-phase-loader!)


### PR DESCRIPTION
## What

Repair-loop wave 3, from the trap-bench REPAIR DEMONSTRATION second series (rq1–rq3, pin 798d53b7b — first ever `:caught` on trap-a, but 1/3).

1. **Vacuous pass closed.** Every rq run's final implement iteration was `decision :allow` on zero changed files: an empty-diff retry passed `:stale-references` while the previous attempt's stale rename still sat in the worktree. The gate now unions the attempt's artifact paths with the worktree's cumulative changes against HEAD (tracked modifications plus untracked files), reading after-content from disk for paths the artifact doesn't carry. A retry is judged on the state it inherits. Test: empty artifact + worktree carrying a stale rename → denied with the right token.
2. **Prompt-section telemetry.** The implementer logs `:implementer/prompt-sections` naming which evidence sections (prior-attempts, gate-failures, phase-handoff, review-feedback, verify-failures) the rendered prompt carried, plus prompt size. Stream dumps record the model's output, not its input — whether a retry ever saw its gate denial was unverifiable from the record, and the next bench series needs ground truth rather than inference.
3. **Evidence chain testable end to end.** `agent/implementer-task->text` exported on the interface; a phase-side test drives stored `:phase/gate-failures` through `build-implement-task` into the rendered prompt and asserts the denial section, gate tag, and file name appear.

## Verification

Full `bb test` green. Validation of the loop itself is the third bench series after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)