### PR TITLE
fix(bench): provision pins branch refs to the checkout; run-trap keeps dogfood logs

### DIFF
--- a/development/test/bench_test.clj
+++ b/development/test/bench_test.clj
@@ -170,7 +170,7 @@
             commit even when the launching checkout's <branch> trails it —
             the 2026-09-03 bench had `main` three weeks behind its pin"
     (let [root (temp-dir)
-          source (init-launching-repo! (str (File. root "launching")))
+          source (init-launching-repo! (temp-dir))
           main-sha (str/trim (str (:out (git/git source "rev-parse" "HEAD"))))
           _ (git/git source "checkout" "--quiet" "--detach")
           _ (spit (str (File. (str source) "later.txt")) "later\n")

--- a/development/test/bench_test.clj
+++ b/development/test/bench_test.clj
@@ -188,4 +188,4 @@
           (is (= pin-sha (rev "origin/main")))
           (is (= main-sha (str/trim (str (:out (git/git source "rev-parse" "main")))))
               "the launching checkout's own main is untouched"))
-        (finally (delete-tree! root))))))
+        (finally (delete-tree! root) (delete-tree! source))))))

--- a/development/test/bench_test.clj
+++ b/development/test/bench_test.clj
@@ -164,3 +164,28 @@
           (git/git source "worktree" "remove" "--force" leaky)
           (delete-tree! parent)
           (delete-tree! source))))))
+
+(deftest ^{:stratum 2} provision-pins-branch-refs-to-the-checkout-test
+  (testing "the clone's local <branch> and origin/<branch> equal the pinned
+            commit even when the launching checkout's <branch> trails it —
+            the 2026-09-03 bench had `main` three weeks behind its pin"
+    (let [root (temp-dir)
+          source (init-launching-repo! (str (File. root "launching")))
+          main-sha (str/trim (str (:out (git/git source "rev-parse" "HEAD"))))
+          _ (git/git source "checkout" "--quiet" "--detach")
+          _ (spit (str (File. (str source) "later.txt")) "later\n")
+          _ (git/git source "add" "later.txt")
+          _ (git/git source "commit" "--quiet" "-m" "later")
+          pin-sha (str/trim (str (:out (git/git source "rev-parse" "HEAD"))))]
+      (try
+        (let [bench-root (str (File. root "bench"))
+              report (sut/provision! {:source source :root bench-root :ref pin-sha})
+              repo (str (File. bench-root sut/repo-dir-name))
+              rev (fn [r] (str/trim (str (:out (git/git repo "rev-parse" r)))))]
+          (is (nil? (:anomaly/type report)) (pr-str report))
+          (is (not= main-sha pin-sha) "fixture: the source's main must trail the pin")
+          (is (= pin-sha (rev "main")))
+          (is (= pin-sha (rev "origin/main")))
+          (is (= main-sha (str/trim (str (:out (git/git source "rev-parse" "main")))))
+              "the launching checkout's own main is untouched"))
+        (finally (delete-tree! root))))))

--- a/eval/codex-traps/RUNSHEET.md
+++ b/eval/codex-traps/RUNSHEET.md
@@ -290,3 +290,20 @@ REVISED RESULTS (frozen detector, recovered trees):
    migration as the peg's best outcome; (b) trap-b and trap-c retire
    at this tier (bench-trap retirement); (c) run-trap.bb detection
    moves to the snapshot record.
+
+AMENDMENT 2026-09-03 (instrument only): run-trap.bb captures each run's
+full dogfood stdout+stderr to eval/codex-traps/logs/<arm>-<trap>-<rep>.log.
+The :implementer/prompt-sections ground truth is a LOGGER line, present
+only in that stream (stream dumps are the model's output; events are a
+subset), and the harness was discarding it. Applied mid-series 3 from
+rs3 onward; rs1/rs2 have gate-history.edn but no prompt log.
+
+AMENDMENT 2026-09-03 (bench defect, provisioning): a provisioned
+sandbox's local `main` and `origin/main` were the launching checkout's
+copies, not the pin — in the series-3 sandbox both sat at d2f0860b
+(#1744) while HEAD was the pin c87b55e7a. Anything that branches from
+`main` by name (the dag-executor's default base ref) started three weeks
+stale; 69 task-* branches in that sandbox were "Created from d2f0860b".
+The two task branches the rs1 verdict was read from chain to the pin,
+so the rs1 evidence stands; series 4 provisions with `bench:provision`
+pinning both refs (tasks/bench.clj, this PR).

--- a/eval/codex-traps/run-trap.bb
+++ b/eval/codex-traps/run-trap.bb
@@ -315,13 +315,22 @@
 (defn ^{:stratum 2} run-dogfood!
   "Returns `{:exit .. :started .. :ended ..}`, or an anomaly when the run
    could not be started from a clean tree."
-  [{:keys [repo specs]} {:keys [arm trap codex home]}]
+  [{:keys [repo specs runs]} {:keys [arm trap codex home rep]}]
   (let [spec-name (trap->spec trap)
-        started (str (java.time.Instant/now))]
+        started (str (java.time.Instant/now))
+        ;; Full dogfood stdout+stderr per run: the logger lines (e.g.
+        ;; :implementer/prompt-sections) live ONLY there — stream dumps
+        ;; are the model's output, events are a subset — and tail -1 was
+        ;; discarding the ground truth the third series was run to get.
+        log-dir (str (fs/path (fs/parent runs) "logs"))
+        _ (fs/create-dirs log-dir)
+        log-file (fs/file (str (fs/path log-dir (str arm "-" trap "-" rep ".log"))))]
     (if-let [failure (or (reset-anomaly repo) (copy-anomaly specs repo spec-name))]
       failure
-      {:exit (:exit (p/shell {:dir repo :env (run-env arm codex home) :continue true}
+      {:exit (:exit (p/shell {:dir repo :env (run-env arm codex home) :continue true
+                              :out log-file :err log-file}
                              "bb" "dogfood" (str "work/" spec-name)))
+       :log (str log-file)
        :started started
        :ended (str (java.time.Instant/now))})))
 
@@ -398,7 +407,7 @@
     (System/exit refused-exit))
   (let [inputs (arm-inputs (:root paths) arm)
         before (snapshot (:repo paths) inputs)
-        run (run-dogfood! paths (assoc inputs :arm arm :trap trap :codex codex))
+        run (run-dogfood! paths (assoc inputs :arm arm :trap trap :codex codex :rep rep))
         _ (when (:anomaly/type run)
             (report-refusal! run)
             (System/exit refused-exit))

--- a/eval/codex-traps/run-trap.bb
+++ b/eval/codex-traps/run-trap.bb
@@ -39,6 +39,11 @@
 (def ^{:stratum 0} usage
   "usage: bb eval/codex-traps/run-trap.bb <baseline|treated> <trap-a|trap-b|trap-c> <rep>")
 
+(defn ^{:stratum 0} valid-rep?
+  "One filename segment: letters, digits, dot, underscore, dash."
+  [rep]
+  (boolean (re-matches #"[A-Za-z0-9._-]+" (str rep))))
+
 (def ^{:stratum 0} refused-exit
   "Exit code for a run that never started, distinct from 0 and 1 so a
    refusal cannot be read as a run that passed or failed."
@@ -324,9 +329,7 @@
         ;; discarding the ground truth the third series was run to get.
         log-dir (str (fs/path (fs/parent runs) "logs"))
         _ (fs/create-dirs log-dir)
-        ;; `rep` is a CLI argument: keep the filename to one path segment.
-        safe-rep (str/replace (str rep) #"[^A-Za-z0-9._-]" "_")
-        log-file (fs/file (str (fs/path log-dir (str arm "-" trap "-" safe-rep ".log"))))]
+        log-file (fs/file (str (fs/path log-dir (str arm "-" trap "-" rep ".log"))))]
     (if-let [failure (or (reset-anomaly repo) (copy-anomaly specs repo spec-name))]
       failure
       ;; stderr is merged into stdout at the process level (`:err :out`),
@@ -401,8 +404,9 @@
 (let [[arm trap rep] *command-line-args*
       paths (sandbox-paths *file*)
       codex (codex-path)]
-  ;; A blank rep would key a runs.edn row and a log file on nothing.
-  (when-not (and (#{baseline-arm treated-arm} arm) (trap->spec trap) (not (str/blank? rep)))
+  ;; rep keys the runs.edn row and names the log file verbatim, so it is
+  ;; one filename segment or nothing -- refused, never rewritten.
+  (when-not (and (#{baseline-arm treated-arm} arm) (trap->spec trap) (valid-rep? rep))
     (println usage)
     (System/exit refused-exit))
   (when-let [refusal (or (isolation-anomaly paths)

--- a/eval/codex-traps/run-trap.bb
+++ b/eval/codex-traps/run-trap.bb
@@ -401,7 +401,8 @@
 (let [[arm trap rep] *command-line-args*
       paths (sandbox-paths *file*)
       codex (codex-path)]
-  (when-not (and (#{baseline-arm treated-arm} arm) (trap->spec trap) rep)
+  ;; A blank rep would key a runs.edn row and a log file on nothing.
+  (when-not (and (#{baseline-arm treated-arm} arm) (trap->spec trap) (not (str/blank? rep)))
     (println usage)
     (System/exit refused-exit))
   (when-let [refusal (or (isolation-anomaly paths)

--- a/eval/codex-traps/run-trap.bb
+++ b/eval/codex-traps/run-trap.bb
@@ -324,11 +324,15 @@
         ;; discarding the ground truth the third series was run to get.
         log-dir (str (fs/path (fs/parent runs) "logs"))
         _ (fs/create-dirs log-dir)
-        log-file (fs/file (str (fs/path log-dir (str arm "-" trap "-" rep ".log"))))]
+        ;; `rep` is a CLI argument: keep the filename to one path segment.
+        safe-rep (str/replace (str rep) #"[^A-Za-z0-9._-]" "_")
+        log-file (fs/file (str (fs/path log-dir (str arm "-" trap "-" safe-rep ".log"))))]
     (if-let [failure (or (reset-anomaly repo) (copy-anomaly specs repo spec-name))]
       failure
+      ;; stderr is merged into stdout at the process level (`:err :out`),
+      ;; so the log is one faithful stream, not two writers on one file.
       {:exit (:exit (p/shell {:dir repo :env (run-env arm codex home) :continue true
-                              :out log-file :err log-file}
+                              :out log-file :err :out}
                              "bb" "dogfood" (str "work/" spec-name)))
        :log (str log-file)
        :started started

--- a/tasks/bench.clj
+++ b/tasks/bench.clj
@@ -114,8 +114,9 @@
 
    Clones `:source` to `<root>/repo` at `:ref`, creates the throwaway bare
    mirror `<root>/origin.git`, pushes the pinned commit to it as a fully
-   qualified `refs/heads/<branch>`, and points only the clone's origin at
-   the mirror. Seeding by explicit push rather than by mirroring every ref
+   qualified `refs/heads/<branch>`, pins the clone's local `<branch>` and
+   `origin/<branch>` to that same commit, and points only the clone's
+   origin at the mirror. Seeding by explicit push rather than by mirroring every ref
    also stops junk refs in the source propagating into the bench.
 
    The launching checkout is read from and never written to: its
@@ -133,7 +134,8 @@
         repo-dir (str (File. (str root) repo-dir-name))
         mirror-dir (str (File. (str root) mirror-dir-name))
         origin-before (git/remote-url source "origin")
-        target-ref (qualified-branch-ref branch)]
+        target-ref (qualified-branch-ref branch)
+        branch-name (when target-ref (subs target-ref (count "refs/heads/")))]
     (cond
       (nil? target-ref)
       (anomaly :invalid-input "branch name is empty once ref prefixes are stripped"
@@ -158,6 +160,15 @@
                      [:seed-mirror #(git/git repo-dir "push" "--quiet" mirror-dir
                                              (str "HEAD:" target-ref))]
                      [:mirror-head #(git/git mirror-dir "symbolic-ref" "HEAD" target-ref)]
+                     ;; The clone copied the launching checkout's local
+                     ;; `<branch>` and its `origin/<branch>` as they were,
+                     ;; which can trail the pin by weeks. Anything that
+                     ;; branches from `<branch>` by name (the dag-executor's
+                     ;; default base ref is "main") would then start from
+                     ;; that stale commit. Pin both refs to the checkout.
+                     [:pin-branch #(git/git repo-dir "branch" "--force" branch-name "HEAD")]
+                     [:pin-tracking #(git/git repo-dir "update-ref"
+                                              (str "refs/remotes/origin/" branch-name) "HEAD")]
                      [:redirect-origin #(git/git repo-dir "remote" "set-url" "origin" mirror-dir)]]
               failed (reduce (fn [_ [step run-step!]]
                                (let [r (run-step!)]


### PR DESCRIPTION
## Summary

Two trap-bench harness defects found while reading series 3 (rs1) forensics.

1. **Provision left `main` stale.** The clone carried the launching checkout's local `main` and `origin/main` unchanged, while HEAD was detached at the pin. In the series-3 sandbox both refs sat at d2f0860b (#1744) under pin c87b55e7a, and 69 `task-*` branches were "Created from d2f0860b" by code that branches from `main` by name (dag-executor's default base ref). `provision!` now force-pins `<branch>` and `origin/<branch>` to HEAD after seeding the mirror. Test: a source whose `main` trails the pin.
2. **run-trap discarded the logger stream.** `:implementer/prompt-sections` (the retry-prompt ground truth the third series was run to obtain) is a logger line; stream dumps are the model's output and events are a subset. Each run's full dogfood stdout+stderr now lands in `eval/codex-traps/logs/<arm>-<trap>-<rep>.log`.

RUNSHEET.md gains the two amendments. The rs1 verdict stands: the two task branches it was read from chain to the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)