### PR TITLE
feat(codex-gap): retrodiction tool + rule-violation attribution

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -587,7 +587,7 @@
   ;; ──────────────────────────────────────────────────────────────────────────
 
   codex-gap-retrodict
-  {:doc "T2 s5.4 retrodiction: re-classify run ledgers against the codex as it is NOW. Usage: bb codex-gap-retrodict [checkpoint-root] [phase=situation ...]; codex from MINIFORGE_CODEX_PATH"
+  {:doc "T2 §5.4 retrodiction: re-classify run ledgers against the codex as it is NOW. Usage: bb codex-gap-retrodict [checkpoint-root] [phase=situation ...]; codex from MINIFORGE_CODEX_PATH"
    :extra-paths ["components/codex-gap/src"
                  "components/codex-gap/resources"
                  "components/codex/src"
@@ -603,6 +603,9 @@
                codex-dir (System/getenv "MINIFORGE_CODEX_PATH")
                phase->situation (into {} (map (fn [m]
                                                 (let [[p s] (str/split m (re-pattern "=") 2)]
+                                                  (when (or (str/blank? p) (str/blank? s))
+                                                    (println "malformed mapping" (pr-str m) "— expected phase=situation")
+                                                    (System/exit 2))
                                                   [(keyword p) s]))
                                               mappings))
                dirs (when (fs/directory? root)

--- a/bb.edn
+++ b/bb.edn
@@ -586,6 +586,43 @@
   ;; MCP Context Server
   ;; ──────────────────────────────────────────────────────────────────────────
 
+  codex-gap-retrodict
+  {:doc "T2 s5.4 retrodiction: re-classify run ledgers against the codex as it is NOW. Usage: bb codex-gap-retrodict [checkpoint-root] [phase=situation ...]; codex from MINIFORGE_CODEX_PATH"
+   :extra-paths ["components/codex-gap/src"
+                 "components/codex-gap/resources"
+                 "components/codex/src"
+                 "components/codex/resources"
+                 "components/messages/src"
+                 "components/messages/resources"]
+   :requires ([ai.miniforge.codex-gap.interface :as codex-gap]
+              [babashka.fs :as fs]
+              [clojure.string :as str])
+   :task (let [[root & mappings] *command-line-args*
+               root (or root (str (fs/path (System/getProperty "user.home")
+                                           ".miniforge" "checkpoints")))
+               codex-dir (System/getenv "MINIFORGE_CODEX_PATH")
+               phase->situation (into {} (map (fn [m]
+                                                (let [[p s] (str/split m (re-pattern "=") 2)]
+                                                  [(keyword p) s]))
+                                              mappings))
+               dirs (when (fs/directory? root)
+                      (sort (filter fs/directory? (fs/list-dir root))))
+               entries (vec (mapcat (fn [d] (:entries (codex-gap/read-ledger (str d)))) dirs))]
+           (if (or (nil? codex-dir) (not (fs/directory? codex-dir)))
+             (do (println "MINIFORGE_CODEX_PATH must name the codex directory") (System/exit 2))
+             (let [{:keys [shift entries]} (codex-gap/retrodict entries codex-dir phase->situation)]
+               (println "retrodicted" (count entries) "misses against" codex-dir)
+               (println "phase->situation" (pr-str phase->situation))
+               (println "shift [recorded retrodicted] -> count")
+               (doseq [[k v] (sort-by (comp - val) shift)] (println " " (pr-str k) v))
+               (let [queued (filter (fn [e] (= :review-queue (:miss/bucket e))) entries)]
+                 (when (seq queued)
+                   (println "review-queue by signal [type reason-code] -> count")
+                   (doseq [[k v] (sort-by (comp - val)
+                                          (frequencies (map (fn [e] [(get-in e [:miss/signal :type])
+                                                                     (get-in e [:miss/signal :payload :reason/code])])
+                                                            queued)))]
+                     (println " " (pr-str k) v)))))))}
   codex-gap-report
   {:doc "Render the Codex gap report (T2 §4) from run ledgers. Usage: bb codex-gap-report [checkpoint-root]; codex from MINIFORGE_CODEX_PATH"
    :extra-paths ["components/codex-gap/src"

--- a/components/codex-gap/resources/config/codex-gap/gate-reason-map.edn
+++ b/components/codex-gap/resources/config/codex-gap/gate-reason-map.edn
@@ -5,4 +5,10 @@
 ;; code-wide mappings. A lookup miss falls through to similarity
 ;; attribution.
 {[:reason/grant-absent nil]   "fail-closed-by-default"
- [:reason/grant-exceeded nil] "authority-outside-the-model"}
+ [:reason/grant-exceeded nil] "authority-outside-the-model"
+ ;; Policy-pack rule violations at verify: the author shipped code an
+ ;; enforced standard refuses — the dominant failure shape of the codex
+ ;; baseline matrix (~280 misses) and the gap the 2026-08-29 harvest
+ ;; admission covers. Code-wide: every rule-id lands on the same problem,
+ ;; because the problem is WHEN the rule reached the author, not which.
+ [:reason/rule-violation nil] "enforcement-after-authoring"}

--- a/components/codex-gap/src/ai/miniforge/codex_gap/interface.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/interface.clj
@@ -28,7 +28,8 @@
   (:require [ai.miniforge.codex-gap.attribute :as attribute]
             [ai.miniforge.codex-gap.classify :as classify]
             [ai.miniforge.codex-gap.ledger :as ledger]
-            [ai.miniforge.codex-gap.report :as report]))
+            [ai.miniforge.codex-gap.report :as report]
+            [ai.miniforge.codex-gap.retrodict :as retrodict]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -69,6 +70,14 @@
    -> problem id) from the classpath resource."
   []
   (attribute/load-gate-reason-map))
+
+(defn ^{:stratum 0} retrodict
+  "T2 §5.4: re-classify recorded misses offline against the codex as it
+   is now, mapping :miss/phase through `phase->situation`. Returns
+   {:entries [..] :shift {[recorded retrodicted] n}} — the shift table is
+   a newly admitted peg's promotion evidence."
+  [entries codex-dir phase->situation]
+  (retrodict/retrodict entries codex-dir phase->situation))
 
 (defn ^{:stratum 0} build-report
   "Ledger entries + {:skipped :run-count :anchoring} -> the T2 §4 gap

--- a/components/codex-gap/src/ai/miniforge/codex_gap/retrodict.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/retrodict.clj
@@ -28,6 +28,7 @@
    The recorded bucket is preserved as :miss/bucket-recorded; the
    retrodicted bucket replaces :miss/bucket."
   (:require [ai.miniforge.codex.interface :as codex]
+            [ai.miniforge.codex-gap.attribute :as attribute]
             [ai.miniforge.codex-gap.classify :as classify]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -47,16 +48,19 @@
    entry's phase (nil keeps the recorded situation); `consider` is a
    memoizable (fn [situation] consider-resp); `classify-fn` is injected
    so the remap is testable without a codex."
-  [classify-fn consider problems situation entry]
+  [classify-fn consider problems opts situation entry]
   (let [situation (or situation (:miss/situation entry))
         consider-resp (when situation (consider situation))
         {:keys [bucket attribution]}
         (classify-fn {:miss/situation situation
                       :miss/consultation (:miss/consultation entry)
                       :miss/signal (:miss/signal entry)}
-                     consider-resp problems {})]
+                     consider-resp problems opts)]
     (assoc entry
-           :miss/bucket-recorded (:miss/bucket entry)
+           ;; Idempotent over re-runs: the ORIGINAL recorded bucket is the
+           ;; datum; a second retrodiction must not overwrite it with the
+           ;; first retrodiction's result.
+           :miss/bucket-recorded (or (:miss/bucket-recorded entry) (:miss/bucket entry))
            :miss/bucket bucket
            :miss/situation situation
            :miss/attribution attribution
@@ -74,8 +78,11 @@
   [entries codex-dir phase->situation]
   (let [problems (codex-problems codex-dir)
         consider (memoize (fn [situation] (codex/consider codex-dir situation)))
+        ;; Loaded once and closed over — classify would otherwise re-read
+        ;; and re-parse the gate-reason map for every entry.
+        opts {:gate-reason-map (attribute/load-gate-reason-map)}
         out (mapv (fn [e]
-                    (retrodict-entry classify/classify consider problems
+                    (retrodict-entry classify/classify consider problems opts
                                      (get phase->situation (:miss/phase e))
                                      e))
                   entries)]

--- a/components/codex-gap/src/ai/miniforge/codex_gap/retrodict.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/retrodict.clj
@@ -1,0 +1,83 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex-gap.retrodict
+  "T2 §5.4 retrodiction: re-classify recorded misses OFFLINE against the
+   codex as it is NOW, with a phase->situation mapping supplied by the
+   caller. A ledger row records the bucket the codex earned at the time;
+   retrodiction asks what bucket the same signal would earn today — the
+   evidence a newly admitted peg needs before promotion (§5.6), and the
+   only way a codex-off baseline arm becomes comparable on coverage and
+   routing. The classifier is pure over data, so this never re-runs a
+   workflow.
+
+   The recorded bucket is preserved as :miss/bucket-recorded; the
+   retrodicted bucket replaces :miss/bucket."
+  (:require [ai.miniforge.codex.interface :as codex]
+            [ai.miniforge.codex-gap.classify :as classify]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} codex-problems
+  "Attribution corpus: every problem node's {:id :title :open}, or nil
+   when the codex is unreadable (the caller decides what that means)."
+  [codex-dir]
+  (let [{:keys [nodes] :as graph} (codex/load-graph codex-dir)]
+    (when-not (:codex/anomaly graph)
+      (->> (vals nodes)
+           (filter #(= "problem" (:type %)))
+           (map #(select-keys % [:id :title :open]))))))
+
+(defn ^{:stratum 0} retrodict-entry
+  "Re-classify one entry. `situation` is the caller's mapping for the
+   entry's phase (nil keeps the recorded situation); `consider` is a
+   memoizable (fn [situation] consider-resp); `classify-fn` is injected
+   so the remap is testable without a codex."
+  [classify-fn consider problems situation entry]
+  (let [situation (or situation (:miss/situation entry))
+        consider-resp (when situation (consider situation))
+        {:keys [bucket attribution]}
+        (classify-fn {:miss/situation situation
+                      :miss/consultation (:miss/consultation entry)
+                      :miss/signal (:miss/signal entry)}
+                     consider-resp problems {})]
+    (assoc entry
+           :miss/bucket-recorded (:miss/bucket entry)
+           :miss/bucket bucket
+           :miss/situation situation
+           :miss/attribution attribution
+           :miss/retrodicted? true)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} retrodict
+  "Re-classify `entries` against the codex at `codex-dir`, mapping each
+   entry's :miss/phase through `phase->situation` (a map; phases absent
+   from it keep their recorded situation). Returns
+   {:entries [...] :shift {[recorded retrodicted] count}} — the shift
+   table IS the promotion evidence: how many misses moved out of
+   :uncovered, and into what."
+  [entries codex-dir phase->situation]
+  (let [problems (codex-problems codex-dir)
+        consider (memoize (fn [situation] (codex/consider codex-dir situation)))
+        out (mapv (fn [e]
+                    (retrodict-entry classify/classify consider problems
+                                     (get phase->situation (:miss/phase e))
+                                     e))
+                  entries)]
+    {:entries out
+     :shift (frequencies (map (juxt :miss/bucket-recorded :miss/bucket) out))}))

--- a/components/codex-gap/src/ai/miniforge/codex_gap/retrodict.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/retrodict.clj
@@ -29,7 +29,8 @@
    retrodicted bucket replaces :miss/bucket."
   (:require [ai.miniforge.codex.interface :as codex]
             [ai.miniforge.codex-gap.attribute :as attribute]
-            [ai.miniforge.codex-gap.classify :as classify]))
+            [ai.miniforge.codex-gap.classify :as classify]
+            [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -49,7 +50,11 @@
    memoizable (fn [situation] consider-resp); `classify-fn` is injected
    so the remap is testable without a codex."
   [classify-fn consider problems opts situation entry]
-  (let [situation (or situation (:miss/situation entry))
+  (let [;; Blank (nil, "", whitespace) means "no mapping" — codex/consider
+        ;; throws on blank situation text, and a blank must behave like
+        ;; keep-the-recorded-situation, never crash the retrodiction.
+        blank->nil (fn [s] (not-empty (some-> s str str/trim)))
+        situation (or (blank->nil situation) (blank->nil (:miss/situation entry)))
         consider-resp (when situation (consider situation))
         {:keys [bucket attribution]}
         (classify-fn {:miss/situation situation

--- a/components/codex-gap/test/ai/miniforge/codex_gap/interface_test.clj
+++ b/components/codex-gap/test/ai/miniforge/codex_gap/interface_test.clj
@@ -143,6 +143,24 @@
     (is (= 1.0 (:confidence attribution)))
     (is (= :unheeded bucket))))
 
+(deftest ^{:stratum 1} policy-rule-violations-attribute-to-enforcement-after-authoring
+  ;; The observational matrix's dominant miss shape: a policy-pack rule
+  ;; violation at verify. Code-wide mapping — WHEN the rule reached the
+  ;; author is the problem, not which rule.
+  (let [signal {:type :gate-failure
+                :payload {:reason/code :reason/rule-violation
+                          :reason/rule-id :std/config-as-data
+                          :reason/detail "policy rule violated"}}
+        {:keys [bucket attribution]}
+        (gap/classify (entry "submitting-work-to-enforced-gates"
+                             {:status :pinned :pinned? true :pin-read? true}
+                             signal)
+                      {:landings [{:id "enforcement-after-authoring" :type "problem"}]}
+                      problems {})]
+    (is (= :mechanical (:method attribution)))
+    (is (= "enforcement-after-authoring" (:problem attribution)))
+    (is (= :unheeded bucket))))
+
 (deftest ^{:stratum 1} ledger-round-trips-and-survives-corrupt-lines
   (let [dir (str (java.nio.file.Files/createTempDirectory
                    "codex-gap-test-"

--- a/components/codex-gap/test/ai/miniforge/codex_gap/retrodict_test.clj
+++ b/components/codex-gap/test/ai/miniforge/codex_gap/retrodict_test.clj
@@ -44,6 +44,11 @@
             twice (retrodict/retrodict-entry classify-fn consider [] {} "submitting-work-to-enforced-gates" once)]
         (is (= :uncovered (:miss/bucket-recorded twice)))
         (is (= :unheeded (:miss/bucket twice)))))
+    (testing "a BLANK mapping behaves like no mapping — never reaches consider"
+      (let [exploding (fn [_] (throw (ex-info "consider called with blank" {})))
+            out (retrodict/retrodict-entry classify-fn exploding [] {} "  " entry)]
+        (is (= :uncovered (:miss/bucket out)))
+        (is (nil? (:miss/situation out)))))
     (testing "no mapping keeps the recorded situation (nil) and bucket"
       (let [out (retrodict/retrodict-entry classify-fn consider [] {} nil entry)]
         (is (= :uncovered (:miss/bucket out)))

--- a/components/codex-gap/test/ai/miniforge/codex_gap/retrodict_test.clj
+++ b/components/codex-gap/test/ai/miniforge/codex_gap/retrodict_test.clj
@@ -34,12 +34,17 @@
                                                 :method :mechanical :confidence :high})})
         consider (fn [situation] (when situation {:landings [:enforcement-after-authoring]}))]
     (testing "a supplied situation moves an :uncovered miss into a covered bucket"
-      (let [out (retrodict/retrodict-entry classify-fn consider [] "submitting-work-to-enforced-gates" entry)]
+      (let [out (retrodict/retrodict-entry classify-fn consider [] {} "submitting-work-to-enforced-gates" entry)]
         (is (= :uncovered (:miss/bucket-recorded out)) "the recorded bucket is preserved")
         (is (= :unheeded (:miss/bucket out)))
         (is (= "submitting-work-to-enforced-gates" (:miss/situation out)))
         (is (true? (:miss/retrodicted? out)))))
+    (testing "retrodicting twice preserves the ORIGINAL recorded bucket"
+      (let [once (retrodict/retrodict-entry classify-fn consider [] {} "submitting-work-to-enforced-gates" entry)
+            twice (retrodict/retrodict-entry classify-fn consider [] {} "submitting-work-to-enforced-gates" once)]
+        (is (= :uncovered (:miss/bucket-recorded twice)))
+        (is (= :unheeded (:miss/bucket twice)))))
     (testing "no mapping keeps the recorded situation (nil) and bucket"
-      (let [out (retrodict/retrodict-entry classify-fn consider [] nil entry)]
+      (let [out (retrodict/retrodict-entry classify-fn consider [] {} nil entry)]
         (is (= :uncovered (:miss/bucket out)))
         (is (nil? (:miss/situation out)))))))

--- a/components/codex-gap/test/ai/miniforge/codex_gap/retrodict_test.clj
+++ b/components/codex-gap/test/ai/miniforge/codex_gap/retrodict_test.clj
@@ -1,0 +1,45 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex-gap.retrodict-test
+  "Retrodiction remaps a recorded miss's situation and bucket while
+   preserving the recorded bucket — the pure part, tested with an
+   injected classifier."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.codex-gap.retrodict :as retrodict]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} retrodict-entry-remaps-situation-and-preserves-recorded-bucket
+  (let [entry {:miss/id :m1 :miss/phase :verify :miss/situation nil
+               :miss/bucket :uncovered :miss/consultation nil
+               :miss/signal {:type :gate-failure :payload {:reason/rule-id :std/config-as-data}}}
+        classify-fn (fn [e resp _problems _opts]
+                      {:bucket (if (and (:miss/situation e) resp) :unheeded :uncovered)
+                       :attribution (when resp {:problem :enforcement-after-authoring
+                                                :method :mechanical :confidence :high})})
+        consider (fn [situation] (when situation {:landings [:enforcement-after-authoring]}))]
+    (testing "a supplied situation moves an :uncovered miss into a covered bucket"
+      (let [out (retrodict/retrodict-entry classify-fn consider [] "submitting-work-to-enforced-gates" entry)]
+        (is (= :uncovered (:miss/bucket-recorded out)) "the recorded bucket is preserved")
+        (is (= :unheeded (:miss/bucket out)))
+        (is (= "submitting-work-to-enforced-gates" (:miss/situation out)))
+        (is (true? (:miss/retrodicted? out)))))
+    (testing "no mapping keeps the recorded situation (nil) and bucket"
+      (let [out (retrodict/retrodict-entry classify-fn consider [] nil entry)]
+        (is (= :uncovered (:miss/bucket out)))
+        (is (nil? (:miss/situation out)))))))


### PR DESCRIPTION
T2 §5.4 retrodiction: re-classify recorded misses offline against the codex as it is NOW, with a caller-supplied phase→situation mapping. Pure over ledger data; never re-runs a workflow. The shift table ([recorded retrodicted] → count) is a newly admitted peg's promotion evidence.

1. codex-gap/retrodict ns (+ interface export): remaps :miss/situation per phase, re-runs the first-leak classifier, preserves the recorded bucket as :miss/bucket-recorded.
2. bb codex-gap-retrodict [checkpoint-root] [phase=situation ...] — prints the shift table and a review-queue breakdown by signal shape. (EDN task body: no #() or regex literals — both bit this task.)
3. gate-reason-map.edn gains [:reason/rule-violation nil] → enforcement-after-authoring: the observational matrix's dominant miss shape, covered by the 2026-08-29 harvest admission (board 3 peg is-the-rule-enforced-downstream; situation submitting-work-to-enforced-gates, wired in #1861).

Live result over every archived ledger (674 misses, all :uncovered when recorded), mapping verify → submitting-work-to-enforced-gates: 494 → :undelivered (covered and routed; delivery is the honest first leak at an agentless phase and in codex-off arms), 180 → :review-queue (90 missing-artifact gate reasons, 90 code-less terminal anomalies — correctly unattributable to a codex problem). The peg was promoted speculative → working on this evidence (zk PROMOTIONS.md).

Tests: pure remap with an injected classifier; mechanical attribution of a rule-violation signal. Full bb test green (serial rerun; the concurrent run tripped the merge_parent_branches integration flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)