### PR TITLE
fix(gate): stale-references judges removal per producer file and names where a token survives

### DIFF
--- a/components/gate/resources/config/gate/messages/en-US.edn
+++ b/components/gate/resources/config/gate/messages/en-US.edn
@@ -11,6 +11,10 @@
   :stale-references/stale
   "'{token}' was removed by this change but is still referenced by: {files}"
 
+  ;; Stale-references gate — the token still appears in another changed file
+  :stale-references/survives
+  "(it still appears in {files} — a same-name key in another sense, or a reference to update)"
+
   ;; Stale-references gate — one matching line per stale file
   :stale-references/hit
   "  - {file}:{line}: {text}"

--- a/components/gate/src/ai/miniforge/gate/stale_references.clj
+++ b/components/gate/src/ai/miniforge/gate/stale_references.clj
@@ -34,9 +34,15 @@
    work, so HEAD is the pre-change state). Producers are the changed
    non-test files that declare a namespace, grouped by namespace family
    (`ai.miniforge.codex-gap` for `...codex-gap.ledger`). A family's
-   candidate tokens are keywords and def'd names present in one of its
-   producers' befores and absent from EVERY changed non-test file's
-   after-content. Each candidate is then searched in the family's
+   candidate tokens are keywords and def'd names present in a
+   producer's before and absent from THAT producer's after -- judged
+   per file. A token that survives in another changed file of the
+   family is still a candidate (trap-bench rep ru3d: report.clj kept
+   `:skipped` as a message-template key while ledger.clj renamed its
+   result key, and a family-wide rule read that as a move and passed
+   the sprung tree); the error names where it survives so the
+   implementer can tell a same-name key from a reference to update.
+   Each candidate is then searched in the family's
    importers -- files outside the changed set that require the family:
    the family name opened by a require vector's bracket or preceded by
    a quote, as a ns :require, a bb.edn :requires, or a quoted require
@@ -238,8 +244,9 @@
 
 (defn ^{:stratum 2} producer-families
   "The changed non-test files that declare a namespace, grouped by
-   namespace family: {family {:befores [content ...] :paths [path ...]}}.
-   `before-of` maps a path to its pre-change content. Public for tests."
+   namespace family: {family {:befores [content ...] :paths [path ...]}},
+   befores and paths in the same order. `before-of` maps a path to its
+   pre-change content. Public for tests."
   [paths before-of]
   (reduce (fn [acc path]
             (let [before (get before-of path)
@@ -254,7 +261,25 @@
 
 ;------------------------------------------------------------------------------ Layer 3
 
-(defn ^{:stratum 3} check-stale-references
+(defn ^{:stratum 3} removed-per-file
+  "Tokens removed from any single producer: present in a file's before
+   and absent from that same file's after. `after-of` maps path to
+   after-content; a producer with no readable after contributes nothing.
+   Longest first, deduplicated. Public for tests."
+  [befores paths after-of]
+  (->> (map (fn [before path]
+              (when-let [after (get after-of path)]
+                (removed-tokens [before] [after])))
+            befores paths)
+       (apply concat)
+       distinct
+       (sort-by (comp - count))
+       (take max-tokens)
+       vec))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} check-stale-references
   "Gate check (see ns docstring). `artifact` is the implement phase
    output; changed files ride on :code/files ({:path :content :action})
    with :code/file-paths as the path fallback.
@@ -286,7 +311,6 @@
                                                           (catch Exception _ nil)))]
                                       [path a])))
                          paths))
-        non-test-afters (keep (fn [[path a]] (when-not (test-path? path) a)) after-of)
         stale (into []
                     (for [[family {:keys [befores] producer-paths :paths}] (producer-families paths before-of)
                           ;; A family nobody names any more (renamed out of
@@ -299,7 +323,7 @@
                                                              (remove #(and own-component
                                                                            (str/starts-with? % own-component))))
                                                        (import-needles family)))]
-                          token (removed-tokens befores non-test-afters)
+                          token (removed-per-file befores producer-paths after-of)
                           :let [in-scope? (if (namespaced-keyword? token)
                                             (constantly true)
                                             @consumers)
@@ -307,16 +331,26 @@
                                            (filter in-scope?)
                                            (take max-files-per-token)
                                            vec)
-                                hits (into [] (keep #(first-hit worktree token %)) files)]
+                                hits (into [] (keep #(first-hit worktree token %)) files)
+                                survives-in (into []
+                                                  (keep (fn [[path a]]
+                                                          (when (and (not (test-path? path))
+                                                                     (token-present? a token))
+                                                            path)))
+                                                  after-of)]
                           :when (seq files)]
                       {:type :stale-reference
                        :token token
                        :family family
                        :files files
                        :hits hits
+                       :survives-in survives-in
                        :message (str (messages/t :stale-references/stale
                                                  {:token token
                                                   :files (str/join ", " files)})
+                                     (when (seq survives-in)
+                                       (str " " (messages/t :stale-references/survives
+                                                            {:files (str/join ", " survives-in)})))
                                      (str/join "" (map #(str "\n" (messages/t :stale-references/hit %))
                                                        hits)))}))]
     (cond
@@ -344,9 +378,9 @@
       :else
       {:passed? true})))
 
-;------------------------------------------------------------------------------ Layer 4
+;------------------------------------------------------------------------------ Layer 5
 
-(defmethod ^{:stratum 4} registry/get-gate :stale-references
+(defmethod ^{:stratum 5} registry/get-gate :stale-references
   [_]
   {:name :stale-references
    :description (messages/t :stale-references/description)

--- a/components/gate/src/ai/miniforge/gate/stale_references.clj
+++ b/components/gate/src/ai/miniforge/gate/stale_references.clj
@@ -264,12 +264,12 @@
 (defn ^{:stratum 3} removed-per-file
   "Tokens removed from any single producer: present in a file's before
    and absent from that same file's after. `after-of` maps path to
-   after-content; a producer with no readable after contributes nothing.
-   Longest first, deduplicated. Public for tests."
+   after-content; a producer with no after-content -- deleted, or
+   unreadable -- has lost every token it had. Longest first,
+   deduplicated. Public for tests."
   [befores paths after-of]
   (->> (map (fn [before path]
-              (when-let [after (get after-of path)]
-                (removed-tokens [before] [after])))
+              (removed-tokens [before] [(get after-of path "")]))
             befores paths)
        (apply concat)
        distinct
@@ -332,12 +332,13 @@
                                            (take max-files-per-token)
                                            vec)
                                 hits (into [] (keep #(first-hit worktree token %)) files)
-                                survives-in (into []
-                                                  (keep (fn [[path a]]
-                                                          (when (and (not (test-path? path))
-                                                                     (token-present? a token))
-                                                            path)))
-                                                  after-of)]
+                                survives-in (->> after-of
+                                                 (keep (fn [[path a]]
+                                                         (when (and (not (test-path? path))
+                                                                    (token-present? a token))
+                                                           path)))
+                                                 sort
+                                                 vec)]
                           :when (seq files)]
                       {:type :stale-reference
                        :token token

--- a/components/gate/src/ai/miniforge/gate/stale_references.clj
+++ b/components/gate/src/ai/miniforge/gate/stale_references.clj
@@ -338,6 +338,7 @@
                                                                     (token-present? a token))
                                                            path)))
                                                  sort
+                                                 (take max-files-per-token)
                                                  vec)]
                           :when (seq files)]
                       {:type :stale-reference

--- a/components/gate/src/ai/miniforge/gate/stale_references.clj
+++ b/components/gate/src/ai/miniforge/gate/stale_references.clj
@@ -36,8 +36,8 @@
    (`ai.miniforge.codex-gap` for `...codex-gap.ledger`). A family's
    candidate tokens are keywords and def'd names present in a
    producer's before and absent from THAT producer's after -- judged
-   per file. A token that survives in another changed file of the
-   family is still a candidate (trap-bench rep ru3d: report.clj kept
+   per file. A token that survives in another changed non-test file
+   (of any family) is still a candidate (trap-bench rep ru3d: report.clj kept
    `:skipped` as a message-template key while ledger.clj renamed its
    result key, and a family-wide rule read that as a move and passed
    the sprung tree); the error names where it survives so the

--- a/components/gate/test/ai/miniforge/gate/stale_references_scope_test.clj
+++ b/components/gate/test/ai/miniforge/gate/stale_references_scope_test.clj
@@ -209,3 +209,8 @@
                                  ["a.clj" "b.clj"]
                                  {"a.clj" "{:torn-lines 0}" "b.clj" "{:x 1 :skipped 2}"}))
       "removed from a.clj even though b.clj still has it"))
+
+(deftest ^{:stratum 0} deleted-producer-loses-every-token
+  (is (= [":skipped"]
+         (stale/removed-per-file ["{:skipped 0}"] ["gone.clj"] {}))
+      "no after-content means every token of the before is removed"))

--- a/components/gate/test/ai/miniforge/gate/stale_references_scope_test.clj
+++ b/components/gate/test/ai/miniforge/gate/stale_references_scope_test.clj
@@ -176,3 +176,36 @@
                   {:code/files [{:path producer :content new-producer :action :modify}]}
                   {:execution/worktree-path dir})]
       (is (true? (:passed? result))))))
+
+(deftest ^{:stratum 0} key-kept-in-a-sibling-in-another-sense-still-flags-the-consumer
+  (testing "ru3d: report.clj kept :skipped as a message-template key while
+            ledger.clj renamed its result key; the consumer is still stale
+            and the error says where the token survives"
+    (let [ledger "components/c/src/ai/m/c/ledger.clj"
+          report "components/c/src/ai/m/c/report.clj"
+          consumer "bb.edn"
+          dir (base/temp-git-repo
+               {ledger "(ns ai.m.c.ledger)\n(defn read-ledger [] {:entries [] :skipped 0})"
+                report "(ns ai.m.c.report (:require [ai.m.c.ledger :as l]))\n(defn header [] (t :h {:skipped (:skipped (l/read-ledger))}))"
+                consumer "{:tasks {r {:requires ([ai.m.c.interface :as c]) :task (:skipped (c/read-ledger d))}}}"})
+          new-ledger "(ns ai.m.c.ledger)\n(defn read-ledger [] {:entries [] :torn-lines 0})"
+          new-report "(ns ai.m.c.report (:require [ai.m.c.ledger :as l]))\n(defn header [] (t :h {:skipped (:torn-lines (l/read-ledger))}))"
+          _ (spit (str dir "/" ledger) new-ledger)
+          _ (spit (str dir "/" report) new-report)
+          result (stale/check-stale-references
+                  {:code/files [{:path ledger :content new-ledger :action :modify}
+                                {:path report :content new-report :action :modify}]}
+                  {:execution/worktree-path dir})
+          err (first (:errors result))]
+      (is (false? (:passed? result)))
+      (is (= ":skipped" (:token err)))
+      (is (= [consumer] (:files err)))
+      (is (= [report] (:survives-in err)))
+      (is (str/includes? (:message err) "still appears in")))))
+
+(deftest ^{:stratum 0} removed-per-file-judges-each-producer-alone
+  (is (= [":skipped"]
+         (stale/removed-per-file ["{:skipped 0}" "{:x 1 :skipped 2}"]
+                                 ["a.clj" "b.clj"]
+                                 {"a.clj" "{:torn-lines 0}" "b.clj" "{:x 1 :skipped 2}"}))
+      "removed from a.clj even though b.clj still has it"))


### PR DESCRIPTION
## Summary

Trap-bench series 5, rep ru3d (pin c4e52062b, first run with the real denial text available): the implementer renamed the ledger's `:skipped` but kept `:skipped` in report.clj as a message-template key. The gate's family-wide removal rule ("absent from every changed non-test file") read that as a move and passed the sprung tree; bb.edn was never touched and verify looped on policy rules.

## Change

- Removal is judged per producer file: present in that file's before, absent from that file's after (`removed-per-file`).
- A token that still appears in another changed non-test file is reported with `:survives-in` and a message suffix ("it still appears in report.clj — a same-name key in another sense, or a reference to update"), so the implementer can decide with the hit line in hand.
- New catalog key `:stale-references/survives`.

Tests: the ru3d shape end to end (ledger renamed, report keeps the key as a template param, bb.edn consumer → deny naming bb.edn with `:survives-in [report.clj]`), plus the per-file unit case. Existing tests unchanged.

Series 6 of the trap bench runs at this merge instead of #1872's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)