### PR TITLE
fix(dag-executor): persist commits run with signing off

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.dag-executor.protocols.impl.worktree
   "Worktree executor implementation (fallback).
 
@@ -32,16 +31,17 @@
    [java.io File]
    [java.nio.file Files StandardCopyOption CopyOption]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Configuration
 ;; ============================================================================
-
-(def ^:dynamic *warn-fn*
+(def ^{:stratum 0} ^:dynamic *warn-fn*
   "Emit a warning message to stderr.
    Rebind via `binding` in tests to capture warnings without stderr noise."
   (fn [msg] (binding [*out* *err*] (println msg))))
 
-(defn- expand-home
+(defn- ^{:stratum 0} expand-home
   "Expand a leading `~/` in a path string to the user home directory.
    Pass-through for absolute paths and bare paths that do not start with `~/`."
   [path]
@@ -51,7 +51,186 @@
       (= "~" path)                 home
       :else                        path)))
 
-(defn default-base-path
+(def ^{:stratum 0} default-max-concurrent 4)
+
+(defn ^{:stratum 0} default-archive-dir
+  "Default location for persisted task work archives.
+   Lives under the user home rather than /tmp so checkpoints survive reboots
+   and can be referenced from evidence bundles long after the run ends."
+  []
+  (str (System/getProperty "user.home") "/.miniforge/checkpoints"))
+
+;; ============================================================================
+;; Legacy /tmp detection
+;; ============================================================================
+(def ^{:stratum 0} ^:private legacy-tmp-worktrees-path
+  "Legacy default worktree base directory that lived under /tmp.
+   Created before the 2026-04-17 gates-workflow data-loss incident forced the
+   move to `~/.miniforge/worktrees`. Checked at creation time to prompt
+   migration without blocking active workflows."
+  "/tmp/miniforge-worktrees")
+
+;; Non-private so tests can `(reset! worktree/legacy-tmp-warned? false)` before
+;; exercising the warning path. `compare-and-set!` in check-legacy-tmp-worktrees!
+;; ensures the advisory fires at most once per JVM session even under concurrent
+;; load — without this, all four default worktree slots could race to emit
+;; identical WARNING lines before any of them acquires worktree-lock.
+(defonce ^{:stratum 0} legacy-tmp-warned?
+  (atom false))
+
+;; ============================================================================
+;; Helper Functions
+;; ============================================================================
+(defn ^{:stratum 0} run-git
+  "Execute a git command and return the result."
+  [& args]
+  (try
+    (apply shell/sh "git" args)
+    (catch Exception e
+      {:exit 1 :err (.getMessage e) :out ""})))
+
+(defn ^{:stratum 0} run-shell
+  "Execute a shell command and return the result."
+  [& args]
+  (try
+    (apply shell/sh args)
+    (catch Exception e
+      {:exit 1 :err (.getMessage e) :out ""})))
+
+(defn ^{:stratum 0} ensure-directory
+  "Ensure a directory exists."
+  [path]
+  (.mkdirs (File. ^String path)))
+
+(defn- ^{:stratum 0} command-output
+  "Return command stdout when it is a string; otherwise return empty text."
+  [result]
+  (let [output (get result :out)]
+    (if (string? output) output "")))
+
+(def ^{:stratum 0} ^:private worktree-lock
+  "JVM-level lock for git worktree add commands.
+   Git uses a config.lock file internally — concurrent worktree adds from
+   multiple threads hit this lock and fail silently. Serializing creation at
+   the JVM level prevents the conflict. Tasks still run in parallel once their
+   worktrees are acquired.
+
+   `check-legacy-tmp-worktrees!` runs inside this lock so that at most one
+   thread emits the advisory warning at a time, avoiding duplicated log lines
+   in high-parallelism scenarios where all default concurrent slots start
+   simultaneously."
+  (Object.))
+
+;; ============================================================================
+;; Archive-based persistence (local-tier fidelity for :governed parity)
+;; ============================================================================
+(def ^{:stratum 0} ^:private default-commit-message
+  "Commit message for the per-phase persist commit when the caller did not
+   override `:message`. Internal infrastructure; not user-visible at
+   commit time."
+  "phase checkpoint")
+
+(def ^{:stratum 0} ^:private default-base-ref
+  "Final fallback base ref when neither :base-branch nor :base-ref was
+   passed by the caller. Used only by direct callers of `archive-bundle!`;
+   the runner threads the real base from environment metadata."
+  "main")
+
+(defn- ^{:stratum 0} ensure-archive-dir
+  "Create the archive directory if it does not exist. Returns the absolute path."
+  [archive-dir]
+  (let [d (File. ^String archive-dir)]
+    (.mkdirs d)
+    (.getAbsolutePath d)))
+
+;; Each git helper below does exactly one operation, returns a result/ok
+;; on exit 0 with the parsed output, or a result/err carrying the git
+;; stderr. Persist treats all errors as diagnosable failures rather than
+;; silent zeros — Copilot review on PR #729 caught the original "treat
+;; non-zero exit as no-changes" pattern as a silent-failure vector.
+(def ^{:stratum 0} ^:private detached-head-sentinel
+  "What `git rev-parse --abbrev-ref HEAD` prints in a detached worktree.
+   Treated as 'no branch' for archive purposes — `archive-bundle!` creates
+   a real branch before recording the bundle so the result always has a
+   `refs/heads/<name>` ref, never a bare HEAD."
+  "HEAD")
+
+(def ^{:stratum 0} ^:private detached-branch-prefix
+  "Prefix prepended to a `task-id` to derive the recovery branch name in
+   `ensure-named-branch!`. Skipped when the task-id already starts with
+   the prefix (the common path: persist-workspace! defaults task-id to
+   the environment-id, which is itself shaped like `task-<id>`)."
+  "task-")
+
+;; ============================================================================
+;; Worktree Lifecycle Registry
+;; ============================================================================
+(def ^{:stratum 0} ^:private worktree-lifecycle-registry
+  "Lightweight atom-based registry tracking worktrees created by the executor.
+
+   Structure: {workflow-id {:scratch-ref   str
+                             :worktree-path str
+                             :created-at    long  ; epoch ms
+                             :status        :active | :released
+                             :released-at   long  ; epoch ms, only present when :released}}
+
+   This is an in-memory atom that retains all entries (including :released)
+   for the lifetime of the process. It is NOT persisted and is NOT pruned by
+   `gc-scratch-refs!`. Git-ref cleanup happens independently via
+   `gc-scratch-refs!`, which neither reads nor mutates this registry. This
+   lets post-mortem tooling inspect which workflows wrote which scratch
+   commits even after the worktrees are gone."
+  (atom {}))
+
+;; ============================================================================
+;; Command Execution
+;; ============================================================================
+(defn ^{:stratum 0} execute-command
+  "Execute a command in a directory using ProcessBuilder.
+
+   Accepts either a string (passed to sh -c, suitable for shell builtins and
+   pipelines) or a vector of strings (exec'd directly without a shell —
+   preferred for user-supplied values to avoid shell injection).
+
+   This allows proper environment variable handling and working directory."
+  [workdir command env-map]
+  (let [cmd-args (if (string? command)
+                   ["sh" "-c" command]
+                   (vec command))
+        start-time (System/currentTimeMillis)]
+    (try
+      (let [pb (ProcessBuilder. ^java.util.List cmd-args)
+            _ (.directory pb (File. ^String workdir))
+            _ (when (seq env-map)
+                (let [pb-env (.environment pb)]
+                  (doseq [[k v] env-map]
+                    (.put pb-env (name k) (str v)))))
+            process (.start pb)
+            stdout (slurp (.getInputStream process))
+            stderr (slurp (.getErrorStream process))
+            exit-code (.waitFor process)]
+        (result/ok {:exit-code exit-code
+                    :stdout stdout
+                    :stderr stderr
+                    :duration-ms (- (System/currentTimeMillis) start-time)}))
+      (catch Exception e
+        (result/err :exec-failed (.getMessage e))))))
+
+;; ============================================================================
+;; File Operations
+;; ============================================================================
+(defn- ^{:stratum 0} path-inside-worktree?
+  "True when `file` (a canonicalized File) is the worktree root or is nested
+   inside it. Prevents path-traversal escape via `../` segments."
+  [^File worktree ^File file]
+  (let [root-path (str (.getPath worktree) File/separator)
+        file-path (.getPath file)]
+    (or (= file-path (.getPath worktree))
+        (str/starts-with? file-path root-path))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} default-base-path
   "Default location for git worktrees acquired by the worktree executor.
 
    Arity 0: returns the hardcoded default `~/.miniforge/worktrees`.
@@ -81,27 +260,7 @@
        (expand-home configured)
        (default-base-path)))))
 
-(def default-max-concurrent 4)
-
-(defn default-archive-dir
-  "Default location for persisted task work archives.
-   Lives under the user home rather than /tmp so checkpoints survive reboots
-   and can be referenced from evidence bundles long after the run ends."
-  []
-  (str (System/getProperty "user.home") "/.miniforge/checkpoints"))
-
-;; ============================================================================
-;; Legacy /tmp detection
-;; ============================================================================
-
-(def ^:private legacy-tmp-worktrees-path
-  "Legacy default worktree base directory that lived under /tmp.
-   Created before the 2026-04-17 gates-workflow data-loss incident forced the
-   move to `~/.miniforge/worktrees`. Checked at creation time to prompt
-   migration without blocking active workflows."
-  "/tmp/miniforge-worktrees")
-
-(defn legacy-tmp-worktrees-exist?
+(defn ^{:stratum 1} legacy-tmp-worktrees-exist?
   "Returns true if the legacy /tmp/miniforge-worktrees directory exists and
    contains at least one entry (indicating active or stale worktrees).
 
@@ -113,78 +272,10 @@
          (let [files (.listFiles dir)]
            (and (some? files) (pos? (alength files)))))))
 
-;; Non-private so tests can `(reset! worktree/legacy-tmp-warned? false)` before
-;; exercising the warning path. `compare-and-set!` in check-legacy-tmp-worktrees!
-;; ensures the advisory fires at most once per JVM session even under concurrent
-;; load — without this, all four default worktree slots could race to emit
-;; identical WARNING lines before any of them acquires worktree-lock.
-(defonce legacy-tmp-warned?
-  (atom false))
-
-(defn check-legacy-tmp-worktrees!
-  "Warn once per JVM session when the legacy /tmp/miniforge-worktrees directory
-   has entries.
-
-   Uses `compare-and-set!` on `legacy-tmp-warned?` so exactly one thread emits
-   the advisory, even when multiple worktree-create calls race at startup.
-
-   Does NOT error — graceful coexistence per the worktree-persistence spec
-   constraint. Existing /tmp worktrees remain usable; the warning tells
-   operators how to migrate to the persistent default path.
-
-   Rebind `*warn-fn*` via `binding` in tests to capture the output.
-   Reset `legacy-tmp-warned?` to false before tests that assert the warning fires."
-  []
-  (when (and (legacy-tmp-worktrees-exist?)
-             (compare-and-set! legacy-tmp-warned? false true))
-    (*warn-fn*
-     (str
-      "[miniforge] WARNING: legacy worktrees detected at "
-      legacy-tmp-worktrees-path "\n"
-      "  These worktrees live under /tmp and will not survive a reboot.\n"
-      "  To migrate to the persistent default:\n"
-      "    1. Add `:workflow/worktree-root \"~/.miniforge/worktrees\"` to\n"
-      "       ~/.miniforge/config.edn (this is already the shipped default).\n"
-      "    2. Let in-flight tasks complete, then remove the stale /tmp directory:\n"
-      "       rm -rf " legacy-tmp-worktrees-path "\n"
-      "  New worktrees are now created under: " (default-base-path)))))
-
-;; ============================================================================
-;; Helper Functions
-;; ============================================================================
-
-(defn run-git
-  "Execute a git command and return the result."
-  [& args]
-  (try
-    (apply shell/sh "git" args)
-    (catch Exception e
-      {:exit 1 :err (.getMessage e) :out ""})))
-
-(defn run-shell
-  "Execute a shell command and return the result."
-  [& args]
-  (try
-    (apply shell/sh args)
-    (catch Exception e
-      {:exit 1 :err (.getMessage e) :out ""})))
-
-(defn ensure-directory
-  "Ensure a directory exists."
-  [path]
-  (.mkdirs (File. ^String path)))
-
-(defn- command-output
-  "Return command stdout when it is a string; otherwise return empty text."
-  [result]
-  (let [output (get result :out)]
-    (if (string? output) output "")))
-
 ;; ============================================================================
 ;; Git Operations
 ;; ============================================================================
-
-(defn git-version
+(defn ^{:stratum 1} git-version
   "Get git version."
   []
   (let [result (run-git "--version")]
@@ -194,20 +285,7 @@
       {:available? false
        :reason "git not found"})))
 
-(def ^:private worktree-lock
-  "JVM-level lock for git worktree add commands.
-   Git uses a config.lock file internally — concurrent worktree adds from
-   multiple threads hit this lock and fail silently. Serializing creation at
-   the JVM level prevents the conflict. Tasks still run in parallel once their
-   worktrees are acquired.
-
-   `check-legacy-tmp-worktrees!` runs inside this lock so that at most one
-   thread emits the advisory warning at a time, avoiding duplicated log lines
-   in high-parallelism scenarios where all default concurrent slots start
-   simultaneously."
-  (Object.))
-
-(defn- resolve-branch-sha
+(defn- ^{:stratum 1} resolve-branch-sha
   "Resolve a branch name to its commit sha so `git worktree add -b new path
    <sha>` works even when <branch> is checked out in another worktree.
 
@@ -227,60 +305,7 @@
       (let [sha (str/trim (command-output r))]
         (when (seq sha) sha)))))
 
-(defn create-worktree
-  "Create a git worktree for the task.
-
-   Serializes creation through worktree-lock to prevent concurrent git
-   config.lock conflicts when multiple sub-workflows acquire environments
-   simultaneously. The legacy /tmp worktree check also runs inside the lock so
-   at most one thread emits the advisory warning at a time.
-
-   Attempts in order:
-   1. git worktree add -b <name> <path> <sha-or-ref>
-   2. Clean up stale branch/directory and retry step 1
-   3. git worktree add --detach <path> — detached HEAD (last resort)
-
-   Detached HEAD is a real fallback path here, but downstream `archive-bundle!`
-   handles it defensively by creating a real branch at HEAD before bundling.
-   This one-two punch keeps `git worktree add` failures from cascading into
-   broken bundles whose only ref is a bare HEAD."
-  [base-path repo-path worktree-name branch]
-  (locking worktree-lock
-    (check-legacy-tmp-worktrees!)
-    (let [worktree-path (str base-path "/" worktree-name)
-          base-sha      (resolve-branch-sha repo-path branch)
-          base-ref      (or base-sha branch)]
-      (ensure-directory base-path)
-      (let [result (run-git "-C" repo-path
-                            "worktree" "add" "-b" worktree-name
-                            worktree-path base-ref)]
-        (if (zero? (:exit result))
-          (result/ok {:worktree-path worktree-path
-                      :base-sha base-sha
-                      :base-ref branch})
-          ;; Failed — clean up stale branch/directory from a prior run and retry
-          (do
-            (run-shell "rm" "-rf" worktree-path)
-            (run-git "-C" repo-path "worktree" "prune")
-            (run-git "-C" repo-path "branch" "-D" worktree-name)
-            (let [result2 (run-git "-C" repo-path
-                                   "worktree" "add" "-b" worktree-name
-                                   worktree-path base-ref)]
-              (if (zero? (:exit result2))
-                (result/ok {:worktree-path worktree-path
-                            :base-sha base-sha
-                            :base-ref branch})
-                ;; Still failing — detached HEAD as last resort
-                (let [result3 (run-git "-C" repo-path
-                                       "worktree" "add" "--detach"
-                                       worktree-path)]
-                  (if (zero? (:exit result3))
-                    (result/ok {:worktree-path worktree-path
-                                :base-sha base-sha
-                                :base-ref branch})
-                    (result/err :worktree-create-failed (:err result3))))))))))))
-
-(defn remove-worktree
+(defn ^{:stratum 1} remove-worktree
   "Remove a git worktree."
   [worktree-path]
   ;; Try git worktree remove first
@@ -293,47 +318,11 @@
         (run-shell "rm" "-rf" worktree-path)
         (result/ok {:released? true})))))
 
-;; ============================================================================
-;; Archive-based persistence (local-tier fidelity for :governed parity)
-;; ============================================================================
-
-(def ^:private default-commit-message
-  "Commit message for the per-phase persist commit when the caller did not
-   override `:message`. Internal infrastructure; not user-visible at
-   commit time."
-  "phase checkpoint")
-
-(def ^:private default-base-ref
-  "Final fallback base ref when neither :base-branch nor :base-ref was
-   passed by the caller. Used only by direct callers of `archive-bundle!`;
-   the runner threads the real base from environment metadata."
-  "main")
-
-(defn- ensure-archive-dir
-  "Create the archive directory if it does not exist. Returns the absolute path."
-  [archive-dir]
-  (let [d (File. ^String archive-dir)]
-    (.mkdirs d)
-    (.getAbsolutePath d)))
-
-;; Each git helper below does exactly one operation, returns a result/ok
-;; on exit 0 with the parsed output, or a result/err carrying the git
-;; stderr. Persist treats all errors as diagnosable failures rather than
-;; silent zeros — Copilot review on PR #729 caught the original "treat
-;; non-zero exit as no-changes" pattern as a silent-failure vector.
-
-(def ^:private detached-head-sentinel
-  "What `git rev-parse --abbrev-ref HEAD` prints in a detached worktree.
-   Treated as 'no branch' for archive purposes — `archive-bundle!` creates
-   a real branch before recording the bundle so the result always has a
-   `refs/heads/<name>` ref, never a bare HEAD."
-  "HEAD")
-
-(defn- detached?
+(defn- ^{:stratum 1} detached?
   [branch-name]
   (= detached-head-sentinel branch-name))
 
-(defn- current-branch
+(defn- ^{:stratum 1} current-branch
   "Returns the worktree HEAD branch name, or the literal sentinel
    `\"HEAD\"` when the worktree is detached. Callers that need a real
    branch name should call `ensure-named-branch!` to materialize one."
@@ -343,14 +332,7 @@
       (result/ok (str/trim (get r :out "")))
       (result/err :archive-no-branch (get r :err "could not resolve HEAD")))))
 
-(def ^:private detached-branch-prefix
-  "Prefix prepended to a `task-id` to derive the recovery branch name in
-   `ensure-named-branch!`. Skipped when the task-id already starts with
-   the prefix (the common path: persist-workspace! defaults task-id to
-   the environment-id, which is itself shaped like `task-<id>`)."
-  "task-")
-
-(defn- recovery-branch-name
+(defn- ^{:stratum 1} recovery-branch-name
   "Branch name to materialize when recovering from a detached scratch.
    Avoids a `task-task-` double-prefix when task-id already carries it."
   [task-id]
@@ -359,29 +341,7 @@
       s
       (str detached-branch-prefix s))))
 
-(defn- ensure-named-branch!
-  "If the worktree is in detached-HEAD state, create a real branch at HEAD
-   so the bundle records `refs/heads/<name>` (not just bare HEAD).
-
-   Returns result/ok with the branch name to use for bundling. Pass-through
-   when the worktree is already on a named branch.
-
-   Uses `git checkout -B` (force-reset to HEAD) so recovery is idempotent
-   across reruns with the same task-id and across leftover local refs from
-   prior runs. The branch is task-namespaced internal infrastructure, not
-   a user-curated ref; resetting it is the right semantics."
-  [worktree-path branch task-id]
-  (if-not (detached? branch)
-    (result/ok branch)
-    (let [name (recovery-branch-name task-id)
-          r    (run-git "-C" worktree-path "checkout" "-B" name)]
-      (if (zero? (:exit r))
-        (result/ok name)
-        (result/err :archive-detach-recovery-failed
-                    (or (:err r)
-                        "could not create or reset branch from detached HEAD"))))))
-
-(defn- dirty?
+(defn- ^{:stratum 1} dirty?
   [worktree-path]
   (let [r (run-git "-C" worktree-path "status" "--porcelain")]
     (if (zero? (:exit r))
@@ -389,7 +349,7 @@
       (result/err :archive-status-failed
                   (get r :err "git status --porcelain failed")))))
 
-(defn- commits-ahead
+(defn- ^{:stratum 1} commits-ahead
   "Count commits on HEAD not reachable from base-ref."
   [worktree-path base-ref]
   (let [r (run-git "-C" worktree-path "rev-list" "--count"
@@ -403,27 +363,32 @@
       (result/err :archive-rev-list-failed
                   (get r :err "git rev-list --count failed")))))
 
-(defn- stage-all!
+(defn- ^{:stratum 1} stage-all!
   [worktree-path]
   (let [r (run-git "-C" worktree-path "add" "-A")]
     (if (zero? (:exit r))
       (result/ok :staged)
       (result/err :archive-stage-failed (get r :err "git add -A failed")))))
 
-(defn- commit-staged!
-  "Commit staged changes with --no-verify. Persist runs inside a scratch
-   worktree where the host pre-commit hook (bb pre-commit) fails because
-   deps are not installed. Persist is infrastructure preservation, not a
-   validated commit — the gate layer upstream owns validation."
+(defn- ^{:stratum 1} commit-staged!
+  "Commit staged changes with --no-verify and without a signature.
+   Persist runs inside a scratch worktree where the host pre-commit hook
+   (bb pre-commit) fails because deps are not installed, and where the
+   operator's global commit.gpgsign would route a machine commit through
+   their signing agent -- which, when locked or absent, fails the commit
+   (\"1Password: failed to fill whole buffer\") and silently strands the
+   task's work in the worktree (trap-bench series 4-6). Persist is
+   infrastructure preservation, not a validated or attributable commit;
+   the gate layer upstream owns validation."
   [worktree-path message]
-  (let [r (run-git "-C" worktree-path "commit"
+  (let [r (run-git "-C" worktree-path "-c" "commit.gpgsign=false" "commit"
                    "--no-verify" "--allow-empty-message" "-m" message)]
     (if (zero? (:exit r))
       (result/ok :committed)
       (result/err :archive-commit-failed
                   (get r :err "git commit --no-verify failed")))))
 
-(defn- head-sha
+(defn- ^{:stratum 1} head-sha
   [worktree-path]
   (let [r (run-git "-C" worktree-path "rev-parse" "HEAD")]
     (if (zero? (:exit r))
@@ -431,7 +396,7 @@
       (result/err :archive-rev-parse-failed
                   (get r :err "git rev-parse HEAD failed")))))
 
-(defn- write-bundle!
+(defn- ^{:stratum 1} write-bundle!
   "Run `git bundle create FILE BRANCH --not BASE`. The `BRANCH --not BASE`
    form records `refs/heads/BRANCH` in the bundle, which is what
    `git fetch <bundle> BRANCH:BRANCH` consumes when the harvest CLI pulls
@@ -444,99 +409,7 @@
       (result/err :archive-bundle-failed
                   (get r :err "git bundle create failed")))))
 
-(defn- maybe-commit
-  "Commit only when the worktree has dirty changes. `git add -A` already
-   ran — if no paths were staged (e.g. all changes were gitignored),
-   commit-staged! would fail with `nothing to commit`, which is not an
-   archive error."
-  [worktree-path message]
-  (-> (dirty? worktree-path)
-      (result/and-then
-       (fn [is-dirty]
-         (if is-dirty
-           (commit-staged! worktree-path message)
-           (result/ok :clean))))))
-
-(defn- bundle-result
-  "Final step of the persist pipeline once we know the worktree is ahead
-   of base-ref. Reads HEAD, writes the bundle, and packages the persist
-   result map."
-  [worktree-path branch base-ref archive-dir task-id ahead]
-  (let [bundle-path (str (ensure-archive-dir archive-dir) "/" task-id ".bundle")]
-    (-> (head-sha worktree-path)
-        (result/and-then
-         (fn [sha]
-           (-> (write-bundle! worktree-path bundle-path branch base-ref)
-               (result/map-ok
-                (fn [_]
-                  {:persisted?    true
-                   :bundle-path   bundle-path
-                   :commit-sha    sha
-                   :branch        branch
-                   :commits-ahead ahead}))))))))
-
-(defn- commit-and-bundle!
-  "Pipeline: stage -> commit-if-dirty -> recompute ahead -> bundle-or-noop."
-  [worktree-path branch base-ref archive-dir task-id message]
-  (-> (stage-all! worktree-path)
-      (result/and-then (fn [_] (maybe-commit worktree-path message)))
-      (result/and-then (fn [_] (commits-ahead worktree-path base-ref)))
-      (result/and-then
-       (fn [ahead]
-         (if (zero? ahead)
-           (result/ok {:persisted? false :no-changes? true :branch branch})
-           (bundle-result worktree-path branch base-ref archive-dir task-id ahead))))))
-
-(defn- already-clean?
-  "True when the worktree has no dirty paths AND no commits ahead of
-   base-ref — there is nothing to bundle. Returns a result so callers see
-   git failures rather than treating them as a clean state."
-  [worktree-path base-ref]
-  (-> (dirty? worktree-path)
-      (result/and-then
-       (fn [is-dirty]
-         (if is-dirty
-           (result/ok false)
-           (-> (commits-ahead worktree-path base-ref)
-               (result/map-ok zero?)))))))
-
-(defn archive-bundle!
-  "Persist a worktree task work as a git bundle.
-
-   Pipeline: resolve current branch -> check for dirty changes or commits
-   ahead of base-ref -> if clean, return no-changes; otherwise stage,
-   commit on the task branch with --no-verify, and write a bundle of
-   `base-ref..HEAD` to <archive-dir>/<task-id>.bundle.
-
-   Arguments:
-   - worktree-path: absolute path to the scratch worktree
-   - opts: {:archive-dir string  -- destination dir for bundles
-           :task-id      string  -- identifier used as the bundle filename
-           :base-ref     string  -- base branch the worktree was forked from
-           :message      string  -- commit message for the persist commit}
-
-   Returns result/ok with one of:
-   - {:persisted? true  :bundle-path str :commit-sha str :branch str}
-   - {:persisted? false :no-changes? true :branch str}
-   Returns result/err on any git failure (no silent fallbacks)."
-  [worktree-path {:keys [archive-dir task-id base-ref message]
-                  :or   {message  default-commit-message
-                         base-ref default-base-ref}}]
-  (-> (current-branch worktree-path)
-      (result/and-then
-       (fn [raw-branch]
-         (-> (ensure-named-branch! worktree-path raw-branch task-id)
-             (result/and-then
-              (fn [branch]
-                (-> (already-clean? worktree-path base-ref)
-                    (result/and-then
-                     (fn [clean?]
-                       (if clean?
-                         (result/ok {:persisted? false :no-changes? true :branch branch})
-                         (commit-and-bundle! worktree-path branch base-ref
-                                             archive-dir task-id message))))))))))))
-
-(defn restore-from-bundle!
+(defn ^{:stratum 1} restore-from-bundle!
   "Restore work from a previously-persisted bundle into the host repo.
 
    `git fetch <bundle> <branch>:<branch>` pulls the branch and all reachable
@@ -603,28 +476,7 @@
       (catch Exception e
         (result/err :archive-restore-failed (.getMessage e))))))
 
-;; ============================================================================
-;; Worktree Lifecycle Registry
-;; ============================================================================
-
-(def ^:private worktree-lifecycle-registry
-  "Lightweight atom-based registry tracking worktrees created by the executor.
-
-   Structure: {workflow-id {:scratch-ref   str
-                             :worktree-path str
-                             :created-at    long  ; epoch ms
-                             :status        :active | :released
-                             :released-at   long  ; epoch ms, only present when :released}}
-
-   This is an in-memory atom that retains all entries (including :released)
-   for the lifetime of the process. It is NOT persisted and is NOT pruned by
-   `gc-scratch-refs!`. Git-ref cleanup happens independently via
-   `gc-scratch-refs!`, which neither reads nor mutates this registry. This
-   lets post-mortem tooling inspect which workflows wrote which scratch
-   commits even after the worktrees are gone."
-  (atom {}))
-
-(defn get-worktree-registry
+(defn ^{:stratum 1} get-worktree-registry
   "Return a snapshot of the current worktree lifecycle registry.
 
    Each entry is keyed by workflow-id and contains:
@@ -636,7 +488,7 @@
   []
   @worktree-lifecycle-registry)
 
-(defn register-worktree-entry!
+(defn ^{:stratum 1} register-worktree-entry!
   "Register a new worktree entry in the lifecycle registry.
 
    Called on worktree creation to record the scratch-ref and worktree path
@@ -651,7 +503,7 @@
           :status        :active})
   nil)
 
-(defn release-worktree-entry!
+(defn ^{:stratum 1} release-worktree-entry!
   "Mark a registry entry as :released while preserving the scratch ref.
 
    Called on worktree destruction. The entry is retained in the registry
@@ -668,7 +520,7 @@
              registry)))
   nil)
 
-(defn- find-workflow-id-by-worktree
+(defn- ^{:stratum 1} find-workflow-id-by-worktree
   "Find the workflow-id whose registry entry has the given worktree-path.
    Returns nil when no match is found."
   [worktree-path]
@@ -680,8 +532,7 @@
 ;; ============================================================================
 ;; Parent-Repo Derivation
 ;; ============================================================================
-
-(defn derive-parent-repo-path
+(defn ^{:stratum 1} derive-parent-repo-path
   "Derive the parent repository path from a linked worktree path.
 
    Uses `git rev-parse --git-common-dir` which returns the shared .git
@@ -716,11 +567,118 @@
                   {:worktree-path worktree-path
                    :stderr        (get r :err "")}))))
 
+(defn- ^{:stratum 1} safe-worktree-path
+  "Resolve `relative-path` inside `worktree-path` and return the canonical
+   File, or nil if the resolved path would escape the worktree sandbox or
+   if canonicalization fails (I/O error, invalid path)."
+  [worktree-path relative-path]
+  (try
+    (let [worktree (.getCanonicalFile (File. ^String worktree-path))
+          file     (.getCanonicalFile (File. worktree ^String relative-path))]
+      (when (path-inside-worktree? worktree file)
+        file))
+    (catch java.io.IOException _ nil)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} check-legacy-tmp-worktrees!
+  "Warn once per JVM session when the legacy /tmp/miniforge-worktrees directory
+   has entries.
+
+   Uses `compare-and-set!` on `legacy-tmp-warned?` so exactly one thread emits
+   the advisory, even when multiple worktree-create calls race at startup.
+
+   Does NOT error — graceful coexistence per the worktree-persistence spec
+   constraint. Existing /tmp worktrees remain usable; the warning tells
+   operators how to migrate to the persistent default path.
+
+   Rebind `*warn-fn*` via `binding` in tests to capture the output.
+   Reset `legacy-tmp-warned?` to false before tests that assert the warning fires."
+  []
+  (when (and (legacy-tmp-worktrees-exist?)
+             (compare-and-set! legacy-tmp-warned? false true))
+    (*warn-fn*
+     (str
+      "[miniforge] WARNING: legacy worktrees detected at "
+      legacy-tmp-worktrees-path "\n"
+      "  These worktrees live under /tmp and will not survive a reboot.\n"
+      "  To migrate to the persistent default:\n"
+      "    1. Add `:workflow/worktree-root \"~/.miniforge/worktrees\"` to\n"
+      "       ~/.miniforge/config.edn (this is already the shipped default).\n"
+      "    2. Let in-flight tasks complete, then remove the stale /tmp directory:\n"
+      "       rm -rf " legacy-tmp-worktrees-path "\n"
+      "  New worktrees are now created under: " (default-base-path)))))
+
+(defn- ^{:stratum 2} ensure-named-branch!
+  "If the worktree is in detached-HEAD state, create a real branch at HEAD
+   so the bundle records `refs/heads/<name>` (not just bare HEAD).
+
+   Returns result/ok with the branch name to use for bundling. Pass-through
+   when the worktree is already on a named branch.
+
+   Uses `git checkout -B` (force-reset to HEAD) so recovery is idempotent
+   across reruns with the same task-id and across leftover local refs from
+   prior runs. The branch is task-namespaced internal infrastructure, not
+   a user-curated ref; resetting it is the right semantics."
+  [worktree-path branch task-id]
+  (if-not (detached? branch)
+    (result/ok branch)
+    (let [name (recovery-branch-name task-id)
+          r    (run-git "-C" worktree-path "checkout" "-B" name)]
+      (if (zero? (:exit r))
+        (result/ok name)
+        (result/err :archive-detach-recovery-failed
+                    (or (:err r)
+                        "could not create or reset branch from detached HEAD"))))))
+
+(defn- ^{:stratum 2} maybe-commit
+  "Commit only when the worktree has dirty changes. `git add -A` already
+   ran — if no paths were staged (e.g. all changes were gitignored),
+   commit-staged! would fail with `nothing to commit`, which is not an
+   archive error."
+  [worktree-path message]
+  (-> (dirty? worktree-path)
+      (result/and-then
+       (fn [is-dirty]
+         (if is-dirty
+           (commit-staged! worktree-path message)
+           (result/ok :clean))))))
+
+(defn- ^{:stratum 2} bundle-result
+  "Final step of the persist pipeline once we know the worktree is ahead
+   of base-ref. Reads HEAD, writes the bundle, and packages the persist
+   result map."
+  [worktree-path branch base-ref archive-dir task-id ahead]
+  (let [bundle-path (str (ensure-archive-dir archive-dir) "/" task-id ".bundle")]
+    (-> (head-sha worktree-path)
+        (result/and-then
+         (fn [sha]
+           (-> (write-bundle! worktree-path bundle-path branch base-ref)
+               (result/map-ok
+                (fn [_]
+                  {:persisted?    true
+                   :bundle-path   bundle-path
+                   :commit-sha    sha
+                   :branch        branch
+                   :commits-ahead ahead}))))))))
+
+(defn- ^{:stratum 2} already-clean?
+  "True when the worktree has no dirty paths AND no commits ahead of
+   base-ref — there is nothing to bundle. Returns a result so callers see
+   git failures rather than treating them as a clean state."
+  [worktree-path base-ref]
+  (-> (dirty? worktree-path)
+      (result/and-then
+       (fn [is-dirty]
+         (if is-dirty
+           (result/ok false)
+           (-> (commits-ahead worktree-path base-ref)
+               (result/map-ok zero?)))))))
+
 ;; ============================================================================
 ;; File-Write Scratch-Commit Hook
 ;; ============================================================================
-
-(defn notify-file-written!
+(defn ^{:stratum 2} notify-file-written!
   "Snapshot a file written inside a worktree into the workflow's scratch ref.
 
    Called by the layer that processes Write tool responses from agents running
@@ -741,67 +699,7 @@
        (fn [{:keys [parent-repo-path]}]
          (scratch-commit/scratch-commit! parent-repo-path workflow-id phase file-path)))))
 
-;; ============================================================================
-;; Command Execution
-;; ============================================================================
-
-(defn execute-command
-  "Execute a command in a directory using ProcessBuilder.
-
-   Accepts either a string (passed to sh -c, suitable for shell builtins and
-   pipelines) or a vector of strings (exec'd directly without a shell —
-   preferred for user-supplied values to avoid shell injection).
-
-   This allows proper environment variable handling and working directory."
-  [workdir command env-map]
-  (let [cmd-args (if (string? command)
-                   ["sh" "-c" command]
-                   (vec command))
-        start-time (System/currentTimeMillis)]
-    (try
-      (let [pb (ProcessBuilder. ^java.util.List cmd-args)
-            _ (.directory pb (File. ^String workdir))
-            _ (when (seq env-map)
-                (let [pb-env (.environment pb)]
-                  (doseq [[k v] env-map]
-                    (.put pb-env (name k) (str v)))))
-            process (.start pb)
-            stdout (slurp (.getInputStream process))
-            stderr (slurp (.getErrorStream process))
-            exit-code (.waitFor process)]
-        (result/ok {:exit-code exit-code
-                    :stdout stdout
-                    :stderr stderr
-                    :duration-ms (- (System/currentTimeMillis) start-time)}))
-      (catch Exception e
-        (result/err :exec-failed (.getMessage e))))))
-
-;; ============================================================================
-;; File Operations
-;; ============================================================================
-
-(defn- path-inside-worktree?
-  "True when `file` (a canonicalized File) is the worktree root or is nested
-   inside it. Prevents path-traversal escape via `../` segments."
-  [^File worktree ^File file]
-  (let [root-path (str (.getPath worktree) File/separator)
-        file-path (.getPath file)]
-    (or (= file-path (.getPath worktree))
-        (str/starts-with? file-path root-path))))
-
-(defn- safe-worktree-path
-  "Resolve `relative-path` inside `worktree-path` and return the canonical
-   File, or nil if the resolved path would escape the worktree sandbox or
-   if canonicalization fails (I/O error, invalid path)."
-  [worktree-path relative-path]
-  (try
-    (let [worktree (.getCanonicalFile (File. ^String worktree-path))
-          file     (.getCanonicalFile (File. worktree ^String relative-path))]
-      (when (path-inside-worktree? worktree file)
-        file))
-    (catch java.io.IOException _ nil)))
-
-(defn copy-file-to
+(defn ^{:stratum 2} copy-file-to
   "Copy a file into the worktree."
   [worktree-path local-path remote-path]
   (let [dest (safe-worktree-path worktree-path remote-path)]
@@ -817,7 +715,7 @@
         (catch Exception e
           (result/err :copy-failed (.getMessage e)))))))
 
-(defn copy-file-from
+(defn ^{:stratum 2} copy-file-from
   "Copy a file from the worktree."
   [worktree-path remote-path local-path]
   (let [source (safe-worktree-path worktree-path remote-path)]
@@ -833,11 +731,123 @@
         (catch Exception e
           (result/err :copy-failed (.getMessage e)))))))
 
+(defn ^{:stratum 2} remove-worktree!
+  "Remove a git worktree created by create-worktree!.
+
+   Takes a map with keys:
+   - :worktree-path - Absolute path to the worktree directory to remove"
+  [{:keys [worktree-path]}]
+  (remove-worktree worktree-path))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} create-worktree
+  "Create a git worktree for the task.
+
+   Serializes creation through worktree-lock to prevent concurrent git
+   config.lock conflicts when multiple sub-workflows acquire environments
+   simultaneously. The legacy /tmp worktree check also runs inside the lock so
+   at most one thread emits the advisory warning at a time.
+
+   Attempts in order:
+   1. git worktree add -b <name> <path> <sha-or-ref>
+   2. Clean up stale branch/directory and retry step 1
+   3. git worktree add --detach <path> — detached HEAD (last resort)
+
+   Detached HEAD is a real fallback path here, but downstream `archive-bundle!`
+   handles it defensively by creating a real branch at HEAD before bundling.
+   This one-two punch keeps `git worktree add` failures from cascading into
+   broken bundles whose only ref is a bare HEAD."
+  [base-path repo-path worktree-name branch]
+  (locking worktree-lock
+    (check-legacy-tmp-worktrees!)
+    (let [worktree-path (str base-path "/" worktree-name)
+          base-sha      (resolve-branch-sha repo-path branch)
+          base-ref      (or base-sha branch)]
+      (ensure-directory base-path)
+      (let [result (run-git "-C" repo-path
+                            "worktree" "add" "-b" worktree-name
+                            worktree-path base-ref)]
+        (if (zero? (:exit result))
+          (result/ok {:worktree-path worktree-path
+                      :base-sha base-sha
+                      :base-ref branch})
+          ;; Failed — clean up stale branch/directory from a prior run and retry
+          (do
+            (run-shell "rm" "-rf" worktree-path)
+            (run-git "-C" repo-path "worktree" "prune")
+            (run-git "-C" repo-path "branch" "-D" worktree-name)
+            (let [result2 (run-git "-C" repo-path
+                                   "worktree" "add" "-b" worktree-name
+                                   worktree-path base-ref)]
+              (if (zero? (:exit result2))
+                (result/ok {:worktree-path worktree-path
+                            :base-sha base-sha
+                            :base-ref branch})
+                ;; Still failing — detached HEAD as last resort
+                (let [result3 (run-git "-C" repo-path
+                                       "worktree" "add" "--detach"
+                                       worktree-path)]
+                  (if (zero? (:exit result3))
+                    (result/ok {:worktree-path worktree-path
+                                :base-sha base-sha
+                                :base-ref branch})
+                    (result/err :worktree-create-failed (:err result3))))))))))))
+
+(defn- ^{:stratum 3} commit-and-bundle!
+  "Pipeline: stage -> commit-if-dirty -> recompute ahead -> bundle-or-noop."
+  [worktree-path branch base-ref archive-dir task-id message]
+  (-> (stage-all! worktree-path)
+      (result/and-then (fn [_] (maybe-commit worktree-path message)))
+      (result/and-then (fn [_] (commits-ahead worktree-path base-ref)))
+      (result/and-then
+       (fn [ahead]
+         (if (zero? ahead)
+           (result/ok {:persisted? false :no-changes? true :branch branch})
+           (bundle-result worktree-path branch base-ref archive-dir task-id ahead))))))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} archive-bundle!
+  "Persist a worktree task work as a git bundle.
+
+   Pipeline: resolve current branch -> check for dirty changes or commits
+   ahead of base-ref -> if clean, return no-changes; otherwise stage,
+   commit on the task branch with --no-verify, and write a bundle of
+   `base-ref..HEAD` to <archive-dir>/<task-id>.bundle.
+
+   Arguments:
+   - worktree-path: absolute path to the scratch worktree
+   - opts: {:archive-dir string  -- destination dir for bundles
+           :task-id      string  -- identifier used as the bundle filename
+           :base-ref     string  -- base branch the worktree was forked from
+           :message      string  -- commit message for the persist commit}
+
+   Returns result/ok with one of:
+   - {:persisted? true  :bundle-path str :commit-sha str :branch str}
+   - {:persisted? false :no-changes? true :branch str}
+   Returns result/err on any git failure (no silent fallbacks)."
+  [worktree-path {:keys [archive-dir task-id base-ref message]
+                  :or   {message  default-commit-message
+                         base-ref default-base-ref}}]
+  (-> (current-branch worktree-path)
+      (result/and-then
+       (fn [raw-branch]
+         (-> (ensure-named-branch! worktree-path raw-branch task-id)
+             (result/and-then
+              (fn [branch]
+                (-> (already-clean? worktree-path base-ref)
+                    (result/and-then
+                     (fn [clean?]
+                       (if clean?
+                         (result/ok {:persisted? false :no-changes? true :branch branch})
+                         (commit-and-bundle! worktree-path branch base-ref
+                                             archive-dir task-id message))))))))))))
+
 ;; ============================================================================
 ;; Public Utility Functions
 ;; ============================================================================
-
-(defn create-worktree!
+(defn ^{:stratum 4} create-worktree!
   "Create a git worktree at <base-path>/task-<task-id> from <branch>.
 
    Takes a map with keys:
@@ -857,19 +867,12 @@
                   :task-id (str task-id)})
       result)))
 
-(defn remove-worktree!
-  "Remove a git worktree created by create-worktree!.
-
-   Takes a map with keys:
-   - :worktree-path - Absolute path to the worktree directory to remove"
-  [{:keys [worktree-path]}]
-  (remove-worktree worktree-path))
+;------------------------------------------------------------------------------ Layer 5
 
 ;; ============================================================================
 ;; WorktreeExecutor Record
 ;; ============================================================================
-
-(defrecord WorktreeExecutor [config base-path max-concurrent]
+(defrecord ^{:stratum 5} WorktreeExecutor [config base-path max-concurrent]
   proto/TaskExecutor
 
   (executor-type [_this] :worktree)
@@ -977,11 +980,12 @@
                         ".")]
       (restore-from-bundle! host-repo opts))))
 
+;------------------------------------------------------------------------------ Layer 6
+
 ;; ============================================================================
 ;; Factory
 ;; ============================================================================
-
-(defn create-worktree-executor
+(defn ^{:stratum 6} create-worktree-executor
   "Create a worktree-based executor (fallback).
 
    Config:

--- a/components/dag-executor/src/ai/miniforge/dag_executor/workspace.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/workspace.clj
@@ -59,11 +59,17 @@
         (if has-changes?
           ;; Unsigned: a scratch-worktree commit must not depend on the
           ;; operator's signing agent (see worktree tier commit-staged!).
-          (let [_ (exec-fn ["git" "-c" "commit.gpgsign=false" "commit" "-m" (str message)])
-                _ (exec-fn ["git" "push" "origin" (str "HEAD:" branch) "--force"])
-                sha-r (exec-fn "git rev-parse HEAD")
-                sha   (str/trim (get-in sha-r [:data :stdout] ""))]
-            (result/ok {:persisted? true :commit-sha sha :branch branch}))
+          ;; Each step's exit code is checked: a failed commit or push that
+          ;; still reported :persisted? true was a silent loss of work.
+          (let [commit-r (exec-fn ["git" "-c" "commit.gpgsign=false" "commit" "-m" (str message)])]
+            (if-not (zero? (get-in commit-r [:data :exit-code] 0))
+              (result/err :persist-commit-failed (get-in commit-r [:data :stderr] "git commit failed"))
+              (let [push-r (exec-fn ["git" "push" "origin" (str "HEAD:" branch) "--force"])]
+                (if-not (zero? (get-in push-r [:data :exit-code] 0))
+                  (result/err :persist-push-failed (get-in push-r [:data :stderr] "git push failed"))
+                  (let [sha-r (exec-fn "git rev-parse HEAD")
+                        sha   (str/trim (get-in sha-r [:data :stdout] ""))]
+                    (result/ok {:persisted? true :commit-sha sha :branch branch}))))))
           (result/ok {:persisted? false :commit-sha nil :no-changes? true :branch branch})))
       (catch Exception e
         (result/err :persist-failed (.getMessage e))))))

--- a/components/dag-executor/src/ai/miniforge/dag_executor/workspace.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/workspace.clj
@@ -38,11 +38,16 @@
   (and (string? branch) (not (str/blank? branch)) (not (str/starts-with? branch "-"))))
 
 (defn- ^{:stratum 0} failed-step
-  "The step's stderr when its exit code is non-zero, else nil. An exec
-   result without an exit code is trusted (older stubs and shells)."
+  "Why the step failed, or nil: the error message when exec-fn returned
+   a result/err, the stderr when the exit code is non-zero. A nil step
+   (skipped) or a result without an exit code (older stubs and shells)
+   is trusted."
   [r fallback]
-  (when (and r (not (zero? (get-in r [:data :exit-code] 0))))
-    (get-in r [:data :stderr] fallback)))
+  (cond
+    (nil? r) nil
+    (result/err? r) (or (get-in r [:error :message]) fallback)
+    (not (zero? (get-in r [:data :exit-code] 0))) (get-in r [:data :stderr] fallback)
+    :else nil))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -62,11 +67,15 @@
   (if (not (safe-branch? branch))
     (result/err :invalid-branch (str "Branch must be a non-empty string not starting with '-': " (pr-str branch)))
     (try
-      (let [_ (exec-fn "git add -A")
-            status-r (exec-fn "git status --porcelain")
+      (let [add-r (exec-fn "git add -A")
+            status-r (when-not (failed-step add-r "") (exec-fn "git status --porcelain"))
             has-changes? (seq (str/trim (get-in status-r [:data :stdout] "")))]
-        (if-not has-changes?
+        (cond
+          (failed-step add-r "") (result/err :persist-add-failed (failed-step add-r "git add failed"))
+          (failed-step status-r "") (result/err :persist-status-failed (failed-step status-r "git status failed"))
+          (not has-changes?)
           (result/ok {:persisted? false :commit-sha nil :no-changes? true :branch branch})
+          :else
           ;; Unsigned: a scratch-worktree commit must not depend on the
           ;; operator's signing agent (see worktree tier commit-staged!).
           (let [commit-r (exec-fn ["git" "-c" "commit.gpgsign=false" "commit" "-m" (str message)])

--- a/components/dag-executor/src/ai/miniforge/dag_executor/workspace.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/workspace.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.dag-executor.workspace
   "Git-based workspace persistence shared by Docker and K8s executors.
 
@@ -29,14 +28,18 @@
    [ai.miniforge.dag-executor.result :as result]
    [clojure.string :as str]))
 
-(defn- safe-branch?
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} safe-branch?
   "Branch names that start with '-' are parsed by git as options even in arg-vector
    mode (no shell involved). Reject them before invoking any git subcommand.
    Non-string values are also invalid — argv elements must be Strings."
   [branch]
   (and (string? branch) (not (str/blank? branch)) (not (str/starts-with? branch "-"))))
 
-(defn git-persist!
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} git-persist!
   "Persist workspace via git commit + push.
 
    Arguments:
@@ -54,7 +57,9 @@
             status-r (exec-fn "git status --porcelain")
             has-changes? (seq (str/trim (get-in status-r [:data :stdout] "")))]
         (if has-changes?
-          (let [_ (exec-fn ["git" "commit" "-m" (str message)])
+          ;; Unsigned: a scratch-worktree commit must not depend on the
+          ;; operator's signing agent (see worktree tier commit-staged!).
+          (let [_ (exec-fn ["git" "-c" "commit.gpgsign=false" "commit" "-m" (str message)])
                 _ (exec-fn ["git" "push" "origin" (str "HEAD:" branch) "--force"])
                 sha-r (exec-fn "git rev-parse HEAD")
                 sha   (str/trim (get-in sha-r [:data :stdout] ""))]
@@ -63,7 +68,7 @@
       (catch Exception e
         (result/err :persist-failed (.getMessage e))))))
 
-(defn git-restore!
+(defn ^{:stratum 1} git-restore!
   "Restore workspace via git fetch + checkout.
 
    Arguments:

--- a/components/dag-executor/src/ai/miniforge/dag_executor/workspace.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/workspace.clj
@@ -37,6 +37,13 @@
   [branch]
   (and (string? branch) (not (str/blank? branch)) (not (str/starts-with? branch "-"))))
 
+(defn- ^{:stratum 0} failed-step
+  "The step's stderr when its exit code is non-zero, else nil. An exec
+   result without an exit code is trusted (older stubs and shells)."
+  [r fallback]
+  (when (and r (not (zero? (get-in r [:data :exit-code] 0))))
+    (get-in r [:data :stderr] fallback)))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} git-persist!
@@ -48,7 +55,9 @@
               no shell — preferred for user-supplied values to avoid injection)
    - opts: {:branch string, :message string}
 
-   Returns result monad with {:persisted? bool :commit-sha string :branch string}"
+   Returns result monad with {:persisted? bool :commit-sha string :branch string}.
+   Every git step's exit code is checked: a failed commit or push that
+   still reported :persisted? true was a silent loss of work."
   [exec-fn {:keys [branch message] :or {branch "task/unknown" message "phase checkpoint"}}]
   (if (not (safe-branch? branch))
     (result/err :invalid-branch (str "Branch must be a non-empty string not starting with '-': " (pr-str branch)))
@@ -56,21 +65,22 @@
       (let [_ (exec-fn "git add -A")
             status-r (exec-fn "git status --porcelain")
             has-changes? (seq (str/trim (get-in status-r [:data :stdout] "")))]
-        (if has-changes?
+        (if-not has-changes?
+          (result/ok {:persisted? false :commit-sha nil :no-changes? true :branch branch})
           ;; Unsigned: a scratch-worktree commit must not depend on the
           ;; operator's signing agent (see worktree tier commit-staged!).
-          ;; Each step's exit code is checked: a failed commit or push that
-          ;; still reported :persisted? true was a silent loss of work.
-          (let [commit-r (exec-fn ["git" "-c" "commit.gpgsign=false" "commit" "-m" (str message)])]
-            (if-not (zero? (get-in commit-r [:data :exit-code] 0))
-              (result/err :persist-commit-failed (get-in commit-r [:data :stderr] "git commit failed"))
-              (let [push-r (exec-fn ["git" "push" "origin" (str "HEAD:" branch) "--force"])]
-                (if-not (zero? (get-in push-r [:data :exit-code] 0))
-                  (result/err :persist-push-failed (get-in push-r [:data :stderr] "git push failed"))
-                  (let [sha-r (exec-fn "git rev-parse HEAD")
-                        sha   (str/trim (get-in sha-r [:data :stdout] ""))]
-                    (result/ok {:persisted? true :commit-sha sha :branch branch}))))))
-          (result/ok {:persisted? false :commit-sha nil :no-changes? true :branch branch})))
+          (let [commit-r (exec-fn ["git" "-c" "commit.gpgsign=false" "commit" "-m" (str message)])
+                push-r (when-not (failed-step commit-r "")
+                         (exec-fn ["git" "push" "origin" (str "HEAD:" branch) "--force"]))
+                sha-r (when (and push-r (not (failed-step push-r "")))
+                        (exec-fn "git rev-parse HEAD"))]
+            (cond
+              (failed-step commit-r "") (result/err :persist-commit-failed (failed-step commit-r "git commit failed"))
+              (failed-step push-r "")   (result/err :persist-push-failed (failed-step push-r "git push failed"))
+              (failed-step sha-r "")    (result/err :persist-sha-failed (failed-step sha-r "git rev-parse failed"))
+              :else (result/ok {:persisted? true
+                                :commit-sha (str/trim (get-in sha-r [:data :stdout] ""))
+                                :branch branch})))))
       (catch Exception e
         (result/err :persist-failed (.getMessage e))))))
 
@@ -88,10 +98,17 @@
   (if (not (safe-branch? branch))
     (result/err :invalid-branch (str "Branch must be a non-empty string not starting with '-': " (pr-str branch)))
     (try
-      (let [_ (exec-fn ["git" "fetch" "origin" branch])
-            _ (exec-fn ["git" "checkout" branch])
-            sha-r (exec-fn "git rev-parse HEAD")
-            sha   (str/trim (get-in sha-r [:data :stdout] ""))]
-        (result/ok {:restored? true :commit-sha sha :branch branch}))
+      (let [fetch-r (exec-fn ["git" "fetch" "origin" branch])]
+        (if-let [e (failed-step fetch-r "git fetch failed")]
+          (result/err :restore-fetch-failed e)
+          (let [co-r (exec-fn ["git" "checkout" branch])]
+            (if-let [e (failed-step co-r "git checkout failed")]
+              (result/err :restore-checkout-failed e)
+              (let [sha-r (exec-fn "git rev-parse HEAD")]
+                (if-let [e (failed-step sha-r "git rev-parse failed")]
+                  (result/err :restore-sha-failed e)
+                  (result/ok {:restored? true
+                              :commit-sha (str/trim (get-in sha-r [:data :stdout] ""))
+                              :branch branch})))))))
       (catch Exception e
         (result/err :restore-failed (.getMessage e))))))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.dag-executor.protocols.impl.runtime.oci-cli-test
   "Tests for OCI-CLI executor: token sanitization, URL auth, image
    management, descriptor wiring."
@@ -28,7 +27,9 @@
    [ai.miniforge.dag-executor.protocols.impl.runtime.descriptor :as descriptor]
    [ai.miniforge.dag-executor.protocols.impl.runtime.oci-cli :as oci-cli]))
 
-(defn- cmd-contains?
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} cmd-contains?
   "True if cmd (string or arg vector) contains the substring s.
    Vector commands are joined with spaces before the check so that
    multi-word substrings like \"git fetch\" match across elements."
@@ -38,16 +39,16 @@
    s))
 
 ;; Private fn accessor helper
-(defn- private-fn [sym]
+(defn- ^{:stratum 0} private-fn [sym]
   (var-get (ns-resolve 'ai.miniforge.dag-executor.protocols.impl.runtime.oci-cli sym)))
 
 ;; Default descriptor used by tests that exercise CLI argument shaping
 ;; rather than runtime selection. `make-descriptor` defaults to :docker.
-(defn- docker-descriptor
+(defn- ^{:stratum 0} docker-descriptor
   ([] (descriptor/make-descriptor {}))
   ([opts] (descriptor/make-descriptor opts)))
 
-(defn- podman-descriptor
+(defn- ^{:stratum 0} podman-descriptor
   "For tests describing Podman-specific behaviour (bare-hex image IDs),
    so the setup matches the runtime named in the test."
   []
@@ -55,34 +56,33 @@
 
 ;; Phase 2: argument-construction tests run against every supported kind so
 ;; a Podman regression in flag shaping shows up at unit-test time.
-(def ^:private supported-kinds-under-test
+(def ^{:stratum 0} ^:private supported-kinds-under-test
   [:docker :podman])
 
-(defn- descriptor-for-kind
+(defn- ^{:stratum 0} descriptor-for-kind
   [kind]
   (descriptor/make-descriptor {:runtime-kind kind}))
 
 ;; ============================================================================
 ;; descriptor — basic construction
 ;; ============================================================================
-
-(deftest descriptor-defaults-to-docker-test
+(deftest ^{:stratum 0} descriptor-defaults-to-docker-test
   (testing "make-descriptor defaults to :docker"
     (let [d (descriptor/make-descriptor {})]
       (is (= :docker (descriptor/kind d)))
       (is (= "docker" (descriptor/executable d))))))
 
-(deftest descriptor-honors-explicit-executable-test
+(deftest ^{:stratum 0} descriptor-honors-explicit-executable-test
   (testing "make-descriptor uses :executable when provided"
     (let [d (descriptor/make-descriptor {:executable "/opt/homebrew/bin/docker"})]
       (is (= "/opt/homebrew/bin/docker" (descriptor/executable d))))))
 
-(deftest descriptor-honors-legacy-docker-path-test
+(deftest ^{:stratum 0} descriptor-honors-legacy-docker-path-test
   (testing "make-descriptor falls back to :docker-path for :docker kind"
     (let [d (descriptor/make-descriptor {:docker-path "/usr/bin/docker"})]
       (is (= "/usr/bin/docker" (descriptor/executable d))))))
 
-(deftest descriptor-accepts-podman-test
+(deftest ^{:stratum 0} descriptor-accepts-podman-test
   (testing "make-descriptor builds a :podman descriptor in Phase 2"
     (let [d (descriptor/make-descriptor {:runtime-kind :podman})]
       (is (= :podman (descriptor/kind d)))
@@ -90,7 +90,7 @@
       (is (descriptor/capable? d :rootless))
       (is (descriptor/capable? d :oci-images)))))
 
-(deftest descriptor-rejects-nerdctl-as-unsupported-test
+(deftest ^{:stratum 0} descriptor-rejects-nerdctl-as-unsupported-test
   (testing "make-descriptor throws :runtime/unsupported for :nerdctl (Future)"
     (try
       (descriptor/make-descriptor {:runtime-kind :nerdctl})
@@ -100,7 +100,7 @@
         (is (contains? (-> e ex-data :runtime/supported-kinds) :docker))
         (is (contains? (-> e ex-data :runtime/supported-kinds) :podman))))))
 
-(deftest descriptor-rejects-unknown-kind-test
+(deftest ^{:stratum 0} descriptor-rejects-unknown-kind-test
   (testing "make-descriptor throws :runtime/unknown-kind for unknown kinds"
     (try
       (descriptor/make-descriptor {:runtime-kind :unknown-runtime})
@@ -108,7 +108,7 @@
       (catch clojure.lang.ExceptionInfo e
         (is (= :unknown-runtime (-> e ex-data :runtime/unknown-kind)))))))
 
-(deftest descriptor-validation-result-returns-anomaly-test
+(deftest ^{:stratum 0} descriptor-validation-result-returns-anomaly-test
   (testing "constructed descriptor schema drift returns a canonical anomaly"
     (let [result (@#'descriptor/validate-descriptor-result
                   {:runtime/kind :docker})]
@@ -117,23 +117,173 @@
       (is (= :runtime/descriptor
              (get-in result [:anomaly/data :anomaly/schema]))))))
 
+(deftest ^{:stratum 0} persist-workspace-no-changes-test
+  (testing "persist-workspace! returns {:persisted? false} when no dirty files"
+    (let [executor (oci-cli/create-docker-executor {:image "test:latest"})]
+      (with-redefs [oci-cli/exec-in-container
+                    (fn [_descriptor _env-id cmd _opts]
+                      (if (= cmd "git status --porcelain")
+                        {:data {:exit-code 0 :stdout ""}}
+                        {:data {:exit-code 0 :stdout "" :stderr ""}}))]
+        (let [result (proto/persist-workspace! executor "container-1"
+                                               {:branch "task/test-123"
+                                                :workdir "/workspace"})]
+          (is (false? (get-in result [:data :persisted?])))
+          (is (true? (get-in result [:data :no-changes?]))))))))
+
+;; ============================================================================
+;; create-container --stop-timeout (N11 §2.2)
+;; ============================================================================
+(defn- ^{:stratum 0} capture-create-container-args
+  "Run create-container with `oci-cli/run-runtime` stubbed and return the
+   captured argv. Keeps the parameterized stop-timeout tests focused on
+   the assertions rather than mock plumbing."
+  [descriptor & {:as create-opts}]
+  (let [captured-args (atom nil)
+        stub          (fn [_descriptor & args]
+                        (reset! captured-args (vec args))
+                        {:exit 0 :out "container-id-123\n" :err ""})]
+    (with-redefs [oci-cli/run-runtime stub]
+      (apply oci-cli/create-container
+             descriptor "test-ctr" "alpine" "/workspace" nil nil nil
+             (mapcat identity create-opts))
+      @captured-args)))
+
+;; ============================================================================
+;; acquisition timeout — production-side guard against stuck Docker
+;; ============================================================================
+;;
+;; The 2026-05-16 dogfood hung 33+ minutes when the Docker daemon stalled
+;; mid acquire; PR #895 mocked the test side, this guard fails fast in
+;; production. Tests target the with-acquisition-timeout helper directly so
+;; they stay deterministic without a real Docker daemon.
+(deftest ^{:stratum 0} with-acquisition-timeout-returns-body-result-on-success-test
+  (testing "body that returns in time passes its result through unchanged"
+    (let [ok-result {:ok? true :data {:environment-id "env-1"}}]
+      (is (= ok-result
+             (oci-cli/with-acquisition-timeout 5000 (fn [] ok-result)))))))
+
+(deftest ^{:stratum 0} with-acquisition-timeout-fires-on-deadline-test
+  (testing "body that exceeds the deadline returns :timeout err"
+    (let [result (oci-cli/with-acquisition-timeout
+                   50
+                   (fn [] (Thread/sleep 5000) :should-not-see))]
+      (is (= false (:ok? result)))
+      (is (= :timeout (:code (:error result)))
+          "Uses the standard dag-executor :timeout code, not a bespoke one")
+      (is (= 50 (get-in result [:error :data :timeout-ms])))
+      (is (= :acquire-environment! (get-in result [:error :data :surface]))
+          ":surface tags which protocol method tripped the deadline")
+      (is (clojure.string/includes? (:message (:error result)) "stuck daemon")))))
+
+(deftest ^{:stratum 0} with-acquisition-timeout-nil-or-nonpositive-disables-guard-test
+  (testing "nil / 0 / negative timeout bypasses the deadline check"
+    (doseq [t [nil 0 -1]]
+      (is (= :body-ran
+             (oci-cli/with-acquisition-timeout t (fn [] :body-ran)))
+          (str "timeout " (pr-str t) " must run the body without the guard")))))
+
+(deftest ^{:stratum 0} with-acquisition-timeout-disabled-body-exception-returns-error-result-test
+  (testing "disabled deadline still returns body exceptions as failure data"
+    (let [result (oci-cli/with-acquisition-timeout
+                   nil
+                   (fn [] (throw (ex-info "boom" {:tag :disabled-timeout}))))]
+      (is (result/err? result))
+      (is (= :acquire-failed (:code (:error result))))
+      (is (= :disabled-timeout
+             (get-in result [:error :data :exception-data :tag]))))))
+
+(deftest ^{:stratum 0} with-acquisition-timeout-cancels-the-future-on-timeout-test
+  (testing "the inner future is cancelled when the deadline fires"
+    ;; The body runs an inner sleep that records `cancelled?` via
+    ;; InterruptedException. After the outer deadline fires,
+    ;; future-cancel interrupts the worker thread and the catch
+    ;; branch flips the flag. Assert the flag — without this the
+    ;; test passed even if cancellation regressed.
+    (let [cancelled? (promise)
+          deadline-ms 50
+          result (oci-cli/with-acquisition-timeout
+                   deadline-ms
+                   (fn []
+                     (try
+                       (Thread/sleep 5000)
+                       :never
+                       (catch InterruptedException _
+                         (deliver cancelled? true)
+                         :interrupted))))]
+      (is (= :timeout (:code (:error result))))
+      (is (= true (deref cancelled? 2000 :no-interrupt))
+          "future-cancel must propagate InterruptedException into the body"))))
+
+(deftest ^{:stratum 0} with-acquisition-timeout-body-exception-returns-error-result-test
+  (testing "exceptions thrown by the body return failure data instead of throwing"
+    (let [result (oci-cli/with-acquisition-timeout
+                   5000
+                   (fn [] (throw (ex-info "boom" {:tag :original}))))]
+      (is (false? (:ok? result)))
+      (is (= :acquire-failed (:code (:error result))))
+      (is (= "boom" (:message (:error result))))
+      (is (= :acquire-environment! (get-in result [:error :data :surface])))
+      (is (= "clojure.lang.ExceptionInfo"
+             (get-in result [:error :data :exception-class])))
+      (is (= {:tag :original}
+             (get-in result [:error :data :exception-data]))))))
+
+(deftest ^{:stratum 0} run-runtime-interrupt-destroys-child-process-test
+  (testing "interrupting a runtime call does not wait for the child command to finish"
+    (let [descriptor {:runtime/executable "/bin/sleep"}
+          started? (promise)
+          worker (Thread.
+                   (fn []
+                     (deliver started? true)
+                     (oci-cli/run-runtime descriptor "5")))]
+      (.start worker)
+      (is (= true (deref started? 1000 false)))
+      (.interrupt worker)
+      ;; Join with 4s — comfortably under the 5s child sleep, so a dead worker
+      ;; still proves the interrupt short-circuited the sleep, but with enough
+      ;; headroom that thread-teardown scheduling under a saturated full-suite
+      ;; run doesn't flake (1500ms raced under `poly test :all` load).
+      (.join worker 4000)
+      (is (false? (.isAlive worker))
+          "interrupt must destroy the child and end the worker well before the 5s sleep"))))
+
+(deftest ^{:stratum 0} run-runtime-returns-interrupted-result-test
+  (testing "run-runtime reports interruption as process result data"
+    (let [descriptor {:runtime/executable "/bin/sleep"}
+          started? (promise)
+          runtime-result (promise)
+          worker (Thread.
+                   (fn []
+                     (deliver started? true)
+                     (deliver runtime-result
+                              (oci-cli/run-runtime descriptor "5"))))]
+      (.start worker)
+      (is (= true (deref started? 1000 false)))
+      (.interrupt worker)
+      (let [result (deref runtime-result 4000 :timeout)]
+        (is (not= :timeout result))
+        (is (= 130 (:exit result)))
+        (is (clojure.string/includes? (:err result) "interrupted"))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
 ;; ============================================================================
 ;; sanitize-token
 ;; ============================================================================
-
-(deftest sanitize-token-github-test
+(deftest ^{:stratum 1} sanitize-token-github-test
   (testing "sanitizes GitHub x-access-token"
     (let [sanitize (private-fn 'sanitize-token)]
       (is (= "https://x-access-token:***@github.com/o/r.git"
              (sanitize "https://x-access-token:ghp_abc123@github.com/o/r.git"))))))
 
-(deftest sanitize-token-gitlab-test
+(deftest ^{:stratum 1} sanitize-token-gitlab-test
   (testing "sanitizes GitLab oauth2 token"
     (let [sanitize (private-fn 'sanitize-token)]
       (is (= "https://oauth2:***@gitlab.com/g/p.git"
              (sanitize "https://oauth2:glpat-xyz@gitlab.com/g/p.git"))))))
 
-(deftest sanitize-token-no-token-test
+(deftest ^{:stratum 1} sanitize-token-no-token-test
   (testing "passes through strings without tokens"
     (let [sanitize (private-fn 'sanitize-token)]
       (is (= "git clone https://github.com/o/r.git"
@@ -142,14 +292,13 @@
 ;; ============================================================================
 ;; authenticated-https-url
 ;; ============================================================================
-
-(deftest authenticated-url-github-test
+(deftest ^{:stratum 1} authenticated-url-github-test
   (testing "injects GitHub x-access-token"
     (let [auth-url (private-fn 'authenticated-https-url)]
       (is (= "https://x-access-token:tok123@github.com/o/r.git"
              (auth-url "https://github.com/o/r.git" "tok123" :github))))))
 
-(deftest authenticated-url-gitlab-test
+(deftest ^{:stratum 1} authenticated-url-gitlab-test
   (testing "injects GitLab oauth2 token"
     (let [auth-url (private-fn 'authenticated-https-url)]
       (is (= "https://oauth2:tok456@gitlab.com/g/p.git"
@@ -158,8 +307,7 @@
 ;; ============================================================================
 ;; image-exists? (public)
 ;; ============================================================================
-
-(deftest image-exists-nonexistent-test
+(deftest ^{:stratum 1} image-exists-nonexistent-test
   (testing "image-exists? returns false for nonexistent image"
     (with-redefs [oci-cli/run-runtime
                   (fn [_d & _args]
@@ -170,8 +318,7 @@
 ;; ============================================================================
 ;; create-container — execution-plan interactions
 ;; ============================================================================
-
-(deftest create-container-plan-without-profile-does-not-use-legacy-network-test
+(deftest ^{:stratum 1} create-container-plan-without-profile-does-not-use-legacy-network-test
   (testing "an execution plan is authoritative even when it omits
             :network-profile"
     (let [captured (atom nil)]
@@ -185,7 +332,7 @@
           (is (not (some #{"--network"} args)))
           (is (not (some #{"bridge"} args))))))))
 
-(deftest create-container-plan-network-profile-overrides-legacy-test
+(deftest ^{:stratum 1} create-container-plan-network-profile-overrides-legacy-test
   (testing "an execution-plan WITH :network-profile drops the legacy network
             argument (profile drives networking via build-security-args)"
     (let [captured (atom nil)]
@@ -200,7 +347,7 @@
           (is (not (some #{"--network"} args)))
           (is (some #{"--network=none"} args)))))))
 
-(deftest create-container-plan-memory-replaces-registry-default-test
+(deftest ^{:stratum 1} create-container-plan-memory-replaces-registry-default-test
   (testing "a plan memory limit emits one authoritative --memory argument"
     (let [captured (atom nil)]
       (with-redefs [oci-cli/run-runtime
@@ -214,7 +361,7 @@
         (is (= 1 (count (filter #{"--memory"} @captured))))
         (is (some #{"768m"} @captured))))))
 
-(deftest create-container-plan-env-replaces-legacy-env-test
+(deftest ^{:stratum 1} create-container-plan-env-replaces-legacy-env-test
   (testing "plan env is authoritative when present; partial plans retain legacy env"
     (let [captured (atom nil)
           run! (fn [plan]
@@ -231,7 +378,7 @@
         (is (not (some #{"SOURCE=legacy"} args))))
       (is (some #{"SOURCE=legacy"} (run! {}))))))
 
-(deftest create-container-runs-plan-command-test
+(deftest ^{:stratum 1} create-container-runs-plan-command-test
   (testing "the container command comes from the plan's :command, defaulting
             to the keep-alive when absent"
     (let [captured (atom nil)]
@@ -249,8 +396,7 @@
 ;; ============================================================================
 ;; container-image-digest
 ;; ============================================================================
-
-(deftest container-image-digest-returns-sha-on-success-test
+(deftest ^{:stratum 1} container-image-digest-returns-sha-on-success-test
   (testing "returns trimmed digest string when inspect succeeds"
     (with-redefs [oci-cli/run-runtime
                   (fn [_d & _args]
@@ -258,7 +404,7 @@
       (is (= "sha256:abc123def456"
              (oci-cli/container-image-digest (docker-descriptor) "my-container"))))))
 
-(deftest container-image-digest-normalizes-podman-bare-hex-test
+(deftest ^{:stratum 1} container-image-digest-normalizes-podman-bare-hex-test
   (testing "Podman prints the image ID as bare 64-hex; the digest is
             normalized to the sha256:-prefixed form the gate expects"
     (let [hex (apply str (repeat 64 \a))]
@@ -268,7 +414,7 @@
         (is (= (str "sha256:" hex)
                (oci-cli/container-image-digest (podman-descriptor) "my-container")))))))
 
-(deftest image-config-digest-normalizes-podman-bare-hex-test
+(deftest ^{:stratum 1} image-config-digest-normalizes-podman-bare-hex-test
   (testing "image-config-digest applies the same normalization on image IDs"
     (let [hex (apply str (repeat 64 \a))]
       (with-redefs [oci-cli/run-runtime
@@ -277,7 +423,7 @@
         (is (= (str "sha256:" hex)
                (oci-cli/image-config-digest (podman-descriptor) "img:tag")))))))
 
-(deftest image-config-digest-passes-docker-prefixed-form-through-test
+(deftest ^{:stratum 1} image-config-digest-passes-docker-prefixed-form-through-test
   (testing "Docker's already-prefixed sha256:<hex> ID is returned unchanged"
     (let [digest (str "sha256:" (apply str (repeat 64 \b)))]
       (with-redefs [oci-cli/run-runtime
@@ -286,21 +432,21 @@
         (is (= digest
                (oci-cli/image-config-digest (docker-descriptor) "img:tag")))))))
 
-(deftest container-image-digest-returns-nil-on-nonzero-exit-test
+(deftest ^{:stratum 1} container-image-digest-returns-nil-on-nonzero-exit-test
   (testing "returns nil when inspect exits non-zero"
     (with-redefs [oci-cli/run-runtime
                   (fn [_d & _args]
                     {:exit 1 :out "" :err "No such container"})]
       (is (nil? (oci-cli/container-image-digest (docker-descriptor) "missing"))))))
 
-(deftest container-image-digest-returns-nil-on-empty-output-test
+(deftest ^{:stratum 1} container-image-digest-returns-nil-on-empty-output-test
   (testing "returns nil when inspect output is blank"
     (with-redefs [oci-cli/run-runtime
                   (fn [_d & _args]
                     {:exit 0 :out "  \n" :err ""})]
       (is (nil? (oci-cli/container-image-digest (docker-descriptor) "empty-out"))))))
 
-(deftest container-image-digest-returns-nil-on-exception-test
+(deftest ^{:stratum 1} container-image-digest-returns-nil-on-exception-test
   (testing "returns nil when run-runtime throws"
     (with-redefs [oci-cli/run-runtime
                   (fn [_d & _args]
@@ -310,8 +456,7 @@
 ;; ============================================================================
 ;; persist-workspace!
 ;; ============================================================================
-
-(deftest persist-workspace-with-changes-test
+(deftest ^{:stratum 1} persist-workspace-with-changes-test
   (testing "persist-workspace! commits and pushes when there are dirty files"
     (let [commands (atom [])
           executor (oci-cli/create-docker-executor {:image "test:latest"})]
@@ -334,28 +479,14 @@
           (is (true? (get-in result [:data :persisted?])))
           (is (= "abc123" (get-in result [:data :commit-sha])))
           (is (some #(= "git add -A" %) @commands))
-          (is (some #(cmd-contains? % "git commit") @commands))
+          (is (some #(cmd-contains? % "-c commit.gpgsign=false commit") @commands)
+              "the persist commit runs unsigned")
           (is (some #(cmd-contains? % "git push") @commands)))))))
-
-(deftest persist-workspace-no-changes-test
-  (testing "persist-workspace! returns {:persisted? false} when no dirty files"
-    (let [executor (oci-cli/create-docker-executor {:image "test:latest"})]
-      (with-redefs [oci-cli/exec-in-container
-                    (fn [_descriptor _env-id cmd _opts]
-                      (if (= cmd "git status --porcelain")
-                        {:data {:exit-code 0 :stdout ""}}
-                        {:data {:exit-code 0 :stdout "" :stderr ""}}))]
-        (let [result (proto/persist-workspace! executor "container-1"
-                                               {:branch "task/test-123"
-                                                :workdir "/workspace"})]
-          (is (false? (get-in result [:data :persisted?])))
-          (is (true? (get-in result [:data :no-changes?]))))))))
 
 ;; ============================================================================
 ;; restore-workspace!
 ;; ============================================================================
-
-(deftest restore-workspace-test
+(deftest ^{:stratum 1} restore-workspace-test
   (testing "restore-workspace! fetches and checks out task branch"
     (let [commands (atom [])
           executor (oci-cli/create-docker-executor {:image "test:latest"})]
@@ -373,26 +504,7 @@
           (is (some #(cmd-contains? % "git fetch") @commands))
           (is (some #(cmd-contains? % "git checkout") @commands)))))))
 
-;; ============================================================================
-;; create-container --stop-timeout (N11 §2.2)
-;; ============================================================================
-
-(defn- capture-create-container-args
-  "Run create-container with `oci-cli/run-runtime` stubbed and return the
-   captured argv. Keeps the parameterized stop-timeout tests focused on
-   the assertions rather than mock plumbing."
-  [descriptor & {:as create-opts}]
-  (let [captured-args (atom nil)
-        stub          (fn [_descriptor & args]
-                        (reset! captured-args (vec args))
-                        {:exit 0 :out "container-id-123\n" :err ""})]
-    (with-redefs [oci-cli/run-runtime stub]
-      (apply oci-cli/create-container
-             descriptor "test-ctr" "alpine" "/workspace" nil nil nil
-             (mapcat identity create-opts))
-      @captured-args)))
-
-(deftest create-container-stop-timeout-test
+(deftest ^{:stratum 1} create-container-stop-timeout-test
   (doseq [kind supported-kinds-under-test]
     (testing (str "runtime " kind)
       (testing "  includes --stop-timeout when execution-plan has :time-limit-ms"
@@ -415,8 +527,7 @@
 ;; ============================================================================
 ;; executor-type reflects descriptor kind
 ;; ============================================================================
-
-(deftest executor-type-from-descriptor-test
+(deftest ^{:stratum 1} executor-type-from-descriptor-test
   (testing "OciCliExecutor reports its descriptor's runtime kind"
     (doseq [kind supported-kinds-under-test]
       (testing (str "kind " kind)
@@ -425,95 +536,13 @@
           (is (= kind (proto/executor-type exec))))))))
 
 ;; ============================================================================
-;; acquisition timeout — production-side guard against stuck Docker
-;; ============================================================================
-;;
-;; The 2026-05-16 dogfood hung 33+ minutes when the Docker daemon stalled
-;; mid acquire; PR #895 mocked the test side, this guard fails fast in
-;; production. Tests target the with-acquisition-timeout helper directly so
-;; they stay deterministic without a real Docker daemon.
-
-(deftest with-acquisition-timeout-returns-body-result-on-success-test
-  (testing "body that returns in time passes its result through unchanged"
-    (let [ok-result {:ok? true :data {:environment-id "env-1"}}]
-      (is (= ok-result
-             (oci-cli/with-acquisition-timeout 5000 (fn [] ok-result)))))))
-
-(deftest with-acquisition-timeout-fires-on-deadline-test
-  (testing "body that exceeds the deadline returns :timeout err"
-    (let [result (oci-cli/with-acquisition-timeout
-                   50
-                   (fn [] (Thread/sleep 5000) :should-not-see))]
-      (is (= false (:ok? result)))
-      (is (= :timeout (:code (:error result)))
-          "Uses the standard dag-executor :timeout code, not a bespoke one")
-      (is (= 50 (get-in result [:error :data :timeout-ms])))
-      (is (= :acquire-environment! (get-in result [:error :data :surface]))
-          ":surface tags which protocol method tripped the deadline")
-      (is (clojure.string/includes? (:message (:error result)) "stuck daemon")))))
-
-(deftest with-acquisition-timeout-nil-or-nonpositive-disables-guard-test
-  (testing "nil / 0 / negative timeout bypasses the deadline check"
-    (doseq [t [nil 0 -1]]
-      (is (= :body-ran
-             (oci-cli/with-acquisition-timeout t (fn [] :body-ran)))
-          (str "timeout " (pr-str t) " must run the body without the guard")))))
-
-(deftest with-acquisition-timeout-disabled-body-exception-returns-error-result-test
-  (testing "disabled deadline still returns body exceptions as failure data"
-    (let [result (oci-cli/with-acquisition-timeout
-                   nil
-                   (fn [] (throw (ex-info "boom" {:tag :disabled-timeout}))))]
-      (is (result/err? result))
-      (is (= :acquire-failed (:code (:error result))))
-      (is (= :disabled-timeout
-             (get-in result [:error :data :exception-data :tag]))))))
-
-(deftest with-acquisition-timeout-cancels-the-future-on-timeout-test
-  (testing "the inner future is cancelled when the deadline fires"
-    ;; The body runs an inner sleep that records `cancelled?` via
-    ;; InterruptedException. After the outer deadline fires,
-    ;; future-cancel interrupts the worker thread and the catch
-    ;; branch flips the flag. Assert the flag — without this the
-    ;; test passed even if cancellation regressed.
-    (let [cancelled? (promise)
-          deadline-ms 50
-          result (oci-cli/with-acquisition-timeout
-                   deadline-ms
-                   (fn []
-                     (try
-                       (Thread/sleep 5000)
-                       :never
-                       (catch InterruptedException _
-                         (deliver cancelled? true)
-                         :interrupted))))]
-      (is (= :timeout (:code (:error result))))
-      (is (= true (deref cancelled? 2000 :no-interrupt))
-          "future-cancel must propagate InterruptedException into the body"))))
-
-(deftest with-acquisition-timeout-body-exception-returns-error-result-test
-  (testing "exceptions thrown by the body return failure data instead of throwing"
-    (let [result (oci-cli/with-acquisition-timeout
-                   5000
-                   (fn [] (throw (ex-info "boom" {:tag :original}))))]
-      (is (false? (:ok? result)))
-      (is (= :acquire-failed (:code (:error result))))
-      (is (= "boom" (:message (:error result))))
-      (is (= :acquire-environment! (get-in result [:error :data :surface])))
-      (is (= "clojure.lang.ExceptionInfo"
-             (get-in result [:error :data :exception-class])))
-      (is (= {:tag :original}
-             (get-in result [:error :data :exception-data]))))))
-
-;; ============================================================================
 ;; run-runtime-timed / run-runtime-process-timed — per-subprocess deadline
 ;; ============================================================================
 ;;
 ;; Covers the 2026-07-18 fix: `execute!`, `release-environment!`, `copy-to!`,
 ;; and `copy-from!` now route through bounded waitFor rather than parking
 ;; the JVM thread indefinitely if Docker stalls (2026-05-16 dogfood follow-up).
-
-(deftest run-runtime-timed-fires-on-deadline-test
+(deftest ^{:stratum 1} run-runtime-timed-fires-on-deadline-test
   (testing "returns exit 124 when the subprocess exceeds the per-op timeout"
     (let [run-timed  (private-fn 'run-runtime-timed)
           descriptor {:runtime/executable "/bin/sleep"}
@@ -523,7 +552,7 @@
       (is (clojure.string/includes? (:err result) "100")
           "error message includes the timeout-ms so operators can distinguish from a real failure"))))
 
-(deftest run-runtime-process-timed-fires-on-deadline-test
+(deftest ^{:stratum 1} run-runtime-process-timed-fires-on-deadline-test
   (testing "returns exit 124 with empty byte arrays when the subprocess exceeds the timeout"
     (let [run-timed  (private-fn 'run-runtime-process-timed)
           descriptor {:runtime/executable "/bin/sleep"}
@@ -534,7 +563,7 @@
       (is (zero? (alength ^bytes (:out-bytes result))))
       (is (zero? (alength ^bytes (:err-bytes result)))))))
 
-(deftest run-runtime-timed-nil-timeout-is-unbounded-test
+(deftest ^{:stratum 1} run-runtime-timed-nil-timeout-is-unbounded-test
   (testing "nil timeout-ms disables the deadline (backward-compatible with run-runtime)"
     (let [run-timed  (private-fn 'run-runtime-timed)
           descriptor {:runtime/executable "/bin/echo"}
@@ -542,44 +571,7 @@
       (is (= 0 (:exit result)))
       (is (clojure.string/includes? (:out result) "hello")))))
 
-(deftest run-runtime-interrupt-destroys-child-process-test
-  (testing "interrupting a runtime call does not wait for the child command to finish"
-    (let [descriptor {:runtime/executable "/bin/sleep"}
-          started? (promise)
-          worker (Thread.
-                   (fn []
-                     (deliver started? true)
-                     (oci-cli/run-runtime descriptor "5")))]
-      (.start worker)
-      (is (= true (deref started? 1000 false)))
-      (.interrupt worker)
-      ;; Join with 4s — comfortably under the 5s child sleep, so a dead worker
-      ;; still proves the interrupt short-circuited the sleep, but with enough
-      ;; headroom that thread-teardown scheduling under a saturated full-suite
-      ;; run doesn't flake (1500ms raced under `poly test :all` load).
-      (.join worker 4000)
-      (is (false? (.isAlive worker))
-          "interrupt must destroy the child and end the worker well before the 5s sleep"))))
-
-(deftest run-runtime-returns-interrupted-result-test
-  (testing "run-runtime reports interruption as process result data"
-    (let [descriptor {:runtime/executable "/bin/sleep"}
-          started? (promise)
-          runtime-result (promise)
-          worker (Thread.
-                   (fn []
-                     (deliver started? true)
-                     (deliver runtime-result
-                              (oci-cli/run-runtime descriptor "5"))))]
-      (.start worker)
-      (is (= true (deref started? 1000 false)))
-      (.interrupt worker)
-      (let [result (deref runtime-result 4000 :timeout)]
-        (is (not= :timeout result))
-        (is (= 130 (:exit result)))
-        (is (clojure.string/includes? (:err result) "interrupted"))))))
-
-(deftest bootstrap-workspace-command-failure-returns-error-result-test
+(deftest ^{:stratum 1} bootstrap-workspace-command-failure-returns-error-result-test
   (testing "bootstrap command failures are returned as result data"
     (let [bootstrap-workspace! (private-fn 'bootstrap-workspace!)
           exec-results (atom [{:data {:exit-code 1

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_persist_commit_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_persist_commit_test.clj
@@ -1,0 +1,41 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.dag-executor.protocols.impl.worktree-persist-commit-test
+  "The persist commit runs with signing off: a scratch-worktree commit
+   must never depend on the operator's signing agent."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.dag-executor.protocols.impl.worktree :as wt]
+            [ai.miniforge.dag-executor.result :as result]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} persist-commit-disables-signing
+  (let [calls (atom [])]
+    (with-redefs [wt/run-git (fn [& args] (swap! calls conj (vec args)) {:exit 0 :out "" :err ""})]
+      (testing "the commit carries -c commit.gpgsign=false ahead of the subcommand"
+        (is (result/ok? (#'wt/commit-staged! "/tmp/wt" "implement phase completed")))
+        (let [args (first @calls)
+              i (.indexOf ^java.util.List args "commit")]
+          (is (= ["-c" "commit.gpgsign=false"] (subvec args (- i 2) i)))
+          (is (some #{"--no-verify"} args)))))))
+
+(deftest ^{:stratum 0} persist-commit-failure-is-a-result
+  (with-redefs [wt/run-git (fn [& _] {:exit 128 :out "" :err "error: 1Password: failed to fill whole buffer"})]
+    (let [r (#'wt/commit-staged! "/tmp/wt" "m")]
+      (is (result/err? r))
+      (is (= :archive-commit-failed (get-in r [:error :code]))))))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_persist_commit_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_persist_commit_test.clj
@@ -24,7 +24,7 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(deftest ^{:stratum 0} persist-commit-disables-signing
+(deftest ^{:stratum 0} persist-commit-disables-signing-test
   (let [calls (atom [])]
     (with-redefs [wt/run-git (fn [& args] (swap! calls conj (vec args)) {:exit 0 :out "" :err ""})]
       (testing "the commit carries -c commit.gpgsign=false ahead of the subcommand"
@@ -34,7 +34,7 @@
           (is (= ["-c" "commit.gpgsign=false"] (subvec args (- i 2) i)))
           (is (some #{"--no-verify"} args)))))))
 
-(deftest ^{:stratum 0} persist-commit-failure-is-a-result
+(deftest ^{:stratum 0} persist-commit-failure-is-a-result-test
   (with-redefs [wt/run-git (fn [& _] {:exit 128 :out "" :err "error: 1Password: failed to fill whole buffer"})]
     (let [r (#'wt/commit-staged! "/tmp/wt" "m")]
       (is (result/err? r))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/workspace_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/workspace_test.clj
@@ -70,6 +70,24 @@
     (is (result/err? r))
     (is (= :persist-push-failed (get-in r [:error :code])))))
 
+(deftest ^{:stratum 0} git-restore!-fetch-and-checkout-failures-are-errors-test
+  (let [failing (fn [needle code]
+                  (fn [cmd]
+                    (if (and (vector? cmd) (some #{needle} cmd))
+                      (result/ok {:exit-code 1 :stdout "" :stderr (str needle " failed")})
+                      (result/ok {:exit-code 0 :stdout "abc\n" :stderr ""}))))]
+    (is (= :restore-fetch-failed (get-in (sut/git-restore! (failing "fetch" 1) {:branch "task/x"}) [:error :code])))
+    (is (= :restore-checkout-failed (get-in (sut/git-restore! (failing "checkout" 1) {:branch "task/x"}) [:error :code])))))
+
+(deftest ^{:stratum 0} rev-parse-failure-is-an-error-test
+  (let [exec-fn (fn [cmd]
+                  (cond
+                    (and (string? cmd) (str/includes? cmd "rev-parse")) (result/ok {:exit-code 128 :stdout "" :stderr "not a git repo"})
+                    (and (string? cmd) (str/includes? cmd "status")) (result/ok {:exit-code 0 :stdout " M a\n" :stderr ""})
+                    :else (result/ok {:exit-code 0 :stdout "" :stderr ""})))]
+    (is (= :persist-sha-failed (get-in (sut/git-persist! exec-fn {:branch "task/x"}) [:error :code])))
+    (is (= :restore-sha-failed (get-in (sut/git-restore! exec-fn {:branch "task/x"}) [:error :code])))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} cmd-has?

--- a/components/dag-executor/test/ai/miniforge/dag_executor/workspace_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/workspace_test.clj
@@ -44,6 +44,32 @@
       (is (result/err? r))
       (is (= :restore-failed (-> r :error :code))))))
 
+(deftest ^{:stratum 0} git-persist!-commit-failure-is-an-error-test
+  (testing "a non-zero commit exit becomes :persist-commit-failed, never :persisted? true"
+    (let [exec-fn (fn [cmd]
+                    (cond
+                      (and (vector? cmd) (some #{"commit"} cmd))
+                      (result/ok {:exit-code 128 :stdout "" :stderr "error: 1Password: failed to fill whole buffer"})
+                      (and (string? cmd) (str/includes? cmd "status"))
+                      (result/ok {:exit-code 0 :stdout " M a.clj\n" :stderr ""})
+                      :else (result/ok {:exit-code 0 :stdout "" :stderr ""})))
+          r (sut/git-persist! exec-fn {:branch "task/x" :message "m"})]
+      (is (result/err? r))
+      (is (= :persist-commit-failed (get-in r [:error :code])))
+      (is (str/includes? (get-in r [:error :message]) "1Password")))))
+
+(deftest ^{:stratum 0} git-persist!-push-failure-is-an-error-test
+  (let [exec-fn (fn [cmd]
+                  (cond
+                    (and (vector? cmd) (some #{"push"} cmd))
+                    (result/ok {:exit-code 1 :stdout "" :stderr "rejected"})
+                    (and (string? cmd) (str/includes? cmd "status"))
+                    (result/ok {:exit-code 0 :stdout " M a.clj\n" :stderr ""})
+                    :else (result/ok {:exit-code 0 :stdout "" :stderr ""})))
+        r (sut/git-persist! exec-fn {:branch "task/x" :message "m"})]
+    (is (result/err? r))
+    (is (= :persist-push-failed (get-in r [:error :code])))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} cmd-has?

--- a/components/dag-executor/test/ai/miniforge/dag_executor/workspace_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/workspace_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.dag-executor.workspace-test
   (:require
    [clojure.test :refer [deftest is testing]]
@@ -24,24 +23,35 @@
    [ai.miniforge.dag-executor.result :as result]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures and factories
 
-(defn- shell-result
+;; Test fixtures and factories
+(defn- ^{:stratum 0} shell-result
   "Build the shape exec-fn callers expect: {:data {:stdout str}}."
   [stdout]
   {:data {:stdout stdout}})
 
-(defn- cmd->str
+(defn- ^{:stratum 0} cmd->str
   "Normalize a command — string or arg vector — to a single string for matching."
   [cmd]
   (if (string? cmd) cmd (str/join " " cmd)))
 
-(defn- cmd-has?
+(def ^{:stratum 0} ^:private head-sha "abc123def456")
+
+(deftest ^{:stratum 0} git-restore!-catches-exec-exceptions-test
+  (testing "An exception from exec-fn is caught and turned into a :restore-failed result/err"
+    (let [boom-exec-fn (fn [_cmd] (throw (Exception. "fetch refused")))
+          r (sut/git-restore! boom-exec-fn {:branch "task/x"})]
+      (is (result/err? r))
+      (is (= :restore-failed (-> r :error :code))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} cmd-has?
   "True if cmd (raw string or vector) contains substring s when normalized."
   [cmd s]
   (str/includes? (cmd->str cmd) s))
 
-(defn- recording-exec-fn
+(defn- ^{:stratum 1} recording-exec-fn
   "Return [exec-fn calls-atom]. exec-fn records every command in its **raw**
    form (string or arg vector) into calls-atom, preserving the distinction so
    tests can assert that user-supplied git commands arrive as vectors (not
@@ -59,12 +69,56 @@
               default)))
       calls])))
 
-(def ^:private head-sha "abc123def456")
+(deftest ^{:stratum 1} git-persist!-catches-exec-exceptions-test
+  (testing "An exception from exec-fn is caught and turned into a :persist-failed result/err"
+    (let [boom-exec-fn (fn [cmd]
+                         (if (str/includes? cmd "status")
+                           (throw (Exception. "git unavailable"))
+                           (shell-result "")))
+          r (sut/git-persist! boom-exec-fn {:branch "task/x"})]
+      (is (result/err? r))
+      (is (= :persist-failed (-> r :error :code))))))
 
-;------------------------------------------------------------------------------ Layer 1
+(deftest ^{:stratum 1} git-persist!-rejects-leading-dash-branch-test
+  (testing "A branch starting with '-' is rejected before exec-fn is called"
+    (let [exec-called (atom false)
+          exec-fn (fn [_] (reset! exec-called true) (shell-result ""))
+          r (sut/git-persist! exec-fn {:branch "--evil"})]
+      (is (result/err? r))
+      (is (= :invalid-branch (-> r :error :code)))
+      (is (false? @exec-called) "exec-fn must not be invoked for an invalid branch"))))
+
+(deftest ^{:stratum 1} git-persist!-rejects-empty-branch-test
+  (testing "An empty string branch is rejected before exec-fn is called"
+    (let [exec-called (atom false)
+          exec-fn (fn [_] (reset! exec-called true) (shell-result ""))
+          r (sut/git-persist! exec-fn {:branch ""})]
+      (is (result/err? r))
+      (is (= :invalid-branch (-> r :error :code)))
+      (is (false? @exec-called) "exec-fn must not be invoked for an empty branch"))))
+
+(deftest ^{:stratum 1} git-restore!-rejects-leading-dash-branch-test
+  (testing "A branch starting with '-' is rejected before exec-fn is called"
+    (let [exec-called (atom false)
+          exec-fn (fn [_] (reset! exec-called true) (shell-result ""))
+          r (sut/git-restore! exec-fn {:branch "--evil"})]
+      (is (result/err? r))
+      (is (= :invalid-branch (-> r :error :code)))
+      (is (false? @exec-called) "exec-fn must not be invoked for an invalid branch"))))
+
+(deftest ^{:stratum 1} git-restore!-rejects-empty-branch-test
+  (testing "An empty string branch is rejected before exec-fn is called"
+    (let [exec-called (atom false)
+          exec-fn (fn [_] (reset! exec-called true) (shell-result ""))
+          r (sut/git-restore! exec-fn {:branch ""})]
+      (is (result/err? r))
+      (is (= :invalid-branch (-> r :error :code)))
+      (is (false? @exec-called) "exec-fn must not be invoked for an empty branch"))))
+
+;------------------------------------------------------------------------------ Layer 2
+
 ;; git-persist!
-
-(deftest git-persist!-no-changes-test
+(deftest ^{:stratum 2} git-persist!-no-changes-test
   (testing "Empty `git status --porcelain` ⇒ no commit, no push, ok with :no-changes? true"
     (let [[exec-fn calls] (recording-exec-fn
                            {"git status" (shell-result "")
@@ -79,10 +133,10 @@
       ;; git add was attempted, but commit/push were not.
       (is (some #(cmd-has? % "git add -A") @calls))
       (is (some #(cmd-has? % "git status") @calls))
-      (is (not (some #(cmd-has? % "git commit") @calls)))
+      (is (not (some #(cmd-has? % " commit -m") @calls)))
       (is (not (some #(cmd-has? % "git push")   @calls))))))
 
-(deftest git-persist!-with-changes-commits-and-pushes-test
+(deftest ^{:stratum 2} git-persist!-with-changes-commits-and-pushes-test
   (testing "Dirty `git status` ⇒ commit + push + read HEAD sha; ok carries the sha and branch"
     (let [[exec-fn calls] (recording-exec-fn
                            {"git status"   (shell-result " M src/foo.clj\n")
@@ -98,21 +152,21 @@
       ;; arg vectors (not shell strings) — the security invariant of this PR.
       (let [cmds @calls]
         (is (some #(cmd-has? % "git add -A") cmds))
-        (is (some #(and (vector? %) (cmd-has? % "git commit -m phase: implement")) cmds)
+        (is (some #(and (vector? %) (cmd-has? % "-c commit.gpgsign=false commit -m phase: implement")) cmds)
             "commit must be an arg vector, not a shell string")
         (is (some #(and (vector? %) (cmd-has? % "git push origin HEAD:feature/bar --force")) cmds)
             "push must be an arg vector, not a shell string")))))
 
-(deftest git-persist!-defaults-branch-and-message-test
+(deftest ^{:stratum 2} git-persist!-defaults-branch-and-message-test
   (testing "Missing :branch and :message use 'task/unknown' and 'phase checkpoint'"
     (let [[exec-fn calls] (recording-exec-fn
                            {"git status"   (shell-result " M file\n")
                             "git rev-parse" (shell-result head-sha)})]
       (sut/git-persist! exec-fn {})
-      (is (some #(cmd-has? % "git commit -m phase checkpoint") @calls))
+      (is (some #(cmd-has? % "-c commit.gpgsign=false commit -m phase checkpoint") @calls))
       (is (some #(cmd-has? % "HEAD:task/unknown")               @calls)))))
 
-(deftest git-persist!-trims-stdout-test
+(deftest ^{:stratum 2} git-persist!-trims-stdout-test
   (testing "stdout from git rev-parse is trimmed before being returned"
     (let [[exec-fn _] (recording-exec-fn
                        {"git status"   (shell-result " M file\n")
@@ -120,38 +174,8 @@
           r (sut/git-persist! exec-fn {:branch "task/x"})]
       (is (= head-sha (:commit-sha (result/unwrap r)))))))
 
-(deftest git-persist!-catches-exec-exceptions-test
-  (testing "An exception from exec-fn is caught and turned into a :persist-failed result/err"
-    (let [boom-exec-fn (fn [cmd]
-                         (if (str/includes? cmd "status")
-                           (throw (Exception. "git unavailable"))
-                           (shell-result "")))
-          r (sut/git-persist! boom-exec-fn {:branch "task/x"})]
-      (is (result/err? r))
-      (is (= :persist-failed (-> r :error :code))))))
-
-(deftest git-persist!-rejects-leading-dash-branch-test
-  (testing "A branch starting with '-' is rejected before exec-fn is called"
-    (let [exec-called (atom false)
-          exec-fn (fn [_] (reset! exec-called true) (shell-result ""))
-          r (sut/git-persist! exec-fn {:branch "--evil"})]
-      (is (result/err? r))
-      (is (= :invalid-branch (-> r :error :code)))
-      (is (false? @exec-called) "exec-fn must not be invoked for an invalid branch"))))
-
-(deftest git-persist!-rejects-empty-branch-test
-  (testing "An empty string branch is rejected before exec-fn is called"
-    (let [exec-called (atom false)
-          exec-fn (fn [_] (reset! exec-called true) (shell-result ""))
-          r (sut/git-persist! exec-fn {:branch ""})]
-      (is (result/err? r))
-      (is (= :invalid-branch (-> r :error :code)))
-      (is (false? @exec-called) "exec-fn must not be invoked for an empty branch"))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; git-restore!
-
-(deftest git-restore!-fetches-checks-out-and-reads-head-test
+(deftest ^{:stratum 2} git-restore!-fetches-checks-out-and-reads-head-test
   (testing "git-restore! issues fetch + checkout + rev-parse and returns the sha"
     (let [[exec-fn calls] (recording-exec-fn
                            {"git rev-parse" (shell-result (str head-sha "\n"))})
@@ -169,7 +193,7 @@
         (is (some #(and (vector? %) (cmd-has? % "git checkout feature/restore")) cmds)
             "checkout must be an arg vector, not a shell string")))))
 
-(deftest git-restore!-defaults-branch-test
+(deftest ^{:stratum 2} git-restore!-defaults-branch-test
   (testing "Missing :branch defaults to 'task/unknown'"
     (let [[exec-fn calls] (recording-exec-fn
                            {"git rev-parse" (shell-result head-sha)})]
@@ -177,34 +201,9 @@
       (is (some #(cmd-has? % "git fetch origin task/unknown") @calls))
       (is (some #(cmd-has? % "git checkout task/unknown")     @calls)))))
 
-(deftest git-restore!-trims-stdout-test
+(deftest ^{:stratum 2} git-restore!-trims-stdout-test
   (testing "git rev-parse stdout is trimmed before return"
     (let [[exec-fn _] (recording-exec-fn
                        {"git rev-parse" (shell-result (str "\n" head-sha "\n"))})
           r (sut/git-restore! exec-fn {:branch "task/x"})]
       (is (= head-sha (:commit-sha (result/unwrap r)))))))
-
-(deftest git-restore!-catches-exec-exceptions-test
-  (testing "An exception from exec-fn is caught and turned into a :restore-failed result/err"
-    (let [boom-exec-fn (fn [_cmd] (throw (Exception. "fetch refused")))
-          r (sut/git-restore! boom-exec-fn {:branch "task/x"})]
-      (is (result/err? r))
-      (is (= :restore-failed (-> r :error :code))))))
-
-(deftest git-restore!-rejects-leading-dash-branch-test
-  (testing "A branch starting with '-' is rejected before exec-fn is called"
-    (let [exec-called (atom false)
-          exec-fn (fn [_] (reset! exec-called true) (shell-result ""))
-          r (sut/git-restore! exec-fn {:branch "--evil"})]
-      (is (result/err? r))
-      (is (= :invalid-branch (-> r :error :code)))
-      (is (false? @exec-called) "exec-fn must not be invoked for an invalid branch"))))
-
-(deftest git-restore!-rejects-empty-branch-test
-  (testing "An empty string branch is rejected before exec-fn is called"
-    (let [exec-called (atom false)
-          exec-fn (fn [_] (reset! exec-called true) (shell-result ""))
-          r (sut/git-restore! exec-fn {:branch ""})]
-      (is (result/err? r))
-      (is (= :invalid-branch (-> r :error :code)))
-      (is (false? @exec-called) "exec-fn must not be invoked for an empty branch"))))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/workspace_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/workspace_test.clj
@@ -88,6 +88,23 @@
     (is (= :persist-sha-failed (get-in (sut/git-persist! exec-fn {:branch "task/x"}) [:error :code])))
     (is (= :restore-sha-failed (get-in (sut/git-restore! exec-fn {:branch "task/x"}) [:error :code])))))
 
+(deftest ^{:stratum 0} exec-fn-result-err-is-surfaced-test
+  (testing "an exec-fn that returns result/err on commit is a persist-commit-failed, not success"
+    (let [exec-fn (fn [cmd]
+                    (cond
+                      (and (vector? cmd) (some #{"commit"} cmd)) (result/err :exec-failed "container gone")
+                      (and (string? cmd) (str/includes? cmd "status")) (result/ok {:exit-code 0 :stdout " M a\n" :stderr ""})
+                      :else (result/ok {:exit-code 0 :stdout "" :stderr ""})))
+          r (sut/git-persist! exec-fn {:branch "task/x"})]
+      (is (= :persist-commit-failed (get-in r [:error :code])))
+      (is (= "container gone" (get-in r [:error :message])))))
+  (testing "a failing status step is not read as no changes"
+    (let [exec-fn (fn [cmd] (if (and (string? cmd) (str/includes? cmd "status"))
+                              (result/err :exec-failed "status blew up")
+                              (result/ok {:exit-code 0 :stdout "" :stderr ""})))
+          r (sut/git-persist! exec-fn {:branch "task/x"})]
+      (is (= :persist-status-failed (get-in r [:error :code]))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} cmd-has?


### PR DESCRIPTION
## Summary

#1871's `persist-rejected` log fired on its first live run (trap-bench series 6, rv1): `:archive-commit-failed — error: 1Password: failed to fill whole buffer`. The scratch-worktree persist commit inherits the operator's global `commit.gpgsign` and routes through their signing agent; with the agent locked, the commit fails and the task's work stays uncommitted in the worktree — invisible to the task branch, the bundle, and the bench's endpoint. This is the mechanism behind "fixed in the worktree but never on the branch" in series 4 (rt3), 5 (ru1, ru3d) and 6 (rv1).

## Change

Both persist commit sites (`worktree.clj` `commit-staged!`, `workspace.clj`) pass `-c commit.gpgsign=false`. Persist is preservation, not attribution; the gate layer owns validation and the release path owns the attributable commit.

Tests: new `worktree_persist_commit_test.clj` pins the flag ahead of the subcommand (with `--no-verify` retained) and the `:archive-commit-failed` result on failure; the three existing command-shape assertions updated to the new shape.

Commit unsigned: the local signing agent is refusing (the same condition); the squash merge is signed by GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

MINIFORGE_PR_BUDGET_OVERRIDE: the stratum autofix re-layered worktree.clj (474/470) and two touched test files (~200 lines each) around a ~15-line functional change (two commit call sites gain -c commit.gpgsign=false; three assertions updated; one new 41-line test file).