### PR TITLE
feat(workflow): append-only gate history per run — redirect loops keep every iteration's gate decision

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
@@ -131,8 +131,12 @@
                    :phase/gate-errors (:phase/gate-errors phase-result)
                    :phase/gate-failures (:phase/gate-failures phase-result)}]
         (fs/create-dirs dir)
+        ;; Same instant normalization the checkpoint records get: gate
+        ;; errors carry java.time.Instant values (policy-pack violations'
+        ;; :timestamp), which pr-str would emit as #object[...] and make
+        ;; the history unreadable.
         (with-open [w (java.io.FileOutputStream. (fs/file dir gate-history-filename) true)]
-          (.write w (.getBytes (str (pr-str entry) "\n") "UTF-8"))))
+          (.write w (.getBytes (str (pr-str (coerce/stringify-instants entry)) "\n") "UTF-8"))))
       (catch Exception _ nil))))
 
 ;------------------------------------------------------------------------------ Layer 2

--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
@@ -125,8 +125,11 @@
                    :at (str (java.time.Instant/now))
                    :decision (:envelope/decision envelope)
                    :redirect-count (get ctx :execution/redirect-count 0)
-                   :gate-errors (:phase/gate-errors phase-result)
-                   :gate-failures (:phase/gate-failures phase-result)}]
+                   ;; The phase result's own keys — one canonical name per
+                   ;; datum, so a history consumer reads what a checkpoint
+                   ;; consumer reads.
+                   :phase/gate-errors (:phase/gate-errors phase-result)
+                   :phase/gate-failures (:phase/gate-failures phase-result)}]
         (fs/create-dirs dir)
         (with-open [w (java.io.FileOutputStream. (fs/file dir gate-history-filename) true)]
           (.write w (.getBytes (str (pr-str entry) "\n") "UTF-8"))))

--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
@@ -60,6 +60,16 @@
   (when (fs/exists? path)
     (coerce/stringify-instants (edn/read-string (slurp path)))))
 
+(def ^{:stratum 0} gate-history-filename
+  "Append-only per-run log of every gate decision, one pr-str'd entry per
+   line. The per-phase checkpoint is OVERWRITTEN on phase re-entry (a
+   redirect loop keeps only its last iteration), which is exactly the
+   record a gate-denied-then-retried phase needs and lost — the
+   trap-bench repair demonstrations could not attribute their retries.
+   Same append discipline as the codex-gap ledger: one O_APPEND write, a
+   failed append cannot damage prior entries."
+  "gate-history.edn")
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} write-edn-atomically!
@@ -100,10 +110,34 @@
      (catch Exception _
        nil))))
 
+(defn- ^{:stratum 1} append-gate-history!
+  "Append the phase's gate decision to the run's gate history when the
+   phase result carries a decision envelope. Best-effort: a failed
+   append logs nothing and changes nothing — the checkpoint write is the
+   authority, this is the audit trail."
+  [checkpoint-root workflow-run-id phase-name phase-result ctx]
+  (when-let [envelope (:phase/decision-envelope phase-result)]
+    ;; Plain try, class-only catch at an absolute boundary (std 211 ex. a):
+    ;; the audit append must never fail the checkpoint write.
+    (try
+      (let [dir (checkpoint-paths/workflow-checkpoint-dir checkpoint-root workflow-run-id)
+            entry {:phase phase-name
+                   :at (str (java.time.Instant/now))
+                   :decision (:envelope/decision envelope)
+                   :redirect-count (get ctx :execution/redirect-count 0)
+                   :gate-errors (:phase/gate-errors phase-result)
+                   :gate-failures (:phase/gate-failures phase-result)}]
+        (fs/create-dirs dir)
+        (with-open [w (java.io.FileOutputStream. (fs/file dir gate-history-filename) true)]
+          (.write w (.getBytes (str (pr-str entry) "\n") "UTF-8"))))
+      (catch Exception _ nil))))
+
 ;------------------------------------------------------------------------------ Layer 2
 
 (defn ^{:stratum 2} persist-execution-state!
-  "Persist a machine snapshot, manifest, and current phase checkpoint."
+  "Persist a machine snapshot, manifest, and current phase checkpoint,
+   and append the phase's gate decision (if any) to the run's
+   append-only gate history."
   [ctx]
   (when-let [workflow-run-id (:execution/id ctx)]
     (let [checkpoint-root (checkpoint-paths/resolve-checkpoint-root ctx)
@@ -126,7 +160,8 @@
            (checkpoint-paths/phase-checkpoint-path checkpoint-root
                                                    workflow-run-id
                                                    phase-name)
-           (checkpoint-records/build-phase-checkpoint ctx phase-name phase-result)))
+           (checkpoint-records/build-phase-checkpoint ctx phase-name phase-result))
+          (append-gate-history! checkpoint-root workflow-run-id phase-name phase-result ctx))
         (write-edn-atomically! snapshot-path snapshot)
         (write-edn-atomically! manifest-path manifest)
         {:checkpoint/root checkpoint-root

--- a/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
@@ -319,7 +319,9 @@
                                {:status :failed
                                 :phase/decision-envelope {:envelope/decision :deny}
                                 :phase/gate-failures [{:gate :stale-references
-                                                       :errors [{:message "stale"}]}]})
+                                                       :errors [{:message "stale"
+                                                                 ;; policy-pack violations carry Instants
+                                                                 :timestamp (java.time.Instant/parse "2026-08-29T00:00:00Z")}]}]})
               allowed (assoc-in base [:execution/phase-results :implement]
                                 {:status :completed
                                  :phase/decision-envelope {:envelope/decision :allow}})
@@ -334,5 +336,8 @@
           (is (= 2 (count history)) "both iterations recorded")
           (is (= [:deny :allow] (mapv :decision history)))
           (is (= :stale-references (-> history first :phase/gate-failures first :gate)))
+          (is (= "2026-08-29T00:00:00Z"
+                 (-> history first :phase/gate-failures first :errors first :timestamp))
+              "Instants inside gate errors are normalized to strings so the history stays EDN-readable")
           (is (= :allow (get-in phase-file [:phase/result :phase/decision-envelope :envelope/decision]))
               "the phase checkpoint holds only the last iteration — the reason the history exists"))))))

--- a/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
@@ -301,3 +301,36 @@
                   "the resuming caller's :acting must not survive in opts")
               (is (nil? (:acting (:execution/opts ctx)))
                   "nor the starting caller's, in the fresh context"))))))))
+
+(deftest ^{:stratum 1} gate-history-survives-phase-re-entry-test
+  (testing "phase re-entry overwrites the phase checkpoint but every gate
+            decision survives in the append-only gate history"
+    (with-temp-checkpoint-root
+      (fn [checkpoint-root]
+        (let [workflow {:workflow/id :gate-history-test
+                        :workflow/version "1.0.0"
+                        :workflow/pipeline [{:phase :implement} {:phase :done}]}
+              base (-> (ctx/create-context workflow {:task "Test"}
+                                           {:checkpoint/root checkpoint-root})
+                       (assoc :execution/current-phase :implement))
+              denied (assoc-in base [:execution/phase-results :implement]
+                               {:status :failed
+                                :phase/decision-envelope {:envelope/decision :deny}
+                                :phase/gate-failures [{:gate :stale-references
+                                                       :errors [{:message "stale"}]}]})
+              allowed (assoc-in base [:execution/phase-results :implement]
+                                {:status :completed
+                                 :phase/decision-envelope {:envelope/decision :allow}})
+              _ (checkpoint-store/persist-execution-state! denied)
+              _ (checkpoint-store/persist-execution-state! allowed)
+              run-dir (str checkpoint-root "/" (:execution/id base))
+              history (->> (slurp (str run-dir "/" checkpoint-store/gate-history-filename))
+                           clojure.string/split-lines
+                           (mapv clojure.edn/read-string))
+              phase-file (clojure.edn/read-string
+                          (slurp (str run-dir "/phases/implement.edn")))]
+          (is (= 2 (count history)) "both iterations recorded")
+          (is (= [:deny :allow] (mapv :decision history)))
+          (is (= :stale-references (-> history first :gate-failures first :gate)))
+          (is (= :allow (get-in phase-file [:phase/result :phase/decision-envelope :envelope/decision]))
+              "the phase checkpoint holds only the last iteration — the reason the history exists"))))))

--- a/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
@@ -17,6 +17,8 @@
 ;; limitations under the License.
 (ns ai.miniforge.workflow.checkpoint-store-test
   (:require
+   [clojure.edn :as edn]
+   [clojure.string :as str]
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
@@ -325,12 +327,12 @@
               _ (checkpoint-store/persist-execution-state! allowed)
               run-dir (str checkpoint-root "/" (:execution/id base))
               history (->> (slurp (str run-dir "/" checkpoint-store/gate-history-filename))
-                           clojure.string/split-lines
-                           (mapv clojure.edn/read-string))
-              phase-file (clojure.edn/read-string
+                           str/split-lines
+                           (mapv edn/read-string))
+              phase-file (edn/read-string
                           (slurp (str run-dir "/phases/implement.edn")))]
           (is (= 2 (count history)) "both iterations recorded")
           (is (= [:deny :allow] (mapv :decision history)))
-          (is (= :stale-references (-> history first :gate-failures first :gate)))
+          (is (= :stale-references (-> history first :phase/gate-failures first :gate)))
           (is (= :allow (get-in phase-file [:phase/result :phase/decision-envelope :envelope/decision]))
               "the phase checkpoint holds only the last iteration — the reason the history exists"))))))


### PR DESCRIPTION
Closes the second half of the gate-observability gap the trap-bench demonstration runs exposed (RUNSHEET, REPAIR DEMONSTRATION series; the first half — Reasons naming the gate and carrying every error — shipped in #1853).

Phase re-entry overwrites phases/<phase>.edn, so a redirect loop's durable record is its last iteration only; whether a gate fired mid-loop was unrecoverable, and rq1/rq3's retries could not be attributed. persist-execution-state! now appends each phase's gate decision to <run-dir>/gate-history.edn — one pr-str'd line per persisted phase result carrying a decision envelope: phase, decision, :phase/gate-errors, :phase/gate-failures, redirect count, timestamp. O_APPEND, one line per write, same discipline as the codex-gap ledger; best-effort so the audit trail can never fail the checkpoint write.

Test drives two persists of the same phase (deny then allow) through a temp checkpoint root and asserts the phase file holds only the last while the history holds both, in order, with the structured gate failure intact.

Full bb test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)