### PR TITLE
fix(gate): stale-references scopes to consumers of the producer's namespace family

### DIFF
--- a/components/gate/src/ai/miniforge/gate/stale_references.clj
+++ b/components/gate/src/ai/miniforge/gate/stale_references.clj
@@ -31,11 +31,25 @@
 
    Mechanics: for each changed file, the before-content comes from
    `git show HEAD:<path>` in the worktree (implement runs on uncommitted
-   work, so HEAD is the pre-change state). Candidate tokens are keywords
-   and def'd names present in a before and absent from EVERY changed
-   file's after-content. Each candidate is then searched repo-wide
-   (`git grep -F`); any hit outside the changed set is a stale
-   reference and fails the gate with the token and its files.
+   work, so HEAD is the pre-change state). Producers are the changed
+   non-test files that declare a namespace, grouped by namespace family
+   (`ai.miniforge.codex-gap` for `...codex-gap.ledger`). A family's
+   candidate tokens are keywords and def'd names present in one of its
+   producers' befores and absent from EVERY changed non-test file's
+   after-content. Each candidate is then searched in the family's
+   consumers -- files outside the changed set that name the family, as
+   a require of its interface does -- with namespaced keywords searched
+   repo-wide; any hit is a stale reference and fails the gate with the
+   token and its files.
+
+   Why per-family and consumer-scoped (trap-bench repair series 3,
+   rep rs1): the implementer renamed the ledger's :skipped but a changed
+   TEST kept `{:status :skipped}` in another sense, so a global
+   absent-from-every-changed-file rule never saw a removal -- allow, five
+   iterations running. And an unscoped repo-wide search for a bare
+   keyword like :skipped returns dozens of unrelated files, which is
+   noise the implementer cannot act on. Tests are not producers and
+   not a token's new home; consumers are the files that import you.
 
    Fail-open guards, each surfaced as a warning: no worktree path, no
    changed-file content, git unavailable. The gate never guesses."
@@ -67,6 +81,32 @@
   "Names bound by def/defn/defn-/defmacro/defmulti at any nesting."
   #"\(def(?:n-?|macro|multi)?\s+(?:\^\S+\s+|\^\{[^}]*\}\s+)*([A-Za-z][A-Za-z0-9*+!?_<>=<-]*[A-Za-z0-9*+!?_<>=-])")
 
+(def ^{:stratum 0} ns-pattern
+  "The name bound by a file's (ns ...) form."
+  #"\(ns\s+(?:\^\S+\s+|\^\{[^}]*\}\s+)*([A-Za-z][\w.*+!?<>=-]*)")
+
+(defn ^{:stratum 0} test-path?
+  "Test files are neither producers nor a token's new home. Public for
+   tests."
+  [path]
+  (boolean (re-find #"(?:^|/)test/|[_-]test\.clj[cs]?$" (str path))))
+
+(defn ^{:stratum 0} namespace-family
+  "A namespace with its last segment dropped -- `ai.miniforge.codex-gap`
+   for `ai.miniforge.codex-gap.ledger` -- which is the string every
+   consumer of the component writes when it requires the interface. A
+   single-segment namespace is its own family. Public for tests."
+  [ns-name]
+  (let [s (str ns-name)
+        i (str/last-index-of s ".")]
+    (if i (subs s 0 i) s)))
+
+(defn ^{:stratum 0} namespaced-keyword?
+  "`:ledger/skipped` -- precise enough to search the whole repo for."
+  [token]
+  (let [s (str token)]
+    (and (str/starts-with? s ":") (str/includes? s "/"))))
+
 (defn- ^{:stratum 0} git
   "Trimmed stdout of a git command in `dir`, or nil on any failure."
   [dir & args]
@@ -89,6 +129,12 @@
             (str blob))))
 
 ;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} ns-name-of
+  "The namespace a Clojure file declares, or nil -- edn, bb.edn and
+   scripts without an ns form are data, not producers. Public for tests."
+  [content]
+  (second (re-find ns-pattern (str content))))
 
 (defn ^{:stratum 1} content-tokens
   "The keyword literals and def'd names in `content`. Public for tests."
@@ -121,17 +167,19 @@
          distinct
          vec)))
 
-(defn- ^{:stratum 1} stale-files
-  "Repo files outside `changed-paths` still referencing `token`."
-  [worktree changed-paths token]
-  ;; -e makes the token an explicit pattern — a token can never be
-  ;; parsed as an option or pathspec regardless of its first character.
-  (when-let [out (git worktree "grep" "-I" "-l" "-F" "-e" token "--")]
-    (->> (str/split-lines out)
-         (remove str/blank?)
-         (remove (set changed-paths))
-         (take max-files-per-token)
-         vec)))
+(defn- ^{:stratum 1} referencing-files
+  "Repo files outside `changed-paths` mentioning `needle`, limited to
+   the `scope` paths -- nil scope is the whole repo, an empty scope is
+   nothing (a family nobody imports has no consumers to check)."
+  [worktree changed-paths needle scope]
+  ;; -e makes the needle an explicit pattern — it can never be parsed
+  ;; as an option or pathspec regardless of its first character.
+  (when (or (nil? scope) (seq scope))
+    (when-let [out (apply git worktree "grep" "-I" "-l" "-F" "-e" needle "--" (or scope []))]
+      (->> (str/split-lines out)
+           (remove str/blank?)
+           (remove (set changed-paths))
+           vec))))
 
 ;------------------------------------------------------------------------------ Layer 2
 
@@ -149,6 +197,20 @@
          (take max-tokens)
          vec)))
 
+(defn ^{:stratum 2} producer-families
+  "The changed non-test files that declare a namespace, grouped by
+   namespace family: {family [before-content ...]}. `before-of` maps a
+   path to its pre-change content. Public for tests."
+  [paths before-of]
+  (reduce (fn [acc path]
+            (let [before (get before-of path)
+                  ns-name (ns-name-of before)]
+              (if (and ns-name (not (test-path? path)))
+                (update acc (namespace-family ns-name) (fnil conj []) before)
+                acc)))
+          {}
+          paths))
+
 ;------------------------------------------------------------------------------ Layer 3
 
 (defn ^{:stratum 3} check-stale-references
@@ -156,10 +218,10 @@
    output; changed files ride on :code/files ({:path :content :action})
    with :code/file-paths as the path fallback.
 
-   `befores`/`afters`/`stale` are computed up front, unconditionally --
-   each is nil-safe on its own (a nil `worktree` or empty `paths` just
-   flows through as empty results) and the work is cheap, so guarding
-   each behind its own nesting level bought nothing but extra
+   `before-of`/`after-of`/`stale` are computed up front, unconditionally
+   -- each is nil-safe on its own (a nil `worktree` or empty `paths`
+   just flows through as empty results) and the work is cheap, so
+   guarding each behind its own nesting level bought nothing but extra
    conditional depth."
   [artifact ctx]
   (let [worktree (get ctx :execution/worktree-path)
@@ -171,24 +233,35 @@
         paths (vec (distinct (concat artifact-paths
                                      (when git-ok? (worktree-changed-paths worktree)))))
         artifact-content (into {} (map (juxt :path :content)) files)
-        befores (when (and git-ok? (seq paths)) (keep #(before-content worktree %) paths))
-        afters (when (seq paths)
-                 (keep (fn [path]
-                         (or (get artifact-content path)
-                             (try (slurp (str worktree "/" path))
-                                  (catch Exception _ nil))))
-                       paths))
+        before-of (when (and git-ok? (seq paths))
+                    (into {} (keep (fn [path]
+                                     (when-let [b (before-content worktree path)]
+                                       [path b])))
+                          paths))
+        after-of (when (seq paths)
+                   (into {} (keep (fn [path]
+                                    (when-let [a (or (get artifact-content path)
+                                                     (try (slurp (str worktree "/" path))
+                                                          (catch Exception _ nil)))]
+                                      [path a])))
+                         paths))
+        non-test-afters (keep (fn [[path a]] (when-not (test-path? path) a)) after-of)
         stale (into []
-                    (keep (fn [token]
-                            (let [hits (stale-files worktree paths token)]
-                              (when (seq hits)
-                                {:type :stale-reference
-                                 :token token
-                                 :files hits
-                                 :message (messages/t :stale-references/stale
-                                                      {:token token
-                                                       :files (str/join ", " hits)})}))))
-                    (removed-tokens befores afters))]
+                    (for [[family befores] (producer-families paths before-of)
+                          :let [consumers (delay (referencing-files worktree paths family nil))]
+                          token (removed-tokens befores non-test-afters)
+                          :let [scope (when-not (namespaced-keyword? token) @consumers)
+                                hits (->> (referencing-files worktree paths token scope)
+                                          (take max-files-per-token)
+                                          vec)]
+                          :when (seq hits)]
+                      {:type :stale-reference
+                       :token token
+                       :family family
+                       :files hits
+                       :message (messages/t :stale-references/stale
+                                            {:token token
+                                             :files (str/join ", " hits)})}))]
     (cond
       (empty? paths)
       {:passed? true}
@@ -203,7 +276,7 @@
        :warnings [{:type :stale-references-skipped
                    :message (messages/t :stale-references/git-unavailable)}]}
 
-      (empty? afters)
+      (empty? after-of)
       {:passed? true
        :warnings [{:type :stale-references-skipped
                    :message (messages/t :stale-references/no-content)}]}

--- a/components/gate/src/ai/miniforge/gate/stale_references.clj
+++ b/components/gate/src/ai/miniforge/gate/stale_references.clj
@@ -248,7 +248,10 @@
         non-test-afters (keep (fn [[path a]] (when-not (test-path? path) a)) after-of)
         stale (into []
                     (for [[family befores] (producer-families paths before-of)
-                          :let [consumers (delay (referencing-files worktree paths family nil))]
+                          ;; A family nobody names any more (renamed out of
+                          ;; the worktree) has NO consumers -- an empty scope,
+                          ;; never nil, or bare tokens would go repo-wide.
+                          :let [consumers (delay (or (referencing-files worktree paths family nil) []))]
                           token (removed-tokens befores non-test-afters)
                           :let [scope (when-not (namespaced-keyword? token) @consumers)
                                 hits (->> (referencing-files worktree paths token scope)

--- a/components/gate/src/ai/miniforge/gate/stale_references.clj
+++ b/components/gate/src/ai/miniforge/gate/stale_references.clj
@@ -168,18 +168,18 @@
          vec)))
 
 (defn- ^{:stratum 1} referencing-files
-  "Repo files outside `changed-paths` mentioning `needle`, limited to
-   the `scope` paths -- nil scope is the whole repo, an empty scope is
-   nothing (a family nobody imports has no consumers to check)."
-  [worktree changed-paths needle scope]
+  "Repo files outside `changed-paths` mentioning `needle`. Always a
+   whole-repo `git grep` -- cheap, and the argv stays constant-size;
+   scoping to consumers is a set intersection in the caller, never a
+   pathspec list that could outgrow the OS argument limit."
+  [worktree changed-paths needle]
   ;; -e makes the needle an explicit pattern — it can never be parsed
   ;; as an option or pathspec regardless of its first character.
-  (when (or (nil? scope) (seq scope))
-    (when-let [out (apply git worktree "grep" "-I" "-l" "-F" "-e" needle "--" (or scope []))]
-      (->> (str/split-lines out)
-           (remove str/blank?)
-           (remove (set changed-paths))
-           vec))))
+  (when-let [out (git worktree "grep" "-I" "-l" "-F" "-e" needle "--")]
+    (->> (str/split-lines out)
+         (remove str/blank?)
+         (remove (set changed-paths))
+         vec)))
 
 ;------------------------------------------------------------------------------ Layer 2
 
@@ -249,12 +249,13 @@
         stale (into []
                     (for [[family befores] (producer-families paths before-of)
                           ;; A family nobody names any more (renamed out of
-                          ;; the worktree) has NO consumers -- an empty scope,
-                          ;; never nil, or bare tokens would go repo-wide.
-                          :let [consumers (delay (or (referencing-files worktree paths family nil) []))]
+                          ;; the worktree) has NO consumers -- an empty set,
+                          ;; so its bare tokens match nothing.
+                          :let [consumers (delay (set (referencing-files worktree paths family)))]
                           token (removed-tokens befores non-test-afters)
-                          :let [scope (when-not (namespaced-keyword? token) @consumers)
-                                hits (->> (referencing-files worktree paths token scope)
+                          :let [in-scope? (if (namespaced-keyword? token) any? @consumers)
+                                hits (->> (referencing-files worktree paths token)
+                                          (filter in-scope?)
                                           (take max-files-per-token)
                                           vec)]
                           :when (seq hits)]

--- a/components/gate/test/ai/miniforge/gate/stale_references_scope_test.clj
+++ b/components/gate/test/ai/miniforge/gate/stale_references_scope_test.clj
@@ -1,0 +1,111 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.gate.stale-references-scope-test
+  "Consumer scoping and per-family removal for the contract-drift gate.
+   The end-to-end fixture is trap-bench repair series 3, rep rs1, as
+   recorded: producer renamed, a changed test keeping the old keyword
+   in another sense, the bb.edn consumer requiring the interface and
+   still reading the old key, and an unrelated file using the same bare
+   keyword with no import of the family."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.gate.stale-references :as stale]
+            [ai.miniforge.gate.stale-references-test :as base]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} ns-name-and-family
+  (is (= "ai.miniforge.codex-gap.ledger"
+         (stale/ns-name-of "(ns ai.miniforge.codex-gap.ledger\n  \"doc\"\n  (:require [x]))")))
+  (is (= "ai.miniforge.codex-gap.ledger"
+         (stale/ns-name-of "(ns ^{:stratum 0} ai.miniforge.codex-gap.ledger)")))
+  (is (nil? (stale/ns-name-of "{:tasks {codex-gap-report {:doc \"x\"}}}")))
+  (is (= "ai.miniforge.codex-gap" (stale/namespace-family "ai.miniforge.codex-gap.ledger")))
+  (is (= "producer" (stale/namespace-family "producer"))))
+
+(deftest ^{:stratum 0} test-path-detection
+  (is (true? (stale/test-path? "components/codex-gap/test/ai/miniforge/codex_gap/interface_test.clj")))
+  (is (true? (stale/test-path? "src/foo_test.clj")))
+  (is (false? (stale/test-path? "components/codex-gap/src/ai/miniforge/codex_gap/ledger.clj")))
+  (is (false? (stale/test-path? "bb.edn"))))
+
+(deftest ^{:stratum 0} namespaced-keyword-detection
+  (is (true? (stale/namespaced-keyword? ":ledger/skipped")))
+  (is (false? (stale/namespaced-keyword? ":skipped")))
+  (is (false? (stale/namespaced-keyword? "read-ledger"))))
+
+(deftest ^{:stratum 0} producer-families-groups-non-test-namespaced-files
+  (let [before-of {"components/c/src/ai/m/c/ledger.clj" "(ns ai.m.c.ledger)"
+                   "components/c/src/ai/m/c/report.clj" "(ns ai.m.c.report)"
+                   "components/c/test/ai/m/c/ledger_test.clj" "(ns ai.m.c.ledger-test)"
+                   "bb.edn" "{:tasks {}}"}
+        families (stale/producer-families (keys before-of) before-of)]
+    (is (= ["ai.m.c"] (keys families)))
+    (is (= 2 (count (get families "ai.m.c"))))))
+
+(deftest ^{:stratum 0} rs1-shape-flags-only-the-importing-consumer
+  (testing "a changed test keeping :skipped in another sense does not
+            hide the producer's removal, and a stranger using :skipped
+            without importing the family is not reported"
+    (let [producer "components/codex-gap/src/ai/miniforge/codex_gap/ledger.clj"
+          test-file "components/codex-gap/test/ai/miniforge/codex_gap/interface_test.clj"
+          consumer "bb.edn"
+          stranger "components/gate/src/ai/miniforge/gate/other.clj"
+          dir (base/temp-git-repo
+               {producer "(ns ai.miniforge.codex-gap.ledger)\n(defn read-ledger [] {:entries [] :skipped 0})"
+                test-file "(ns ai.miniforge.codex-gap.interface-test)\n(is (= {:status :skipped} (pin)))\n(is (= 0 (:skipped (read))))"
+                consumer "{:tasks {report {:requires ([ai.miniforge.codex-gap.interface :as codex-gap])\n :task (:skipped (codex-gap/read-ledger d))}}}"
+                stranger "(ns ai.miniforge.gate.other)\n(def r {:status :skipped})"})
+          new-producer "(ns ai.miniforge.codex-gap.ledger)\n(defn read-ledger [] {:entries [] :torn-lines 0})"
+          new-test "(ns ai.miniforge.codex-gap.interface-test)\n(is (= {:status :skipped} (pin)))\n(is (= 0 (:torn-lines (read))))"
+          _ (spit (str dir "/" producer) new-producer)
+          _ (spit (str dir "/" test-file) new-test)
+          result (stale/check-stale-references
+                  {:code/files [{:path producer :content new-producer :action :modify}
+                                {:path test-file :content new-test :action :modify}]}
+                  {:execution/worktree-path dir})]
+      (is (false? (:passed? result)))
+      (is (= [{:token ":skipped" :family "ai.miniforge.codex-gap" :files [consumer]}]
+             (mapv #(select-keys % [:token :family :files]) (:errors result)))))))
+
+(deftest ^{:stratum 0} namespaced-keyword-is-searched-repo-wide
+  (let [producer "src/ai/m/c/ledger.clj"
+        consumer "src/ai/m/other/reader.clj"
+        dir (base/temp-git-repo
+             {producer "(ns ai.m.c.ledger)\n(defn read [] {:ledger/skipped 0})"
+              consumer "(ns ai.m.other.reader)\n(get {} :ledger/skipped)"})
+        new-producer "(ns ai.m.c.ledger)\n(defn read [] {:ledger/torn-lines 0})"
+        _ (spit (str dir "/" producer) new-producer)
+        result (stale/check-stale-references
+                {:code/files [{:path producer :content new-producer :action :modify}]}
+                {:execution/worktree-path dir})]
+    (is (false? (:passed? result)))
+    (is (= [":ledger/skipped"] (mapv :token (:errors result))))
+    (is (= [[consumer]] (mapv :files (:errors result))))))
+
+(deftest ^{:stratum 0} family-without-importers-passes
+  (let [producer "src/ai/m/c/ledger.clj"
+        stranger "src/ai/m/other/x.clj"
+        dir (base/temp-git-repo
+             {producer "(ns ai.m.c.ledger)\n(defn read [] {:skipped 0})"
+              stranger "(ns ai.m.other.x)\n(def r {:status :skipped})"})
+        new-producer "(ns ai.m.c.ledger)\n(defn read [] {:torn-lines 0})"
+        _ (spit (str dir "/" producer) new-producer)
+        result (stale/check-stale-references
+                {:code/files [{:path producer :content new-producer :action :modify}]}
+                {:execution/worktree-path dir})]
+    (is (true? (:passed? result)))))

--- a/components/gate/test/ai/miniforge/gate/stale_references_scope_test.clj
+++ b/components/gate/test/ai/miniforge/gate/stale_references_scope_test.clj
@@ -109,3 +109,19 @@
                 {:code/files [{:path producer :content new-producer :action :modify}]}
                 {:execution/worktree-path dir})]
     (is (true? (:passed? result)))))
+
+(deftest ^{:stratum 0} renamed-family-with-no-remaining-mention-does-not-go-repo-wide
+  (testing "the old family string vanishes from the worktree with the
+            rename, so its consumer search has no matches at all; that
+            is an empty scope, not a repo-wide one"
+    (let [producer "src/ai/old/c/ledger.clj"
+          stranger "src/ai/other/x.clj"
+          dir (base/temp-git-repo
+               {producer "(ns ai.old.c.ledger)\n(defn read [] {:skipped 0})"
+                stranger "(ns ai.other.x)\n(def r {:status :skipped})"})
+          new-producer "(ns ai.new.c.ledger)\n(defn read [] {:torn-lines 0})"
+          _ (spit (str dir "/" producer) new-producer)
+          result (stale/check-stale-references
+                  {:code/files [{:path producer :content new-producer :action :modify}]}
+                  {:execution/worktree-path dir})]
+      (is (true? (:passed? result))))))

--- a/components/gate/test/ai/miniforge/gate/stale_references_test.clj
+++ b/components/gate/test/ai/miniforge/gate/stale_references_test.clj
@@ -114,7 +114,7 @@
           consumer "tasks/report.clj"
           dir (temp-git-repo
                {producer "(ns producer)\n(defn read-ledger [] {:entries [] :skipped 0})"
-                consumer "(ns report)\n(defn skipped-count [r] (get r :skipped 0))"})
+                consumer "(ns report (:require [producer :as p]))\n(defn skipped-count [r] (get (p/read-ledger) :skipped 0))"})
           new-producer "(ns producer)\n(defn read-ledger [] {:entries [] :torn-lines 0})"
           _ (spit (str dir "/" producer) new-producer)
           result (stale/check-stale-references
@@ -129,9 +129,9 @@
         consumer "tasks/report.clj"
         dir (temp-git-repo
              {producer "(ns producer)\n(defn read-ledger [] {:skipped 0})"
-              consumer "(ns report)\n(get {} :skipped)"})
+              consumer "(ns report (:require [producer]))\n(get {} :skipped)"})
         new-producer "(ns producer)\n(defn read-ledger [] {:torn-lines 0})"
-        new-consumer "(ns report)\n(get {} :torn-lines)"
+        new-consumer "(ns report (:require [producer]))\n(get {} :torn-lines)"
         _ (spit (str dir "/" producer) new-producer)
         _ (spit (str dir "/" consumer) new-consumer)
         result (stale/check-stale-references
@@ -148,7 +148,7 @@
           consumer "tasks/report.clj"
           dir (temp-git-repo
                {producer "(ns producer)\n(defn read-ledger [] {:skipped 0})"
-                consumer "(ns report)\n(get {} :skipped)"})
+                consumer "(ns report (:require [producer]))\n(get {} :skipped)"})
           _ (spit (str dir "/" producer) "(ns producer)\n(defn read-ledger [] {:torn-lines 0})")
           result (stale/check-stale-references
                   {:code/files []}


### PR DESCRIPTION
## Summary

Trap-bench repair series 3, rep rs1 (pin c87b55e7a), with the new gate-history ground truth: the `:stale-references` gate allowed every one of five implement iterations while the tree was sprung (bb.edn still reading `:skipped`). Two causes, both by the gate's own definition:

1. Removal was judged globally over every changed file. The implementer's changed test kept `{:status :skipped}` in another sense, so `:skipped` never counted as removed.
2. Even if it had, an unscoped repo-wide search for a bare keyword is noise: 76 files in the repo use `:skipped`.

## Change

- Producers = changed non-test files that declare a namespace, grouped by namespace family (`ai.miniforge.codex-gap` for `...codex-gap.ledger`).
- Removal is judged per family against changed non-test after-content only.
- Stale search is scoped to files that name the family (a require of its interface does), which is how bb.edn reaches `codex-gap/read-ledger`. Namespaced keywords stay repo-wide.
- Errors carry `:family`.

Tests: new `stale_references_scope_test.clj` keeps the rs1 shape as the end-to-end fixture (producer renamed, changed test retaining the keyword, bb.edn consumer, unrelated stranger not flagged). Existing fixtures now require the producer.

Stratum budget: warn mode on commit; the file's 5-layer count is pre-existing on main (#1756).

Bench evidence: `~/.miniforge/checkpoints/4ad44a07-.../gate-history.edn` (implement allow x5, verify policy-verify deny x7), task branch task-83dbab21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)