### PR TITLE
fix(bb): every task path list that has a brick's src also has its resources

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -596,7 +596,6 @@
                  "components/codex/src"
                  "components/codex/resources"
                  "components/messages/src"
-                 "components/messages/resources"
                  "components/messages/resources"]
    :requires ([ai.miniforge.codex-gap.interface :as codex-gap]
               [babashka.fs :as fs]
@@ -636,9 +635,7 @@
                  "components/codex-gap/resources"
                  "components/codex/src"
                  "components/codex/resources"
-                 "components/codex-gap/src"
                  "components/messages/src"
-                 "components/messages/resources"
                  "components/messages/resources"]
    :requires ([ai.miniforge.codex-gap.interface :as codex-gap]
               [babashka.fs :as fs])
@@ -667,7 +664,6 @@
                  "components/codex-gap/src"
                  "components/codex-gap/resources"
                  "components/messages/src"
-                 "components/messages/resources"
                  "components/messages/resources"]
    :extra-deps {cheshire/cheshire {:mvn/version "5.13.0"}}
    :requires ([ai.miniforge.mcp-context-server.main :as mcp])
@@ -687,7 +683,6 @@
                  "components/messages/src"
                  "components/messages/resources"
                  "components/config/src"
-                 "components/config/resources"
                  "components/config/resources"]
    ;; response → anomaly requires slingshot; config → governance requires
    ;; aero (both caught by check:bb-classpaths)
@@ -706,7 +701,6 @@
                  "components/messages/src"
                  "components/messages/resources"
                  "components/config/src"
-                 "components/config/resources"
                  "components/config/resources"]
    ;; response → anomaly requires slingshot (caught by check:bb-classpaths)
    :extra-deps {slingshot/slingshot {:mvn/version "0.12.2"}}
@@ -723,7 +717,6 @@
                  "components/messages/src"
                  "components/messages/resources"
                  "components/config/src"
-                 "components/config/resources"
                  "components/config/resources"]
    ;; response → anomaly requires slingshot (caught by check:bb-classpaths)
    :extra-deps {slingshot/slingshot {:mvn/version "0.12.2"}}
@@ -740,7 +733,6 @@
                  "components/messages/src"
                  "components/messages/resources"
                  "components/config/src"
-                 "components/config/resources"
                  "components/config/resources"]
    ;; response → anomaly requires slingshot (caught by check:bb-classpaths)
    :extra-deps {slingshot/slingshot {:mvn/version "0.12.2"}}
@@ -980,7 +972,6 @@
                  "components/workflow-financial-etl/src"
                  "components/workflow-financial-etl/resources"
                  "components/workflow-security-compliance/src"
-                 "components/workflow-security-compliance/resources"
                  "components/workflow-security-compliance/resources"]
    :extra-deps {metosin/malli {:mvn/version "0.16.1"}
                 clj-statecharts/clj-statecharts {:mvn/version "0.1.5"}

--- a/bb.edn
+++ b/bb.edn
@@ -521,8 +521,11 @@
   extract:artifact
   {:doc "Extract files from a code artifact EDN file and write them to disk"
    :extra-paths ["components/evidence-bundle/src"
+                 "components/evidence-bundle/resources"
                  "components/response/src"
-                 "components/messages/src"]
+                 "components/response/resources"
+                 "components/messages/src"
+                 "components/messages/resources"]
    :extra-deps {slingshot/slingshot {:mvn/version "0.12.2"}}
    :requires ([ai.miniforge.evidence-bundle.extraction-bulk :as extraction-bulk])
    :task (if-let [artifact-file (first *command-line-args*)]
@@ -593,6 +596,7 @@
                  "components/codex/src"
                  "components/codex/resources"
                  "components/messages/src"
+                 "components/messages/resources"
                  "components/messages/resources"]
    :requires ([ai.miniforge.codex-gap.interface :as codex-gap]
               [babashka.fs :as fs]
@@ -635,6 +639,7 @@
                  "components/codex-gap/src"
                  "components/codex-gap/resources"
                  "components/messages/src"
+                 "components/messages/resources"
                  "components/messages/resources"]
    :requires ([ai.miniforge.codex-gap.interface :as codex-gap]
               [babashka.fs :as fs])
@@ -663,6 +668,7 @@
                  "components/codex-gap/src"
                  "components/codex-gap/resources"
                  "components/messages/src"
+                 "components/messages/resources"
                  "components/messages/resources"]
    :extra-deps {cheshire/cheshire {:mvn/version "5.13.0"}}
    :requires ([ai.miniforge.mcp-context-server.main :as mcp])
@@ -678,9 +684,11 @@
                  "bases/lsp-mcp-bridge/resources"
                  "components/tool-registry/resources"
                  "components/response/src"
+                 "components/response/resources"
                  "components/messages/src"
                  "components/messages/resources"
                  "components/config/src"
+                 "components/config/resources"
                  "components/config/resources"]
    ;; response → anomaly requires slingshot; config → governance requires
    ;; aero (both caught by check:bb-classpaths)
@@ -695,9 +703,11 @@
                  "bases/lsp-mcp-bridge/resources"
                  "components/tool-registry/resources"
                  "components/response/src"
+                 "components/response/resources"
                  "components/messages/src"
                  "components/messages/resources"
                  "components/config/src"
+                 "components/config/resources"
                  "components/config/resources"]
    ;; response → anomaly requires slingshot (caught by check:bb-classpaths)
    :extra-deps {slingshot/slingshot {:mvn/version "0.12.2"}}
@@ -710,9 +720,11 @@
                  "bases/lsp-mcp-bridge/resources"
                  "components/tool-registry/resources"
                  "components/response/src"
+                 "components/response/resources"
                  "components/messages/src"
                  "components/messages/resources"
                  "components/config/src"
+                 "components/config/resources"
                  "components/config/resources"]
    ;; response → anomaly requires slingshot (caught by check:bb-classpaths)
    :extra-deps {slingshot/slingshot {:mvn/version "0.12.2"}}
@@ -725,9 +737,11 @@
                  "bases/lsp-mcp-bridge/resources"
                  "components/tool-registry/resources"
                  "components/response/src"
+                 "components/response/resources"
                  "components/messages/src"
                  "components/messages/resources"
                  "components/config/src"
+                 "components/config/resources"
                  "components/config/resources"]
    ;; response → anomaly requires slingshot (caught by check:bb-classpaths)
    :extra-deps {slingshot/slingshot {:mvn/version "0.12.2"}}
@@ -774,10 +788,12 @@
                  "components/heuristic/src"
                  "components/heuristic/resources"
                  "components/response/src"
+                 "components/response/resources"
                  "components/fsm/src"
                  "components/phase/src"
                  "components/phase/resources"
                  "components/gate/src"
+                 "components/gate/resources"
                  "components/workflow/src"
                  "components/workflow/resources"
                  "components/spec-parser/src"
@@ -788,10 +804,13 @@
                  "components/event-stream/src"
                  "components/event-stream/resources"
                  "components/supervisory-state/src"
+                 "components/supervisory-state/resources"
                  "components/policy-clause/src"
                  "components/decision-envelope/src"
                  "components/effect-transaction/src"
+                 "components/effect-transaction/resources"
                  "components/execution-grant/src"
+                 "components/execution-grant/resources"
                  "components/automation-edge-correlator/src"
                  "components/workflow-resume/src"
                  "components/workflow-resume/resources"
@@ -799,6 +818,7 @@
                  "components/dag-executor/src"
                  "components/dag-executor/resources"
                  "components/task-executor/src"
+                 "components/task-executor/resources"
                  "components/pr-lifecycle/src"
                 "components/pr-lifecycle/resources"
                  "components/release-executor/src"
@@ -884,18 +904,23 @@
                  "components/evaluation/resources"
                  ;; Keep the Babashka CLI task aligned with deps.edn :dev.
                  "bases/etl/src"
+                 "bases/etl/resources"
                  "components/workbench-etl-adapter/src"
                  "components/workbench-etl-adapter/resources"
                  "components/bb-config/src"
+                 "components/bb-config/resources"
                  "components/bb-data-plane-http/src"
+                 "components/bb-data-plane-http/resources"
                  "components/bb-dev-tools/src"
                  "components/bb-etl-runner/src"
                  "components/bb-generate-icon/src"
+                 "components/bb-generate-icon/resources"
                  "components/bb-out/src"
                  "components/bb-paths/src"
                  "components/bb-platform/src"
                  "components/bb-proc/src"
                  "components/bb-r2/src"
+                 "components/bb-r2/resources"
                  "components/bb-test-runner/src"
                  "components/boundary/src"
                  "components/coerce/src"
@@ -922,6 +947,7 @@
                  "components/connector-sarif/src"
                  "components/content-hash/src"
                  "components/cursor-store/src"
+                 "components/cursor-store/resources"
                  "components/data-quality/src"
                  "components/data-quality/resources"
                  "components/dataset/src"
@@ -929,6 +955,7 @@
                  "components/dataset-schema/src"
                  "components/dataset-schema/resources"
                  "components/gate-classification/src"
+                 "components/gate-classification/resources"
                  "components/messages/resources"
                  "components/metric-registry/src"
                  "components/metric-registry/resources"
@@ -944,6 +971,7 @@
                  "components/pipeline-runner/src"
                  "components/pipeline-runner/resources"
                  "components/pr-scoring/src"
+                 "components/pr-scoring/resources"
                  "components/response-chain/src"
                  "components/tui-engine/src"
                  "components/tui-engine/resources"
@@ -954,6 +982,7 @@
                  "components/workflow-financial-etl/src"
                  "components/workflow-financial-etl/resources"
                  "components/workflow-security-compliance/src"
+                 "components/workflow-security-compliance/resources"
                  "components/workflow-security-compliance/resources"]
    :extra-deps {metosin/malli {:mvn/version "0.16.1"}
                 clj-statecharts/clj-statecharts {:mvn/version "0.1.5"}

--- a/bb.edn
+++ b/bb.edn
@@ -637,7 +637,6 @@
                  "components/codex/src"
                  "components/codex/resources"
                  "components/codex-gap/src"
-                 "components/codex-gap/resources"
                  "components/messages/src"
                  "components/messages/resources"
                  "components/messages/resources"]
@@ -956,7 +955,6 @@
                  "components/dataset-schema/resources"
                  "components/gate-classification/src"
                  "components/gate-classification/resources"
-                 "components/messages/resources"
                  "components/metric-registry/src"
                  "components/metric-registry/resources"
                  "components/phase-deployment/src"

--- a/development/test/deps_resources_test.clj
+++ b/development/test/deps_resources_test.clj
@@ -41,6 +41,18 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
+(defn- ^{:stratum 1} resource-gaps
+  "Resources dirs that exist but are missing from a path vector in
+   `file` that lists the brick's src."
+  [file]
+  (let [form (edn/read-string {:default (fn [_ v] v)} (slurp file))]
+    (for [v (path-vectors form)
+          p v :when (brick-src? p)
+          :let [brick (str/replace p #"/src$" "")
+                res (str brick "/resources")]
+          :when (and (.isDirectory (io/file res)) (not (some #{res} v)))]
+      res)))
+
 (deftest ^{:stratum 1} listed-brick-src-brings-its-resources
   (let [deps (edn/read-string (slurp "deps.edn"))
         gaps (for [v (path-vectors deps)
@@ -52,3 +64,13 @@
     (is (empty? (vec gaps))
         (str "resources dirs that exist but are missing from a path list that has the brick's src: "
              (pr-str (vec gaps))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} bb-task-path-lists-bring-resources-too
+  ;; bb.edn tasks (`bb miniforge run` is how dogfood launches the
+  ;; workflow) carry their own :extra-paths lists; the trap bench read
+  ;; bare message keys from exactly this gap after deps.edn was fixed.
+  (is (empty? (vec (resource-gaps "bb.edn")))
+      (str "bb.edn path lists missing a listed brick's resources: "
+           (pr-str (vec (resource-gaps "bb.edn"))))))

--- a/development/test/deps_resources_test.clj
+++ b/development/test/deps_resources_test.clj
@@ -71,6 +71,6 @@
   ;; bb.edn tasks (`bb miniforge run` is how dogfood launches the
   ;; workflow) carry their own :extra-paths lists; the trap bench read
   ;; bare message keys from exactly this gap after deps.edn was fixed.
-  (is (empty? (vec (resource-gaps "bb.edn")))
-      (str "bb.edn path lists missing a listed brick's resources: "
-           (pr-str (vec (resource-gaps "bb.edn"))))))
+  (let [gaps (vec (resource-gaps "bb.edn"))]
+    (is (empty? gaps)
+        (str "bb.edn path lists missing a listed brick's resources: " (pr-str gaps)))))


### PR DESCRIPTION
## Summary

#1872 fixed deps.edn, but dogfood launches the workflow through `bb miniforge run`, whose `:extra-paths` list in bb.edn is a separate path list with the same gap: `components/gate/src` without `components/gate/resources`. Series 6 rep rv1 (pin ffb335599, which contains #1872) still rendered `:stale-references/stale`, `/hit` and `/description` as bare keys, plus `:policy/violation-summary` (supervisory-state) and `:decide/gate-failed` (gate system catalog). The new missing-key warning is what made this visible.

## Change

- bb.edn: 27 resources entries added next to listed brick `src` entries across the tasks' `:extra-paths` (17 bricks).
- `development/test/deps_resources_test.clj`: the invariant now also runs over bb.edn's path vectors (tagged readers tolerated).

Verified: `bb tasks` loads; the guard passes for both files. Commit unsigned: the local signing agent is refusing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)