### PR TITLE
fix(gate): stale-references names importers by require form, skips tests and own component, cites each stale line

### DIFF
--- a/components/gate/resources/config/gate/messages/en-US.edn
+++ b/components/gate/resources/config/gate/messages/en-US.edn
@@ -11,6 +11,10 @@
   :stale-references/stale
   "'{token}' was removed by this change but is still referenced by: {files}"
 
+  ;; Stale-references gate — one matching line per stale file
+  :stale-references/hit
+  "  - {file}:{line}: {text}"
+
   ;; Stale-references gate — no worktree available
   :stale-references/no-worktree
   "No worktree path on the execution context — stale-references check skipped"

--- a/components/gate/src/ai/miniforge/gate/stale_references.clj
+++ b/components/gate/src/ai/miniforge/gate/stale_references.clj
@@ -37,9 +37,11 @@
    candidate tokens are keywords and def'd names present in one of its
    producers' befores and absent from EVERY changed non-test file's
    after-content. Each candidate is then searched in the family's
-   importers -- files outside the changed set that require the family
-   (`[ai.miniforge.codex-gap` or `'ai.miniforge.codex-gap`, as a ns
-   :require, a bb.edn :requires, or a quoted require do) -- with
+   importers -- files outside the changed set that require the family:
+   the family name opened by a require vector's bracket or preceded by
+   a quote, as a ns :require, a bb.edn :requires, or a quoted require
+   write it (spelled out in `import-needles`; not repeated here, since
+   this docstring would otherwise import every family it names) -- with
    namespaced keywords searched repo-wide; any hit is a stale reference
    and fails the gate with the token, its files, and each file's first
    matching line. Three kinds of file are never importers: prose that
@@ -111,8 +113,8 @@
     (if i (subs s 0 i) s)))
 
 (defn ^{:stratum 0} component-dir
-  "`components/<c>/` for a Polylith component path, else nil. Public
-   for tests."
+  "The brick directory -- `components/<c>/` or `bases/<b>/` -- for a
+   Polylith path, else nil. Public for tests."
   [path]
   (second (re-find #"^((?:components|bases)/[^/]+/)" (str path))))
 
@@ -298,7 +300,9 @@
                                                                            (str/starts-with? % own-component))))
                                                        (import-needles family)))]
                           token (removed-tokens befores non-test-afters)
-                          :let [in-scope? (if (namespaced-keyword? token) any? @consumers)
+                          :let [in-scope? (if (namespaced-keyword? token)
+                                            (constantly true)
+                                            @consumers)
                                 files (->> (referencing-files worktree paths token)
                                            (filter in-scope?)
                                            (take max-files-per-token)

--- a/components/gate/src/ai/miniforge/gate/stale_references.clj
+++ b/components/gate/src/ai/miniforge/gate/stale_references.clj
@@ -37,10 +37,19 @@
    candidate tokens are keywords and def'd names present in one of its
    producers' befores and absent from EVERY changed non-test file's
    after-content. Each candidate is then searched in the family's
-   consumers -- files outside the changed set that name the family, as
-   a require of its interface does -- with namespaced keywords searched
-   repo-wide; any hit is a stale reference and fails the gate with the
-   token and its files.
+   importers -- files outside the changed set that require the family
+   (`[ai.miniforge.codex-gap` or `'ai.miniforge.codex-gap`, as a ns
+   :require, a bb.edn :requires, or a quoted require do) -- with
+   namespaced keywords searched repo-wide; any hit is a stale reference
+   and fails the gate with the token, its files, and each file's first
+   matching line. Three kinds of file are never importers: prose that
+   merely mentions the namespace, test files, and the producer's own
+   component -- the last two are exercised by verify's tests, and this
+   gate exists for the consumer no test covers. Trap-bench series 4:
+   the denial listed the gate's own docstring, a test fixture and a
+   same-component enum use of the keyword next to the real consumer;
+   the implementer fixed the wrong files in rt1/rt2, and in rt3 fixed
+   the right one and was still denied on the spurious ones.
 
    Why per-family and consumer-scoped (trap-bench repair series 3,
    rep rs1): the implementer renamed the ledger's :skipped but a changed
@@ -100,6 +109,18 @@
   (let [s (str ns-name)
         i (str/last-index-of s ".")]
     (if i (subs s 0 i) s)))
+
+(defn ^{:stratum 0} component-dir
+  "`components/<c>/` for a Polylith component path, else nil. Public
+   for tests."
+  [path]
+  (second (re-find #"^((?:components|bases)/[^/]+/)" (str path))))
+
+(defn ^{:stratum 0} import-needles
+  "The literal forms a file uses to require a namespace family: the
+   opening of a require vector and a quoted symbol. Public for tests."
+  [family]
+  [(str "[" family) (str "'" family)])
 
 (defn ^{:stratum 0} namespaced-keyword?
   "`:ledger/skipped` -- precise enough to search the whole repo for."
@@ -170,7 +191,7 @@
 (defn- ^{:stratum 1} referencing-files
   "Repo files outside `changed-paths` mentioning `needle`. Always a
    whole-repo `git grep` -- cheap, and the argv stays constant-size;
-   scoping to consumers is a set intersection in the caller, never a
+   scoping to importers is a set intersection in the caller, never a
    pathspec list that could outgrow the OS argument limit."
   [worktree changed-paths needle]
   ;; -e makes the needle an explicit pattern — it can never be parsed
@@ -180,6 +201,22 @@
          (remove str/blank?)
          (remove (set changed-paths))
          vec)))
+
+(defn- ^{:stratum 1} first-hit
+  "`{:file :line :text}` for the first line of `path` mentioning `token`
+   -- the evidence an implementer can act on without re-running the
+   search. Nil when git reports nothing."
+  [worktree token path]
+  (when-let [out (git worktree "grep" "-n" "-I" "-F" "-e" token "--" path)]
+    (when-let [line (first (remove str/blank? (str/split-lines out)))]
+      ;; git grep -n prints path:lineno:text; the path may itself
+      ;; contain ":" only on exotic filesystems, so split from the
+      ;; known prefix rather than on the first two colons.
+      (let [rest (subs line (min (count line) (inc (count path))))
+            [lineno text] (str/split rest #":" 2)]
+        {:file path
+         :line (some-> lineno str/trim parse-long)
+         :text (str/trim (str text))}))))
 
 ;------------------------------------------------------------------------------ Layer 2
 
@@ -199,14 +236,16 @@
 
 (defn ^{:stratum 2} producer-families
   "The changed non-test files that declare a namespace, grouped by
-   namespace family: {family [before-content ...]}. `before-of` maps a
-   path to its pre-change content. Public for tests."
+   namespace family: {family {:befores [content ...] :paths [path ...]}}.
+   `before-of` maps a path to its pre-change content. Public for tests."
   [paths before-of]
   (reduce (fn [acc path]
             (let [before (get before-of path)
                   ns-name (ns-name-of before)]
               (if (and ns-name (not (test-path? path)))
-                (update acc (namespace-family ns-name) (fnil conj []) before)
+                (-> acc
+                    (update-in [(namespace-family ns-name) :befores] (fnil conj []) before)
+                    (update-in [(namespace-family ns-name) :paths] (fnil conj []) path))
                 acc)))
           {}
           paths))
@@ -247,25 +286,35 @@
                          paths))
         non-test-afters (keep (fn [[path a]] (when-not (test-path? path) a)) after-of)
         stale (into []
-                    (for [[family befores] (producer-families paths before-of)
+                    (for [[family {:keys [befores] producer-paths :paths}] (producer-families paths before-of)
                           ;; A family nobody names any more (renamed out of
                           ;; the worktree) has NO consumers -- an empty set,
                           ;; so its bare tokens match nothing.
-                          :let [consumers (delay (set (referencing-files worktree paths family)))]
+                          :let [own-component (some component-dir producer-paths)
+                                consumers (delay (into #{}
+                                                       (comp (mapcat #(referencing-files worktree paths %))
+                                                             (remove test-path?)
+                                                             (remove #(and own-component
+                                                                           (str/starts-with? % own-component))))
+                                                       (import-needles family)))]
                           token (removed-tokens befores non-test-afters)
                           :let [in-scope? (if (namespaced-keyword? token) any? @consumers)
-                                hits (->> (referencing-files worktree paths token)
-                                          (filter in-scope?)
-                                          (take max-files-per-token)
-                                          vec)]
-                          :when (seq hits)]
+                                files (->> (referencing-files worktree paths token)
+                                           (filter in-scope?)
+                                           (take max-files-per-token)
+                                           vec)
+                                hits (into [] (keep #(first-hit worktree token %)) files)]
+                          :when (seq files)]
                       {:type :stale-reference
                        :token token
                        :family family
-                       :files hits
-                       :message (messages/t :stale-references/stale
-                                            {:token token
-                                             :files (str/join ", " hits)})}))]
+                       :files files
+                       :hits hits
+                       :message (str (messages/t :stale-references/stale
+                                                 {:token token
+                                                  :files (str/join ", " files)})
+                                     (str/join "" (map #(str "\n" (messages/t :stale-references/hit %))
+                                                       hits)))}))]
     (cond
       (empty? paths)
       {:passed? true}

--- a/components/gate/test/ai/miniforge/gate/stale_references_scope_test.clj
+++ b/components/gate/test/ai/miniforge/gate/stale_references_scope_test.clj
@@ -22,7 +22,8 @@
    in another sense, the bb.edn consumer requiring the interface and
    still reading the old key, and an unrelated file using the same bare
    keyword with no import of the family."
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
             [ai.miniforge.gate.stale-references :as stale]
             [ai.miniforge.gate.stale-references-test :as base]))
 
@@ -55,7 +56,14 @@
                    "bb.edn" "{:tasks {}}"}
         families (stale/producer-families (keys before-of) before-of)]
     (is (= ["ai.m.c"] (keys families)))
-    (is (= 2 (count (get families "ai.m.c"))))))
+    (is (= 2 (count (get-in families ["ai.m.c" :befores]))))
+    (is (= ["components/c/src/ai/m/c/ledger.clj" "components/c/src/ai/m/c/report.clj"]
+           (get-in families ["ai.m.c" :paths])))))
+
+(deftest ^{:stratum 0} component-dir-of-paths
+  (is (= "components/codex-gap/" (stale/component-dir "components/codex-gap/src/ai/miniforge/codex_gap/ledger.clj")))
+  (is (= "bases/cli/" (stale/component-dir "bases/cli/src/x.clj")))
+  (is (nil? (stale/component-dir "bb.edn"))))
 
 (deftest ^{:stratum 0} rs1-shape-flags-only-the-importing-consumer
   (testing "a changed test keeping :skipped in another sense does not
@@ -80,7 +88,50 @@
                   {:execution/worktree-path dir})]
       (is (false? (:passed? result)))
       (is (= [{:token ":skipped" :family "ai.miniforge.codex-gap" :files [consumer]}]
-             (mapv #(select-keys % [:token :family :files]) (:errors result)))))))
+             (mapv #(select-keys % [:token :family :files]) (:errors result))))
+      (testing "the message carries the consumer's first matching line"
+        (let [{:keys [hits message]} (first (:errors result))]
+          (is (= [{:file consumer :line 2 :text ":task (:skipped (codex-gap/read-ledger d))}}}"}] hits))
+          (is (str/includes? message (str "  - " consumer ":2: :task (:skipped"))))))))
+
+(deftest ^{:stratum 0} same-component-siblings-and-tests-are-not-importers
+  (testing "rt3: a sibling in the producer's component using the keyword in
+            another sense, and a test fixture quoting the require form,
+            kept denying after the real consumer was fixed"
+    (let [producer "components/c/src/ai/m/c/ledger.clj"
+          sibling "components/c/src/ai/m/c/classify.clj"
+          fixture "components/gate/test/ai/m/gate/scope_test.clj"
+          consumer "components/other/src/ai/m/other/report.clj"
+          dir (base/temp-git-repo
+               {producer "(ns ai.m.c.ledger)\n(defn read [] {:skipped 0})"
+                sibling "(ns ai.m.c.classify (:require [ai.m.c.ledger]))\n(def r {:status :skipped})"
+                fixture "(ns ai.m.gate.scope-test)\n(def s \"[ai.m.c.interface :as c] :skipped\")"
+                consumer "(ns ai.m.other.report (:require [ai.m.c.ledger :as l]))\n(:skipped (l/read))"})
+          new-producer "(ns ai.m.c.ledger)\n(defn read [] {:torn-lines 0})"
+          _ (spit (str dir "/" producer) new-producer)
+          result (stale/check-stale-references
+                  {:code/files [{:path producer :content new-producer :action :modify}]}
+                  {:execution/worktree-path dir})]
+      (is (false? (:passed? result)))
+      (is (= [[consumer]] (mapv :files (:errors result)))))))
+
+(deftest ^{:stratum 0} prose-mention-of-the-family-is-not-an-import
+  (testing "rt1: a docstring naming the namespace and a fixture quoting it
+            were listed next to the real consumer; only require forms count"
+    (let [producer "src/ai/m/c/ledger.clj"
+          prose "src/ai/other/gate.clj"
+          quoted "src/ai/other/loader.clj"
+          dir (base/temp-git-repo
+               {producer "(ns ai.m.c.ledger)\n(defn read [] {:skipped 0})"
+                prose "(ns ai.other.gate\n  \"Enforces ai.m.c contracts\")\n(def r {:status :skipped})"
+                quoted "(ns ai.other.loader)\n(require 'ai.m.c.ledger)\n(get (read) :skipped)"})
+          new-producer "(ns ai.m.c.ledger)\n(defn read [] {:torn-lines 0})"
+          _ (spit (str dir "/" producer) new-producer)
+          result (stale/check-stale-references
+                  {:code/files [{:path producer :content new-producer :action :modify}]}
+                  {:execution/worktree-path dir})]
+      (is (false? (:passed? result)))
+      (is (= [[quoted]] (mapv :files (:errors result)))))))
 
 (deftest ^{:stratum 0} namespaced-keyword-is-searched-repo-wide
   (let [producer "src/ai/m/c/ledger.clj"

--- a/components/gate/test/ai/miniforge/gate/stale_references_scope_test.clj
+++ b/components/gate/test/ai/miniforge/gate/stale_references_scope_test.clj
@@ -57,8 +57,8 @@
         families (stale/producer-families (keys before-of) before-of)]
     (is (= ["ai.m.c"] (keys families)))
     (is (= 2 (count (get-in families ["ai.m.c" :befores]))))
-    (is (= ["components/c/src/ai/m/c/ledger.clj" "components/c/src/ai/m/c/report.clj"]
-           (get-in families ["ai.m.c" :paths])))))
+    (is (= #{"components/c/src/ai/m/c/ledger.clj" "components/c/src/ai/m/c/report.clj"}
+           (set (get-in families ["ai.m.c" :paths]))))))
 
 (deftest ^{:stratum 0} component-dir-of-paths
   (is (= "components/codex-gap/" (stale/component-dir "components/codex-gap/src/ai/miniforge/codex_gap/ledger.clj")))

--- a/components/gate/test/ai/miniforge/gate/stale_references_test.clj
+++ b/components/gate/test/ai/miniforge/gate/stale_references_test.clj
@@ -37,6 +37,9 @@
     (shell/sh "git" "-C" dir "init" "-q")
     (shell/sh "git" "-C" dir "config" "user.email" "test@test")
     (shell/sh "git" "-C" dir "config" "user.name" "test")
+    ;; A signing agent that is locked or absent fails the fixture commit,
+    ;; and the gate then reads an empty HEAD and passes vacuously.
+    (shell/sh "git" "-C" dir "config" "commit.gpgsign" "false")
     (doseq [[path content] files]
       (let [f (java.io.File. dir path)]
         (.mkdirs (.getParentFile f))


### PR DESCRIPTION
## Summary

Trap-bench series 4 (pin 25f017442): 0/3, but this time the `:stale-references` gate denied on the first implement of every rep and the retry prompt carried the denial (`:implementer/prompt-sections` shows `[:task/gate-failures]`). The denial named bb.edn first and five more files, four spurious: a same-component enum use of `:skipped` (classify.clj), the gate's own docstring and scope-test fixture naming the namespace, and a wiring test. rt1/rt2 fixed the test file and declared it the root cause; rt3 fixed bb.edn (entries 3–4 no longer list it) and was still denied on the spurious files until the retry budget ran out, so the fix never persisted.

## Change

- Importers = files that require the family (`[family` or `'family`), not files that mention it in prose.
- Test files and the producer's own component are never importers: verify's tests exercise them, and this gate exists for the consumer no test covers.
- Each stale file's first matching line is attached (`:hits`) and rendered in the message, so the implementer sees `bb.edn:596: :task (:skipped (codex-gap/read-ledger d))` next to the path.
- `producer-families` now returns `{family {:befores [...] :paths [...]}}`.
- Gate test fixtures set `commit.gpgsign false`: a locked signing agent made the fixture commit fail and the gate pass vacuously (found while writing these tests).

Tests: rs1 shape now asserts the hit line; new cases for prose mentions, same-component siblings and test fixtures, and the renamed-family case from #1864 still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)