### PR TITLE
feat(codex): submitting-work-to-enforced-gates — verify mapping and implement secondary consultation

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
@@ -136,14 +136,17 @@
            (do (warn-skip! phase logger anomaly (:codex/reason entry))
                {:entry nil :status :skipped :anomaly anomaly :situation situation
                 :pegs nil})
-           ;; Secondary situations append their landings to the same pin
-           ;; entry; a secondary that fails to answer is dropped with a
-           ;; warning rather than failing the primary consultation.
+           ;; Secondary situations append their rendered LANDINGS BODY to
+           ;; the same pin entry — consider + render, not a second pinned
+           ;; artifact (which would repeat the pin header mid-file). A
+           ;; secondary that fails to answer is dropped with a warning
+           ;; rather than failing the primary consultation.
            (let [secondaries (keep (fn [s]
-                                     (let [e (codex/pin-entry codex-dir s pin-path)]
-                                       (if-let [a (:codex/anomaly e)]
-                                         (do (warn-skip! phase logger a (:codex/reason e)) nil)
-                                         e)))
+                                     (let [resp (codex/consider codex-dir s)]
+                                       (if-let [a (:codex/anomaly resp)]
+                                         (do (warn-skip! phase logger a (:codex/reason resp)) nil)
+                                         {:content (codex/render-response resp)
+                                          :pegs (:pegs resp)})))
                                    (get phase->secondary-situations phase))
                  content (str/join "\n\n" (cons (:content entry) (map :content secondaries)))
                  pegs (into (vec (:pegs entry)) (mapcat :pegs secondaries))]

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
@@ -56,7 +56,20 @@
    ;; same situation plan enters at, consulted again at the moment the
    ;; commitment actually happens. Delivered via the releaser's behavior
    ;; addendum (no existing-files channel, same reasoning as review).
-   :release   "about-to-commit-consequential"})
+   :release   "about-to-commit-consequential"
+   ;; Verify has no agent to deliver to; the mapping exists for the gap
+   ;; instrument, so verify-phase misses (the dominant failure shape in
+   ;; the observational matrix — policy-gate redirect loops) classify
+   ;; against the board that now covers them instead of :uncovered.
+   :verify    "submitting-work-to-enforced-gates"})
+
+(def ^{:stratum 0} phase->secondary-situations
+  "Additional situations a phase consults, whose landings APPEND to the
+   primary pin. The implementer is at two doors at once: changing a
+   boundary, and about to submit work that gates will judge (HARVEST
+   2026-08 §7, admitted 2026-08-29). The primary stays the ledger's
+   :situation; secondary pegs merge into the §7.7 telemetry."
+  {:implement ["submitting-work-to-enforced-gates"]})
 
 (defn ^{:stratum 0} configured-codex-dir
   "MINIFORGE_CODEX_PATH, trimmed, or nil — nil means the capability is off."
@@ -123,8 +136,19 @@
            (do (warn-skip! phase logger anomaly (:codex/reason entry))
                {:entry nil :status :skipped :anomaly anomaly :situation situation
                 :pegs nil})
-           {:entry (select-keys entry [:path :content]) :status :pinned
-            :anomaly nil :situation situation :pegs (:pegs entry)}))))))
+           ;; Secondary situations append their landings to the same pin
+           ;; entry; a secondary that fails to answer is dropped with a
+           ;; warning rather than failing the primary consultation.
+           (let [secondaries (keep (fn [s]
+                                     (let [e (codex/pin-entry codex-dir s pin-path)]
+                                       (if-let [a (:codex/anomaly e)]
+                                         (do (warn-skip! phase logger a (:codex/reason e)) nil)
+                                         e)))
+                                   (get phase->secondary-situations phase))
+                 content (str/join "\n\n" (cons (:content entry) (map :content secondaries)))
+                 pegs (into (vec (:pegs entry)) (mapcat :pegs secondaries))]
+             {:entry {:path (:path entry) :content content} :status :pinned
+              :anomaly nil :situation situation :pegs (not-empty pegs)})))))))
 
 (defn ^{:stratum 1} landings-outcome
   "Prompt-section delivery outcome for phases with no existing-files

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
@@ -141,12 +141,16 @@
            ;; artifact (which would repeat the pin header mid-file). A
            ;; secondary that fails to answer is dropped with a warning
            ;; rather than failing the primary consultation.
-           (let [secondaries (keep (fn [s]
+           ;; Realized once: keep is lazy and the seq is traversed for
+           ;; content and again for pegs — an unrealized seq would consult
+           ;; the codex (IO + warnings) once per traversal.
+           (let [secondaries (into []
+                                   (keep (fn [s]
                                      (let [resp (codex/consider codex-dir s)]
                                        (if-let [a (:codex/anomaly resp)]
                                          (do (warn-skip! phase logger a (:codex/reason resp)) nil)
                                          {:content (codex/render-response resp)
-                                          :pegs (:pegs resp)})))
+                                          :pegs (:pegs resp)}))))
                                    (get phase->secondary-situations phase))
                  content (str/join "\n\n" (cons (:content entry) (map :content secondaries)))
                  pegs (into (vec (:pegs entry)) (mapcat :pegs secondaries))]

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
@@ -39,12 +39,16 @@
   ;; landings-text (prompt section); release wires via landings-outcome
   ;; through the releaser's behavior addendum. A mapping without a wire
   ;; would be a defined-but-unreachable capability.
-  (is (= #{:implement :plan :review :release}
-         (set (keys codex-pin/phase->situation)))))
+  ;; verify is mapped for the gap instrument only (no agent, no pin) —
+  ;; its misses classify against board 3 instead of :uncovered.
+  (is (= #{:implement :plan :review :release :verify}
+         (set (keys codex-pin/phase->situation))))
+  (is (= {:implement ["submitting-work-to-enforced-gates"]}
+         codex-pin/phase->secondary-situations)))
 
 (deftest ^{:stratum 0} landings-text-skip-conditions
   (is (nil? (codex-pin/landings-text :review nil nil)))
-  (is (nil? (codex-pin/landings-text :verify nil "/anywhere")))
+  (is (nil? (codex-pin/landings-text :explore nil "/anywhere")))
   (is (nil? (codex-pin/landings-text :review nil "/nonexistent/codex"))))
 
 (deftest ^{:stratum 0} anomaly-with-nil-logger-warns-on-stderr
@@ -59,7 +63,7 @@
           :situation "changing-one-side-of-a-boundary" :pegs nil}
          (codex-pin/pin-outcome :implement nil nil)))
   (is (= {:entry nil :status :unmapped :anomaly nil :situation nil :pegs nil}
-         (codex-pin/pin-outcome :verify nil "/anywhere")))
+         (codex-pin/pin-outcome :explore nil "/anywhere")))
   (is (= :skipped
          (:status (codex-pin/pin-outcome :implement nil "/nonexistent/codex")))))
 

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
@@ -20,7 +20,8 @@
    component's own tests against generator-produced fixtures
    (ai.miniforge.codex.render-test/pin-entry-builds-a-prompt-ready-file);
    these cover the phase-side skip conditions."
-  (:require [ai.miniforge.phase-software-factory.codex-pin :as codex-pin]
+  (:require [ai.miniforge.codex.interface :as codex]
+   [ai.miniforge.phase-software-factory.codex-pin :as codex-pin]
             [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -117,3 +118,29 @@
                        {:status :success :output {:code/summary "s"}} summary)))))
     (testing "non-map result passes through untouched"
       (is (nil? (codex-pin/attach-consultation nil summary))))))
+
+(deftest ^{:stratum 0} secondary-consultations-append-and-merge
+  (let [primary {:path codex-pin/pin-path :content "PRIMARY" :pegs [{:id "p1"}]}]
+    (testing "secondary landings append after a blank line; pegs merge primary-first"
+      (with-redefs [codex/pin-entry (fn [_dir _situation _path] primary)
+                    codex/consider (fn [_dir situation]
+                                     (when (= "submitting-work-to-enforced-gates" situation)
+                                       {:landings [] :pegs [{:id "s1"}]}))
+                    codex/render-response (fn [_resp] "SECONDARY")]
+        (let [out (codex-pin/pin-outcome :implement nil "/codex")]
+          (is (= :pinned (:status out)))
+          (is (= "PRIMARY\n\nSECONDARY" (get-in out [:entry :content])))
+          (is (= [{:id "p1"} {:id "s1"}] (:pegs out)))
+          (is (= "changing-one-side-of-a-boundary" (:situation out))
+              "the ledger's situation stays the primary"))))
+    (testing "a secondary that fails to answer warns and is dropped; the primary stands"
+      (let [err (java.io.StringWriter.)]
+        (with-redefs [codex/pin-entry (fn [_dir _situation _path] primary)
+                      codex/consider (fn [_dir _situation]
+                                       {:codex/anomaly :codex-unreadable :codex/reason "no nodes"})
+                      codex/render-response (fn [_resp] (throw (ex-info "must not render an anomaly" {})))]
+          (let [out (binding [*err* err] (codex-pin/pin-outcome :implement nil "/codex"))]
+            (is (= :pinned (:status out)))
+            (is (= "PRIMARY" (get-in out [:entry :content])))
+            (is (= [{:id "p1"}] (:pegs out)))
+            (is (re-find #"WARN: codex consultation skipped for implement" (str err)))))))))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
@@ -29,7 +29,7 @@
   (is (nil? (codex-pin/pin-file :implement nil nil))))
 
 (deftest ^{:stratum 0} unmapped-phase-gets-no-pin
-  (is (nil? (codex-pin/pin-file :verify nil "/anywhere"))))
+  (is (nil? (codex-pin/pin-file :explore nil "/anywhere"))))
 
 (deftest ^{:stratum 0} anomaly-skips-the-pin-rather-than-pinning-garbage
   (is (nil? (codex-pin/pin-file :implement nil "/nonexistent/codex"))))


### PR DESCRIPTION
Wires the harvest admission made in the zk codex on 2026-08-29 (HARVEST-2026-08 §7, admitted via validate.py admit): new situation submitting-work-to-enforced-gates, peg is-the-rule-enforced-downstream, problem enforcement-after-authoring, scar codex-matrix-policy-loop.

1. :verify maps to the new situation. Verify has no agent, so nothing is delivered — the mapping exists so verify-phase misses (the observational matrix's dominant failure shape, ~280 ledger entries, all :uncovered at the time) classify against the board that now covers them. Retrodiction (separate PR) re-scores the archived ledgers.
2. phase->secondary-situations: implement additionally consults the new situation; secondary landings append to the primary pin entry and secondary pegs merge into the §7.7 telemetry. A failing secondary warns and is dropped, never failing the primary.

Lockstep tests updated (phase->situation key set; the unmapped example moves from :verify to :explore). Full bb test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)