### PR TITLE
fix(logging): the human format carries the entry's :data map

### DIFF
--- a/components/logging/src/ai/miniforge/logging/format.clj
+++ b/components/logging/src/ai/miniforge/logging/format.clj
@@ -29,11 +29,9 @@
   (pr-str entry))
 
 (defn ^{:stratum 0} format-human
-  "Format a log entry as a human-readable string. A :data map rides on
-   the same line as EDN: an event whose whole point is its payload
-   (:implementer/prompt-sections, :policy/budget-exceeded) is otherwise
-   just a name in the console and file sinks, and the trap bench read
-   two series of logs that recorded the name and nothing else."
+  "Format a log entry as one line: timestamp, [level], category/event,
+   ` - message` when present, then :data as EDN when present -- the
+   payload is the evidence for payload-only events."
   [entry]
   (let [{:log/keys [timestamp level category event message]} entry
         data (get entry :data)]

--- a/components/logging/src/ai/miniforge/logging/format.clj
+++ b/components/logging/src/ai/miniforge/logging/format.clj
@@ -41,7 +41,10 @@
          " [" (name level) "] "
          (name category) "/" (name event)
          (when message (str " - " message))
-         (when (seq data) (str " " (pr-str data))))))
+         ;; :data is documented as a map, but a sink must never throw on
+         ;; a scalar — anything non-nil and non-empty is printed as-is.
+         (when-not (or (nil? data) (and (coll? data) (empty? data)))
+           (str " " (pr-str data))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/logging/src/ai/miniforge/logging/format.clj
+++ b/components/logging/src/ai/miniforge/logging/format.clj
@@ -29,13 +29,19 @@
   (pr-str entry))
 
 (defn ^{:stratum 0} format-human
-  "Format a log entry as a human-readable string."
+  "Format a log entry as a human-readable string. A :data map rides on
+   the same line as EDN: an event whose whole point is its payload
+   (:implementer/prompt-sections, :policy/budget-exceeded) is otherwise
+   just a name in the console and file sinks, and the trap bench read
+   two series of logs that recorded the name and nothing else."
   [entry]
-  (let [{:log/keys [timestamp level category event message]} entry]
+  (let [{:log/keys [timestamp level category event message]} entry
+        data (get entry :data)]
     (str (when timestamp (.toInstant timestamp))
          " [" (name level) "] "
          (name category) "/" (name event)
-         (when message (str " - " message)))))
+         (when message (str " - " message))
+         (when (seq data) (str " " (pr-str data))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/logging/test/ai/miniforge/logging/format_test.clj
+++ b/components/logging/test/ai/miniforge/logging/format_test.clj
@@ -36,12 +36,14 @@
       (is (= {:sections [:gate-failures :phase-handoff] :prompt-chars 4120}
              (edn/read-string (subs line (str/index-of line "{")))))))
   (testing "message and data both render, message first"
-    (is (= " [warn] policy/budget-exceeded - over {:used 100, :limit 50}"
-           (fmt/format-human {:log/level :warn
-                              :log/category :policy
-                              :log/event :policy/budget-exceeded
-                              :log/message "over"
-                              :data {:used 100 :limit 50}}))))
+    (let [line (fmt/format-human {:log/level :warn
+                                  :log/category :policy
+                                  :log/event :policy/budget-exceeded
+                                  :log/message "over"
+                                  :data {:used 100 :limit 50}})]
+      (is (str/starts-with? line " [warn] policy/budget-exceeded - over {"))
+      (is (= {:used 100 :limit 50}
+             (edn/read-string (subs line (str/index-of line "{")))))))
   (testing "scalar data does not throw and is printed"
     (is (= " [info] loop/tick 42"
            (fmt/format-human {:log/level :info :log/category :loop :log/event :loop/tick :data 42}))))

--- a/components/logging/test/ai/miniforge/logging/format_test.clj
+++ b/components/logging/test/ai/miniforge/logging/format_test.clj
@@ -1,0 +1,49 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.logging.format-test
+  "The human format must carry an entry's :data, or payload-only events
+   leave no evidence in console and file sinks."
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.logging.format :as fmt]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} format-human-carries-data
+  (testing "the data map is appended as readable EDN"
+    (let [line (fmt/format-human {:log/level :info
+                                  :log/category :implementer
+                                  :log/event :implementer/prompt-sections
+                                  :data {:sections [:gate-failures :phase-handoff]
+                                         :prompt-chars 4120}})]
+      (is (str/starts-with? line " [info] implementer/prompt-sections {"))
+      (is (= {:sections [:gate-failures :phase-handoff] :prompt-chars 4120}
+             (edn/read-string (subs line (str/index-of line "{")))))))
+  (testing "message and data both render, message first"
+    (is (= " [warn] policy/budget-exceeded - over {:used 100, :limit 50}"
+           (fmt/format-human {:log/level :warn
+                              :log/category :policy
+                              :log/event :policy/budget-exceeded
+                              :log/message "over"
+                              :data {:used 100 :limit 50}}))))
+  (testing "no data, no trailing map"
+    (is (= " [info] loop/iteration-started"
+           (fmt/format-human {:log/level :info
+                              :log/category :loop
+                              :log/event :loop/iteration-started})))))

--- a/components/logging/test/ai/miniforge/logging/format_test.clj
+++ b/components/logging/test/ai/miniforge/logging/format_test.clj
@@ -42,6 +42,12 @@
                               :log/event :policy/budget-exceeded
                               :log/message "over"
                               :data {:used 100 :limit 50}}))))
+  (testing "scalar data does not throw and is printed"
+    (is (= " [info] loop/tick 42"
+           (fmt/format-human {:log/level :info :log/category :loop :log/event :loop/tick :data 42}))))
+  (testing "empty data is omitted"
+    (is (= " [info] loop/tick"
+           (fmt/format-human {:log/level :info :log/category :loop :log/event :loop/tick :data {}}))))
   (testing "no data, no trailing map"
     (is (= " [info] loop/iteration-started"
            (fmt/format-human {:log/level :info


### PR DESCRIPTION
## Summary

`format-human` rendered timestamp, level, category/event and message, and dropped `:data`. Events whose whole point is the payload (`:implementer/prompt-sections`, `:policy/budget-exceeded`) showed up as a bare name in the console sink and in the default file sink (which uses the same formatter). The trap bench's repair series 3 captured full dogfood logs for exactly that event and got the name and nothing else.

The `:data` map now follows on the same line as EDN, after the message when there is one. Test covers data-only, message+data, and no-data lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)