### PR TITLE
fix(deliberation-workspace): refuse a close-goal whose outcome the engine cannot impose

### DIFF
--- a/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
+++ b/components/deliberation-workspace/src/ai/miniforge/deliberation_workspace/validation.clj
@@ -17,7 +17,7 @@
 ;; limitations under the License.
 (ns ai.miniforge.deliberation-workspace.validation
   "The concurrency stages of the N14 §3.4 transaction validation pipeline:
-   schema conformance, creation-payload conformance, target existence, role
+   schema conformance, operation-payload conformance, target existence, role
    permission, and basis staleness. Rejections are anomalies as data — a
    routable value the scheduler logs, never an exception.
 
@@ -285,6 +285,45 @@
             "Operation declares edges the engine cannot write"
             (merge {:op (:op operation) :reason reason} data))))
 
+(defn- ^{:stratum 1} check-outcome
+  "N14 §2.3 conformance for the outcome `close-goal` imposes on its goals.
+
+   `close-goal` is the one operation whose status comes from the payload
+   rather than from `tx/status-effect`, and `commit/apply-status` reads it
+   as `(tx/goal-outcomes (:outcome operation))` — a set used as a function,
+   so anything outside the set yields nil. nil is also what the table
+   yields for an operation with no status effect at all, and one line later
+   the two are indistinguishable: the goal is touched, the transaction
+   commits, the version advances, and the goal stays `:open`.
+
+   Nothing downstream notices. `termination/goals-terminal?` closes a run
+   when every goal is terminal, so a synthesizer that believes it closed
+   the last goal leaves the run to end on a budget boundary rather than on
+   the §7 success rule.
+
+   An absent outcome is refused for the same reason as an illegal one, and
+   under the same `:reason`: both name a status the engine cannot impose,
+   and both are repaired by supplying one it can.
+
+   Every other operation is refused for carrying the field. `commit`
+   derives their status from the operation precisely so a payload cannot
+   name one — otherwise a transaction could say `:challenge` and carry
+   `:accepted`. That defense stops the field taking effect; it does not
+   report it, which leaves the same silence in the other direction. An
+   explicit nil is absent rather than inapplicable: it names no status."
+  [_workspace operation _context]
+  (let [outcome (:outcome operation)]
+    (if (= :close-goal (:op operation))
+      (when-not (contains? tx/goal-outcomes outcome)
+        (reject :invalid-input :anomalies.deliberation/invalid-outcome
+                "close-goal must carry an outcome legal for a goal (N14 §2.3)"
+                {:op (:op operation) :reason :unknown-outcome :outcome outcome}))
+      (when (some? outcome)
+        (reject :invalid-input :anomalies.deliberation/invalid-outcome
+                "Only close-goal carries an outcome"
+                {:op (:op operation) :reason :inapplicable-outcome
+                 :outcome outcome})))))
+
 (defn- ^{:stratum 1} check-targets [workspace operation _context]
   (let [known (objects-of workspace)
         missing (remove #(contains? known %) (tx/touched-ids operation))]
@@ -368,9 +407,14 @@
    It still runs after `check-schema`, and skips siblings outside the
    vocabulary, so an unknown operation is never reported as a shape fault.
 
+   Order among the payload stages after it is a preference. `check-outcome`
+   reads one scalar field of the operation it is handed, so nothing depends
+   on where it sits; it is placed last of them because it is the only one
+   whose fault is silent absorption at commit rather than a crash there.
+
    The payload stages precede the three that read the object graph. A
    transaction can carry a malformed payload and a missing target at once,
    and the payload is the more basic fault: the ids a graph stage would
    report come out of the same payload whose shape is not yet established."
-  [check-schema check-id-fields check-creates check-links
+  [check-schema check-id-fields check-creates check-links check-outcome
    check-targets check-permission check-basis])

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/commit_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/commit_test.clj
@@ -97,7 +97,11 @@
     (let [ws (transact (workspace (obj "goal-1" :goal)) :synthesizer
                        {:op :close-goal :targets #{"goal-1"} :outcome :accepted})]
       (is (= :accepted (:object/status (object-at ws "goal-1"))))))
-  (testing "an outcome outside the closed set leaves the goal open"
+  (testing "an outcome outside the closed set imposes no status"
+    ;; `validation/check-outcome` refuses this payload, so a run never
+    ;; reaches here with one. What this pins is the layer beneath it: commit
+    ;; must not invent a status for an outcome it cannot read, so an
+    ;; unvalidated caller leaves the goal open rather than closing it wrong.
     (let [ws (transact (workspace (obj "goal-1" :goal)) :synthesizer
                        {:op :close-goal :targets #{"goal-1"} :outcome :maybe})]
       (is (= :open (:object/status (object-at ws "goal-1")))))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/run_test.clj
@@ -227,3 +227,21 @@
                                                :tx/operations :assert-claim}))]
       (is (= [:anomalies.deliberation/invalid-transaction]
              (mapv :reason (events-of after :transaction/rejected)))))))
+(deftest ^{:stratum 2} a-close-goal-the-engine-cannot-honor-is-routed-not-absorbed
+  (testing "this committed, advanced the version, and left the goal open"
+    (let [propose (fn [{:keys [role]}]
+                    (tx/new-transaction
+                     {:role role :activation "act-1" :basis 1
+                      :operations [{:op :close-goal :targets #{"goal-1"}
+                                    :outcome :maybe}]}))
+          after (run/step (workspace :workspace/roles [:synthesizer]) propose)
+          closed (get-in after [:workspace/objects "goal-1"])]
+      (is (= [:anomalies.deliberation/invalid-outcome]
+             (mapv :reason (events-of after :transaction/rejected))))
+      (is (empty? (events-of after :transaction/committed))
+          "the log recorded a synthesizer's misbelief as a committed transaction")
+      (is (= 1 (:workspace/version after))
+          "a rejected transaction does not advance the clock")
+      (is (= :open (:object/status closed)))
+      (is (= 1 (:object/touched-at closed))
+          "and the goal is untouched, not touched-but-still-open"))))

--- a/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
+++ b/components/deliberation-workspace/test/ai/miniforge/deliberation_workspace/validation_test.clj
@@ -495,3 +495,78 @@
                                     (transaction :proposer 10
                                                  {:op :assert-claim}
                                                  {:op :refine-claim :targets :x})))))))
+(deftest ^{:stratum 1} closing-a-goal-requires-an-outcome-the-engine-can-impose
+  (testing "apply-status reads :outcome through a set, so anything outside yields nil"
+    (doseq [[label outcome] [["outside the closed set" :maybe]
+                             ["a string, not a status" "accepted"]
+                             ["explicitly nil" nil]]]
+      (is (= :anomalies.deliberation/invalid-outcome
+             (subtype-of (validate-tx
+                          (workspace (object-at "goal-1" 4 :object/type :goal))
+                          (transaction :synthesizer 10
+                                       {:op :close-goal :targets #{"goal-1"}
+                                        :outcome outcome}))))
+          label)))
+  (testing "an absent :outcome is the same fault: the operation names no status"
+    (is (= :anomalies.deliberation/invalid-outcome
+           (subtype-of (validate-tx
+                        (workspace (object-at "goal-1" 4 :object/type :goal))
+                        (transaction :synthesizer 10
+                                     {:op :close-goal :targets #{"goal-1"}})))))))
+
+(deftest ^{:stratum 1} a-legal-outcome-passes
+  (testing "the stage refuses outcomes the engine cannot impose, not closing itself"
+    (doseq [outcome tx/goal-outcomes]
+      (is (nil? (validate-tx
+                 (workspace (object-at "goal-1" 4 :object/type :goal))
+                 (transaction :synthesizer 10
+                              {:op :close-goal :targets #{"goal-1"}
+                               :outcome outcome})))
+          outcome))))
+
+(deftest ^{:stratum 1} only-close-goal-carries-an-outcome
+  (testing "every other status is derived from the operation, and the field is ignored"
+    (is (= :anomalies.deliberation/invalid-outcome
+           (subtype-of (validate-tx
+                        (workspace (object-at "claim-1" 4))
+                        (transaction :skeptic 10
+                                     {:op :challenge :targets #{"claim-1"}
+                                      :outcome :accepted}))))
+        "naming :challenge and carrying :accepted is a confusion, not an inert field"))
+  (testing "an explicit nil names no status, so it is absent rather than inapplicable"
+    (is (nil? (validate-tx (workspace (object-at "claim-1" 4))
+                           (transaction :proposer 10
+                                        {:op :attach-evidence :targets #{"claim-1"}
+                                         :outcome nil}))))))
+
+(deftest ^{:stratum 1} an-outcome-rejection-carries-the-reason-and-the-value
+  (testing "routing reads both without parsing the message"
+    (doseq [[reason outcome operation]
+            [[:unknown-outcome :maybe
+              {:op :close-goal :targets #{"goal-1"} :outcome :maybe}]
+             [:unknown-outcome nil
+              {:op :close-goal :targets #{"goal-1"}}]
+             [:inapplicable-outcome :accepted
+              {:op :declare-blocked :targets #{"goal-1"} :outcome :accepted}]]]
+      (let [data (:anomaly/data
+                  (validate-tx (workspace (object-at "goal-1" 4 :object/type :goal))
+                               (transaction :synthesizer 10 operation)))]
+        (is (= reason (:reason data)))
+        (is (= outcome (:outcome data)))))))
+
+(deftest ^{:stratum 1} an-unusable-outcome-outranks-the-goal-it-would-close
+  (testing "the payload stages run before the three that read the object graph"
+    (is (= :anomalies.deliberation/invalid-outcome
+           (subtype-of (validate-tx
+                        (workspace)
+                        (transaction :synthesizer 10
+                                     {:op :close-goal :targets #{"goal-404"}
+                                      :outcome :maybe}))))
+        "check-targets would otherwise report the missing goal first"))
+  (testing "but the vocabulary is established before either"
+    (is (= :anomalies.deliberation/unknown-operation
+           (subtype-of (validate-tx
+                        (workspace)
+                        (transaction :synthesizer 10
+                                     {:op :close-every-goal :outcome :accepted}))))
+        "an operation outside the vocabulary has no outcome contract to violate")))

--- a/docs/pull-requests/2026-09-02-fix-n14-stage0-close-goal-outcome.md
+++ b/docs/pull-requests/2026-09-02-fix-n14-stage0-close-goal-outcome.md
@@ -63,8 +63,11 @@ routing, following the `invalid-creation` / `invalid-links` precedent:
 1. `:unknown-outcome` — a `close-goal` whose `:outcome` is not in
    `tx/goal-outcomes`. An absent outcome is refused under the same reason as an
    illegal one: both name a status the engine cannot impose, and both are
-   repaired by supplying one it can. The value is carried in `:outcome` so the
-   two cases stay distinguishable to a reader without splitting the routing.
+   repaired by supplying one it can. The offending value is carried in
+   `:outcome`, so an illegal one is legible as itself without splitting the
+   routing. An absent `:outcome` and an explicit nil both report `:outcome nil`,
+   which is the whole of the distinction between them — neither names a status,
+   and the repair does not differ.
 2. `:inapplicable-outcome` — the field on any other operation. `commit`
    ignores it there by design, which stops it taking effect but does not report
    it, leaving the same silence in the other direction. An explicit nil names

--- a/docs/pull-requests/2026-09-02-fix-n14-stage0-close-goal-outcome.md
+++ b/docs/pull-requests/2026-09-02-fix-n14-stage0-close-goal-outcome.md
@@ -1,0 +1,164 @@
+# fix: refuse a `close-goal` whose outcome the engine cannot impose
+
+## Overview
+
+`close-goal` is the one N14 §3.2 operation whose status comes from the
+transaction payload rather than from a table. That payload field was never
+validated. An outcome outside `#{:accepted :rejected}` — or no outcome at all —
+committed, advanced the workspace version, moved the goal's staleness clock,
+and left the goal `:open`.
+
+This PR adds a `check-outcome` validation stage that refuses those payloads as
+`:anomalies.deliberation/invalid-outcome`, so `run/step` records a
+`:transaction/rejected` event instead of a `:transaction/committed` one.
+
+## Motivation
+
+Every other status effect is derived from the operation via
+`tx/status-effect`, which is what stops a transaction naming `:challenge` and
+carrying `:accepted`. `close-goal` is the exception, and
+`commit/apply-status` reads it as:
+
+```clojure
+(if (= :close-goal (:op operation))
+  (tx/goal-outcomes (:outcome operation))
+  (get tx/status-effect (:op operation)))
+```
+
+`tx/goal-outcomes` is a set used as a function, so anything outside it yields
+nil. nil is also what the table yields for an operation with no status effect,
+and one line later the two are indistinguishable — the `(and status ...)`
+branch falls through to a plain `object/touch`.
+
+Reproduced on 2026-09-02 against `798d53b7b`, with the full stage list
+`(into validation/concurrency-stages guards/guard-stages)`:
+
+| Payload | `validate` | After commit |
+|---|---|---|
+| `{:op :close-goal :targets #{"goal-1"} :outcome :maybe}` | `nil` | `:open`, touched-at 11, version 11 |
+| `{:op :close-goal :targets #{"goal-1"} :outcome "accepted"}` | `nil` | same |
+| `{:op :close-goal :targets #{"goal-1"} :outcome nil}` | `nil` | same |
+| `{:op :close-goal :targets #{"goal-1"}}` | `nil` | same |
+| `{:op :close-goal :targets #{"goal-1"} :outcome :accepted}` | `nil` | `:accepted`, run closes `:success` |
+
+This is a quieter failure than the ones #1852 and #1858 closed. Those threw,
+either at commit or out of the validator itself; a throw is at least visible.
+Here the transaction commits, the event log records a success, and only the
+object's status disagrees.
+
+It does not stay contained to the one operation.
+`termination/goals-terminal?` closes a run when every `:goal` object is
+terminal, so a synthesizer that believes it closed the last goal leaves the run
+to end on a budget boundary instead of on its §7 closing rule — and the log
+gives no reason why.
+
+## Changes in Detail
+
+### `validation.clj`
+
+`check-outcome` (Layer 1) refuses two payloads, both under
+`:anomalies.deliberation/invalid-outcome` with a distinct `:reason` for
+routing, following the `invalid-creation` / `invalid-links` precedent:
+
+1. `:unknown-outcome` — a `close-goal` whose `:outcome` is not in
+   `tx/goal-outcomes`. An absent outcome is refused under the same reason as an
+   illegal one: both name a status the engine cannot impose, and both are
+   repaired by supplying one it can. The value is carried in `:outcome` so the
+   two cases stay distinguishable to a reader without splitting the routing.
+2. `:inapplicable-outcome` — the field on any other operation. `commit`
+   ignores it there by design, which stops it taking effect but does not report
+   it, leaving the same silence in the other direction. An explicit nil names
+   no status and is treated as absent rather than inapplicable.
+
+The stage is validated against `tx/goal-outcomes` rather than
+`object/status-model`'s `:goal` entry, because `goal-outcomes` is exactly what
+`apply-status` reads.
+
+It is placed last of the payload stages in `concurrency-stages`. Order among
+those is a preference rather than a constraint — the stage reads one scalar
+field of the operation it is handed — and it is last because it is the only one
+whose fault is silent absorption at commit rather than a crash there. It stays
+after `check-schema`, so an operation outside the vocabulary is reported as an
+unknown operation rather than as a bad outcome.
+
+The namespace docstring said "creation-payload conformance", which stopped
+being the whole story when #1852 added `check-links`. It now says
+"operation-payload conformance", which covers the three without enumerating
+them.
+
+### `commit_test.clj`
+
+`closing-a-goal-requires-a-legal-outcome` already asserted the silent-absorption
+behavior as if it were the intended end state. The assertion is still right —
+commit must not invent a status for an outcome it cannot read — but the label
+now says validation refuses the payload before commit sees it, so the test reads
+as the layer beneath rather than as an endorsement.
+
+## Scope
+
+`close-goal` targeting an object that is not a goal is left alone. A
+`{:op :close-goal :targets #{"question-1"} :outcome :accepted}` is skipped by
+`object/legal-status?` and absorbed the same way. That is not a `close-goal`
+problem: every entry in `tx/status-effect` has it, so
+`{:op :answer-question :targets #{"claim-1"}}` absorbs identically. Closing it
+means deciding whether a graph-reading stage refuses the mismatch or
+`apply-status` throws on it, which is a larger change than this one and is
+tracked separately.
+
+## Testing Plan
+
+Five tests in `validation_test.clj` and one in `run_test.clj`. Run from
+`components/deliberation-workspace`:
+
+```bash
+clojure -M:test -e "(require 'ai.miniforge.deliberation-workspace.validation-test) (clojure.test/run-tests 'ai.miniforge.deliberation-workspace.validation-test)"
+```
+
+- `closing-a-goal-requires-an-outcome-the-engine-can-impose` — the four
+  payloads from the table above.
+- `a-legal-outcome-passes` — every member of `tx/goal-outcomes` still
+  validates.
+- `only-close-goal-carries-an-outcome` — the field is refused elsewhere;
+  an explicit nil is not.
+- `an-outcome-rejection-carries-the-reason-and-the-value` — `:reason` and
+  `:outcome` are readable without parsing the message.
+- `an-unusable-outcome-outranks-the-goal-it-would-close` — the payload stage
+  precedes `check-targets`, and `check-schema` precedes both.
+- `a-close-goal-the-engine-cannot-honor-is-routed-not-absorbed` (`run_test`) —
+  the end-to-end shape: a `:transaction/rejected` event with the subtype, no
+  `:transaction/committed` event, the version unmoved, and the goal untouched
+  rather than touched-but-still-open.
+
+Verified the tests fail without the fix: reverting the stage from
+`concurrency-stages` produces 20 failures across the two namespaces; with it,
+the component's 125 tests and 400 assertions pass. `bb lint:clj`,
+`bb lint:stratum` and `bb commit-budget` (138/200) are clean;
+`validation.clj` stays at three strata.
+
+## Deployment Plan
+
+Ships with the component. No migration: the component has no consumers outside
+its own tests yet, so nothing downstream changes shape. Runs that previously
+committed an unusable `close-goal` now log a rejection instead, which costs the
+same activation budget and surfaces a fault that was previously invisible.
+
+## Related Issues/PRs
+
+- [#1858](https://github.com/miniforge-ai/miniforge/pull/1858) — refuses the
+  operation payloads the validator could not read. Same class, same file;
+  merged, and this branch is rebased onto main after it. `check-outcome` sits
+  after the `check-id-fields` it added, which is the one payload-stage
+  ordering that is a constraint rather than a preference.
+- [#1852](https://github.com/miniforge-ai/miniforge/pull/1852) — an
+  operation's own `:links`, and creates across a transaction.
+- [#1851](https://github.com/miniforge-ai/miniforge/pull/1851) — made the
+  commit path's agent-reachable failures routable.
+
+## Checklist
+
+- [x] Bug reproduced against `798d53b7b` before the fix
+- [x] Tests confirmed failing without the fix, passing with it
+- [x] Full component suite green (125 tests, 400 assertions)
+- [x] `bb lint:clj`, `bb lint:stratum`, `bb commit-budget` clean
+- [x] `validation.clj` still within the 3-stratum ceiling
+- [x] Remaining gap named in Scope rather than silently widened


### PR DESCRIPTION
## Overview

`close-goal` is the one N14 §3.2 operation whose status comes from the
transaction payload rather than from a table. That payload field was never
validated. An outcome outside `#{:accepted :rejected}` — or no outcome at all —
committed, advanced the workspace version, moved the goal's staleness clock,
and left the goal `:open`.

This PR adds a `check-outcome` validation stage that refuses those payloads as
`:anomalies.deliberation/invalid-outcome`, so `run/step` records a
`:transaction/rejected` event instead of a `:transaction/committed` one.

## Motivation

`commit/apply-status` reads the field as:

```clojure
(if (= :close-goal (:op operation))
  (tx/goal-outcomes (:outcome operation))
  (get tx/status-effect (:op operation)))
```

`tx/goal-outcomes` is a set used as a function, so anything outside it yields
nil. nil is also what the table yields for an operation with no status effect,
and one line later the two are indistinguishable — the `(and status ...)`
branch falls through to a plain `object/touch`.

Reproduced against `798d53b7b` with the full stage list
`(into validation/concurrency-stages guards/guard-stages)`:

| Payload | `validate` | After commit |
|---|---|---|
| `{:op :close-goal :targets #{"goal-1"} :outcome :maybe}` | `nil` | `:open`, touched-at 11, version 11 |
| `{:op :close-goal :targets #{"goal-1"} :outcome "accepted"}` | `nil` | same |
| `{:op :close-goal :targets #{"goal-1"} :outcome nil}` | `nil` | same |
| `{:op :close-goal :targets #{"goal-1"}}` | `nil` | same |
| `{:op :close-goal :targets #{"goal-1"} :outcome :accepted}` | `nil` | `:accepted`, run closes `:success` |

This is quieter than the faults #1852 and #1858 closed. Those threw, either at
commit or out of the validator itself; a throw is at least visible. Here the
transaction commits, the event log records a success, and only the object's
status disagrees.

It does not stay contained to the one operation. `termination/goals-terminal?`
closes a run when every `:goal` object is terminal, so a synthesizer that
believes it closed the last goal leaves the run to end on a budget boundary
instead of on its §7 closing rule — and the log gives no reason why.

## Changes

`check-outcome` (Layer 1) refuses two payloads, both as
`:anomalies.deliberation/invalid-outcome` with a distinct `:reason` for
routing, following the `invalid-creation` / `invalid-links` precedent:

1. `:unknown-outcome` — a `close-goal` whose `:outcome` is not in
   `tx/goal-outcomes`. An absent outcome is refused under the same reason as
   an illegal one: both name a status the engine cannot impose, and both are
   repaired by supplying one it can. The value is carried in `:outcome`.
2. `:inapplicable-outcome` — the field on any other operation. `commit`
   ignores it there by design, which stops it taking effect but does not
   report it, leaving the same silence in the other direction. An explicit nil
   names no status and is treated as absent rather than inapplicable.

The stage validates against `tx/goal-outcomes` rather than
`object/status-model`'s `:goal` entry, because `goal-outcomes` is exactly what
`apply-status` reads. It is placed after the `check-id-fields` #1858 added —
the one payload-stage ordering that is a constraint rather than a preference —
and last among the rest, because it is the only one whose fault is silent
absorption at commit rather than a crash there.

`commit_test.clj`'s `closing-a-goal-requires-a-legal-outcome` asserted the
absorption as if it were the intended end state. The assertion is still right —
commit must not invent a status for an outcome it cannot read — but the label
now says validation refuses the payload first, so it reads as the layer beneath
rather than as an endorsement.

## Scope

`close-goal` targeting an object that is not a goal is left alone. That is not
a `close-goal` problem: every entry in `tx/status-effect` absorbs the same way,
so `{:op :answer-question :targets #{"claim-1"}}` behaves identically. Closing
it means deciding whether a graph-reading stage refuses the mismatch or
`apply-status` throws on it — a larger change than this one, tracked
separately. Named in the PR doc rather than silently widened into this PR.

## Testing

Five tests in `validation_test.clj`, one in `run_test.clj`. Reverting the stage
from `concurrency-stages` produces 20 failures across the two namespaces; with
it, the component's 125 tests and 400 assertions pass. `bb pre-commit` clean;
`validation.clj` stays at three strata (SL003); commit budget 138/200.

PR doc: `docs/pull-requests/2026-09-02-fix-n14-stage0-close-goal-outcome.md`

## Related

- #1858 — refuses the operation payloads the validator could not read (merged; this is rebased onto main after it)
- #1852 — an operation's own `:links`, and creates across a transaction
- #1851 — made the commit path's agent-reachable failures routable

🤖 Generated with [Claude Code](https://claude.com/claude-code)