### PR TITLE
fix(reporting): remove two dead #_ blocks and fix poll-events TOCTOU race

### DIFF
--- a/components/reporting/src/ai/miniforge/reporting/core.clj
+++ b/components/reporting/src/ai/miniforge/reporting/core.clj
@@ -49,11 +49,6 @@
   [workflows status]
   (count (filter #(= status (:workflow/status %)) workflows)))
 
-;; Note: Keep for future phase-based filtering
-#_(defn count-by-phase
-    "Count workflows by phase."
-    [workflows phase]
-    (count (filter #(= phase (:workflow/phase %)) workflows)))
 ;; Subscription management (polling-based for BB compatibility)
 (defn ^{:stratum 0} create-subscription
   "Create a new subscription record."
@@ -88,13 +83,6 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-;; Note: Keep for future event broadcasting support
-#_(defn add-event-to-subscriptions
-    "Add event to relevant subscriptions."
-    [subscriptions event]
-    (doseq [[_id sub] @subscriptions]
-      (when (contains? (:subscription/topics sub) (:event/topic event))
-        (swap! (:subscription/event-queue sub) conj event))))
 ;; System status aggregation
 (defn ^{:stratum 1} aggregate-workflow-stats
   "Aggregate workflow statistics."
@@ -246,14 +234,14 @@
 
   (poll-events [_this subscription-id]
     (if-let [sub (get @subscriptions subscription-id)]
-      (let [queue (:subscription/event-queue sub)
-            events @queue
-            callback (:subscription/callback sub)]
-        ;; Reset queue and update last poll time
-        (reset! queue [])
+      (let [queue     (:subscription/event-queue sub)
+            ;; swap-vals! atomically drains the queue, returning [old new].
+            ;; A plain @queue + reset! pair has a TOCTOU gap: events arriving
+            ;; between the deref and the reset! are silently dropped.
+            [events _] (swap-vals! queue (constantly []))
+            callback  (:subscription/callback sub)]
         (swap! subscriptions assoc-in [subscription-id :subscription/last-poll]
                (System/currentTimeMillis))
-        ;; Invoke callback for each event
         (doseq [event events]
           (try
             (callback event)


### PR DESCRIPTION
## What and why

`components/reporting/src/ai/miniforge/reporting/core.clj` had two `#_(defn …)` reader-macro blocks kept alive with "Keep for future …" comments:

- **`count-by-phase`** (Layer 0) — unused filtering helper
- **`add-event-to-subscriptions`** (Layer 1) — event queue feeder

Both violate dewey 008 (no-dead-code): the rule explicitly prohibits `#_`-commented-out code and "Keep for future" rationale comments as substitutes for a tracked issue.

Removing `add-event-to-subscriptions` also exposes a **TOCTOU race in `poll-events`**: the old implementation read the queue with `@queue`, then cleared it with `(reset! queue [])`. Any event conj'd between the deref and the reset would be silently dropped. The fix replaces the pair with `(swap-vals! queue (constantly []))`, which atomically drains the queue and returns its former contents in a single CAS.

## Changes

- `components/reporting/src/ai/miniforge/reporting/core.clj`
  - Delete `count-by-phase` `#_` block (Layer 0) and its "Keep for future" comment
  - Delete `add-event-to-subscriptions` `#_` block (Layer 1) and its "Keep for future" comment
  - Replace `@queue` + `(reset! queue [])` in `poll-events` with `(swap-vals! queue (constantly []))`

## Tests

Existing `interface_test.clj` tests for `poll-events` (empty-queue and nonexistent-subscription cases) remain green; the swap-vals! replacement is backward-compatible for both.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GauHkBVdgJqR5eLFd6k319

---
_Generated by [Claude Code](https://claude.ai/code/session_01GauHkBVdgJqR5eLFd6k319)_