### PR TITLE
feat(codex-gap): §7.7 per-peg telemetry from ledgers and gate histories

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -589,6 +589,25 @@
   ;; MCP Context Server
   ;; ──────────────────────────────────────────────────────────────────────────
 
+  codex-gap-peg-telemetry
+  {:doc "T1 §7.7 per-peg telemetry over run ledgers + gate histories: mechanism verdicts as answers, entropy, collapsed branches. Usage: bb codex-gap-peg-telemetry [checkpoint-root]; codex from MINIFORGE_CODEX_PATH"
+   :extra-paths ["components/codex-gap/src"
+                 "components/codex-gap/resources"
+                 "components/codex/src"
+                 "components/codex/resources"
+                 "components/messages/src"
+                 "components/messages/resources"]
+   :requires ([ai.miniforge.codex-gap.interface :as codex-gap]
+              [ai.miniforge.codex.interface :as codex]
+              [babashka.fs :as fs])
+   :task (let [[root] *command-line-args*
+               root (or root (str (fs/path (System/getProperty "user.home") ".miniforge" "checkpoints")))
+               codex-dir (System/getenv "MINIFORGE_CODEX_PATH")
+               graph (when codex-dir (codex/load-graph codex-dir))]
+           (if (or (nil? codex-dir) (:codex/anomaly graph))
+             (do (println "codex unavailable:" (or (:codex/reason graph) "MINIFORGE_CODEX_PATH unset")) (System/exit 2))
+             (prn (codex-gap/peg-telemetry root (:nodes graph) (codex-gap/load-mechanism-gate-map)))))}
+
   codex-gap-retrodict
   {:doc "T2 §5.4 retrodiction: re-classify run ledgers against the codex as it is NOW. Usage: bb codex-gap-retrodict [checkpoint-root] [phase=situation ...]; codex from MINIFORGE_CODEX_PATH"
    :extra-paths ["components/codex-gap/src"

--- a/components/codex-gap/resources/config/codex-gap/mechanism-gate-map.edn
+++ b/components/codex-gap/resources/config/codex-gap/mechanism-gate-map.edn
@@ -1,0 +1,7 @@
+;; Mechanism pointer (T1 SPEC §4.5, the `mechanism:` field a problem node
+;; carries once a peg migrated into enforcement) -> the gate keyword whose
+;; decision is that mechanism's verdict in a run's gate-history.edn.
+;; A peg landing on a problem listed here has a mechanically recorded
+;; answer (§7.7): the gate denied (the guarded failure occurred) or
+;; allowed (it did not). Pegs with no mapped mechanism stay unobserved.
+{"miniforge/gate/stale-references" :stale-references}

--- a/components/codex-gap/src/ai/miniforge/codex_gap/interface.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/interface.clj
@@ -29,6 +29,7 @@
             [ai.miniforge.codex-gap.classify :as classify]
             [ai.miniforge.codex-gap.ledger :as ledger]
             [ai.miniforge.codex-gap.report :as report]
+            [ai.miniforge.codex-gap.peg-telemetry :as peg-telemetry]
             [ai.miniforge.codex-gap.retrodict :as retrodict]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -95,3 +96,18 @@
   "The §4.1.3 anchoring slot from the codex graph, or nil when unreadable."
   [codex-dir]
   (report/codex-anchoring-stats codex-dir))
+
+(defn ^{:stratum 0} peg-telemetry
+  "T1 SPEC §7.7 per-peg record over the run directories under
+   `checkpoint-root`: for each peg a consultation presented, the answers
+   its landing problem's mechanism recorded in gate-history.edn, their
+   entropy, and whether the peg's answer branches collapsed onto one
+   landing set. `nodes` is the codex graph's {id node}; `gate-map` maps
+   mechanism pointers to gate keywords (see load-mechanism-gate-map)."
+  [checkpoint-root nodes gate-map]
+  (peg-telemetry/peg-telemetry checkpoint-root nodes gate-map))
+
+(defn ^{:stratum 0} load-mechanism-gate-map
+  "The mechanism->gate map resource, or {} when absent."
+  []
+  (peg-telemetry/load-mechanism-gate-map))

--- a/components/codex-gap/src/ai/miniforge/codex_gap/peg_telemetry.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/peg_telemetry.clj
@@ -18,7 +18,8 @@
 (ns ai.miniforge.codex-gap.peg-telemetry
   "T1 SPEC §7.7 per-peg telemetry, computed from records that already
    exist: the gap ledger's :miss/pegs (which discriminators a
-   consultation presented, with each answer's landing set) and the run's
+   consultation presented, each as {:id :answer nil :landings {answer
+   [landing-ids]}}) and the run's
    gate-history.edn (every gate decision per iteration).
 
    A peg's recorded answer is the verdict of the mechanism its landing
@@ -67,26 +68,13 @@
                        :let [p (/ n total)]]
                    (* p (/ (Math/log p) (Math/log 2)))))))))
 
-(defn ^{:stratum 0} branches-collapsed?
-  "True when every answer of `peg` lands on the same problem set -- the
-   second §4.4.1 signature. A peg with fewer than two answers cannot
-   collapse."
+(defn ^{:stratum 0} peg-landings
+  "The peg's {answer [landing-ids]} map. The ledger's per-peg record
+   (built by phase-software-factory's consultation summary) carries it
+   under :landings, with :answer nil; the raw codex basis carries it
+   under :answers. Both are read so a record from either side counts."
   [peg]
-  (let [landings (map set (vals (get peg :answers {})))]
-    (and (> (count landings) 1)
-         (apply = landings))))
-
-(defn ^{:stratum 0} peg-mechanisms
-  "Mechanism pointers carried by the problems `peg` can land on, from
-   `nodes` ({id node}); sorted so the choice among several is stable
-   across runs; empty when none carries one."
-  [peg nodes]
-  (->> (vals (get peg :answers {}))
-       (apply concat)
-       (keep #(get-in nodes [% :mechanism]))
-       distinct
-       sort
-       vec))
+  (or (get peg :landings) (get peg :answers) {}))
 
 (defn ^{:stratum 0} gate-answers
   "The answers a run's gate-history records for `gate`: one per
@@ -102,6 +90,27 @@
         history))
 
 ;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} branches-collapsed?
+  "True when every answer of `peg` lands on the same problem set -- the
+   second §4.4.1 signature. A peg with fewer than two answers cannot
+   collapse."
+  [peg]
+  (let [landings (map set (vals (peg-landings peg)))]
+    (and (> (count landings) 1)
+         (apply = landings))))
+
+(defn ^{:stratum 1} peg-mechanisms
+  "Mechanism pointers carried by the problems `peg` can land on, from
+   `nodes` ({id node}); sorted so the choice among several is stable
+   across runs; empty when none carries one."
+  [peg nodes]
+  (->> (vals (peg-landings peg))
+       (apply concat)
+       (keep #(get-in nodes [% :mechanism]))
+       distinct
+       sort
+       vec))
 
 (defn ^{:stratum 1} load-mechanism-gate-map
   "The mechanism->gate map, or {} when the resource is absent."

--- a/components/codex-gap/src/ai/miniforge/codex_gap/peg_telemetry.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/peg_telemetry.clj
@@ -143,7 +143,10 @@
                      entropy (entropy-bits freqs)
                      collapsed (count (filter :collapsed? obs))]
                  [peg {:runs (count obs)
-                       :mechanism (some :mechanism obs)
+                       ;; The mechanism that answered in some run wins over
+                       ;; one that never did; ties resolve by sorted name.
+                       :mechanism (or (->> obs (filter :observed?) (keep :mechanism) sort first)
+                                      (->> obs (keep :mechanism) sort first))
                        :observed? (boolean (some :observed? obs))
                        :observations n
                        :answers freqs

--- a/components/codex-gap/src/ai/miniforge/codex_gap/peg_telemetry.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/peg_telemetry.clj
@@ -170,8 +170,10 @@
 ;------------------------------------------------------------------------------ Layer 2
 
 (defn ^{:stratum 2} run-observations
-  "Per distinct peg presented in `run-dir`'s ledger: the answers its
-   mechanism's gate recorded in that run, or :unobserved."
+  "Per distinct peg presented in `run-dir`'s ledger: {:peg :mechanism
+   :collapsed? :answers :observed?} -- the answers its mechanism's gate
+   recorded in that run, or :observed? false with no answers when no
+   landing carries a mapped mechanism."
   [run-dir nodes gate-map]
   (let [pegs (->> (:entries (ledger/read-ledger (str run-dir)))
                   (mapcat :miss/pegs)
@@ -202,8 +204,16 @@
   [checkpoint-root nodes gate-map]
   (let [run-dirs (->> (.listFiles (io/file checkpoint-root))
                       (filter #(.isDirectory ^java.io.File %)))
-        per-run (map #(vec (run-observations % nodes gate-map)) run-dirs)
-        obs (vec (apply concat per-run))]
+        ;; One pass over the run dirs: observations accumulate into a
+        ;; single vector and runs contributing any are counted as we go.
+        {:keys [obs runs-with-pegs]}
+        (reduce (fn [acc run-dir]
+                  (let [these (run-observations run-dir nodes gate-map)]
+                    (if (seq these)
+                      (-> acc (update :obs into these) (update :runs-with-pegs inc))
+                      acc)))
+                {:obs [] :runs-with-pegs 0}
+                run-dirs)]
     {:pegs (aggregate obs)
-     :runs-with-pegs (count (filter seq per-run))
+     :runs-with-pegs runs-with-pegs
      :runs-scanned (count run-dirs)}))

--- a/components/codex-gap/src/ai/miniforge/codex_gap/peg_telemetry.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/peg_telemetry.clj
@@ -169,9 +169,13 @@
         history (delay (read-gate-history run-dir))]
     (for [peg pegs
           :let [mechanisms (peg-mechanisms peg nodes)
-                gate (some gate-map mechanisms)]]
+                ;; The mechanism reported is the one whose gate produced
+                ;; the answers -- the first mapped one, in sorted order.
+                mechanism (or (some #(when (contains? gate-map %) %) mechanisms)
+                              (first mechanisms))
+                gate (get gate-map mechanism)]]
       {:peg (:id peg)
-       :mechanism (first mechanisms)
+       :mechanism mechanism
        :collapsed? (branches-collapsed? peg)
        :answers (if gate (gate-answers @history gate) [])
        :observed? (some? gate)})))

--- a/components/codex-gap/src/ai/miniforge/codex_gap/peg_telemetry.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/peg_telemetry.clj
@@ -78,12 +78,14 @@
 
 (defn ^{:stratum 0} peg-mechanisms
   "Mechanism pointers carried by the problems `peg` can land on, from
-   `nodes` ({id node}); empty when none carries one."
+   `nodes` ({id node}); sorted so the choice among several is stable
+   across runs; empty when none carries one."
   [peg nodes]
   (->> (vals (get peg :answers {}))
        (apply concat)
        (keep #(get-in nodes [% :mechanism]))
        distinct
+       sort
        vec))
 
 (defn ^{:stratum 0} gate-answers
@@ -110,19 +112,25 @@
 
 (defn ^{:stratum 1} read-gate-history
   "Every readable line of a run's gate-history.edn as a map; unreadable
-   lines are skipped (a torn last line must not lose the run)."
+   lines are skipped (a torn last line must not lose the run) and an
+   unreadable file yields no entries (one run's IO failure must not
+   abort the scan of a whole checkpoint root)."
   [run-dir]
   (let [f (io/file run-dir gate-history-filename)]
     (if-not (.exists f)
       []
       ;; Streamed line by line: the file is append-only and unbounded.
-      (with-open [rdr (io/reader f)]
-        (into []
-              (keep (fn [line]
-                      (when-not (str/blank? line)
-                        (try (edn/read-string {:default (fn [_ v] v)} line)
-                             (catch Exception _ nil)))))
-              (line-seq rdr))))))
+      ;; Plain try, IOException only (std 211 ex. a): this is the IO
+      ;; boundary of a read-only report.
+      (try
+        (with-open [rdr (io/reader f)]
+          (into []
+                (keep (fn [line]
+                        (when-not (str/blank? line)
+                          (try (edn/read-string {:default (fn [_ v] v)} line)
+                               (catch Exception _ nil)))))
+                (line-seq rdr)))
+        (catch java.io.IOException _ [])))))
 
 (defn ^{:stratum 1} aggregate
   "Fold per-run observations into the §7.7 record per peg."

--- a/components/codex-gap/src/ai/miniforge/codex_gap/peg_telemetry.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/peg_telemetry.clj
@@ -1,0 +1,183 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex-gap.peg-telemetry
+  "T1 SPEC §7.7 per-peg telemetry, computed from records that already
+   exist: the gap ledger's :miss/pegs (which discriminators a
+   consultation presented, with each answer's landing set) and the run's
+   gate-history.edn (every gate decision per iteration).
+
+   A peg's recorded answer is the verdict of the mechanism its landing
+   problem carries (§4.5 `mechanism` pointer): the mapped gate denied in
+   an implement iteration -> the guarded failure occurred; allowed -> it
+   did not. Pegs whose landings carry no mapped mechanism are reported
+   :unobserved -- no answer is invented from prose.
+
+   Two §4.4.1 trigger signatures fall out: answer entropy near zero over
+   enough observations (the question stopped discriminating), and answer
+   branches whose landing sets are identical (the board collapsed under
+   the peg; the remedy is a branch merge, not retirement)."
+  (:require [ai.miniforge.codex-gap.ledger :as ledger]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} mechanism-gate-map-resource
+  "Classpath resource mapping mechanism pointers to gate keywords."
+  "config/codex-gap/mechanism-gate-map.edn")
+
+(def ^{:stratum 0} gate-history-filename
+  "The workflow checkpoint's append-only gate decision record."
+  "gate-history.edn")
+
+(def ^{:stratum 0} min-observations
+  "Observations a peg needs before its entropy can trigger review: below
+   this, a flat distribution is small numbers, not a dead question."
+  10)
+
+(def ^{:stratum 0} entropy-floor-bits
+  "Answer entropy (bits) at or below which a peg has stopped
+   discriminating. 0.2 bits is roughly 97:3 on a binary answer."
+  0.2)
+
+(defn ^{:stratum 0} entropy-bits
+  "Shannon entropy in bits of a {value count} map; 0 for empty."
+  [freqs]
+  (let [total (double (reduce + 0 (vals freqs)))]
+    (if (zero? total)
+      0.0
+      (- (reduce + 0.0
+                 (for [[_ n] freqs :when (pos? n)
+                       :let [p (/ n total)]]
+                   (* p (/ (Math/log p) (Math/log 2)))))))))
+
+(defn ^{:stratum 0} branches-collapsed?
+  "True when every answer of `peg` lands on the same problem set -- the
+   second §4.4.1 signature. A peg with fewer than two answers cannot
+   collapse."
+  [peg]
+  (let [landings (map set (vals (get peg :answers {})))]
+    (and (> (count landings) 1)
+         (apply = landings))))
+
+(defn ^{:stratum 0} peg-mechanisms
+  "Mechanism pointers carried by the problems `peg` can land on, from
+   `nodes` ({id node}); empty when none carries one."
+  [peg nodes]
+  (->> (vals (get peg :answers {}))
+       (apply concat)
+       (keep #(get-in nodes [% :mechanism]))
+       distinct
+       vec))
+
+(defn ^{:stratum 0} gate-answers
+  "The answers a run's gate-history records for `gate`: one per
+   implement iteration, :denied when the gate is among that iteration's
+   failures, :allowed otherwise. Non-implement entries are not answers."
+  [history gate]
+  (into []
+        (comp (filter #(= :implement (:phase %)))
+              (map (fn [entry]
+                     (if (some #(= gate (:gate %)) (:phase/gate-failures entry))
+                       :denied
+                       :allowed))))
+        history))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} load-mechanism-gate-map
+  "The mechanism->gate map, or {} when the resource is absent."
+  []
+  (if-let [r (io/resource mechanism-gate-map-resource)]
+    (edn/read-string (slurp r))
+    {}))
+
+(defn ^{:stratum 1} read-gate-history
+  "Every readable line of a run's gate-history.edn as a map; unreadable
+   lines are skipped (a torn last line must not lose the run)."
+  [run-dir]
+  (let [f (io/file run-dir gate-history-filename)]
+    (if-not (.exists f)
+      []
+      (into []
+            (keep (fn [line]
+                    (when-not (str/blank? line)
+                      (try (edn/read-string {:default (fn [_ v] v)} line)
+                           (catch Exception _ nil)))))
+            (str/split-lines (slurp f))))))
+
+(defn ^{:stratum 1} aggregate
+  "Fold per-run observations into the §7.7 record per peg."
+  [observations]
+  (into (sorted-map)
+        (map (fn [[peg obs]]
+               (let [answers (mapcat :answers obs)
+                     freqs (frequencies answers)
+                     n (count answers)
+                     entropy (entropy-bits freqs)
+                     collapsed (count (filter :collapsed? obs))]
+                 [peg {:runs (count obs)
+                       :mechanism (some :mechanism obs)
+                       :observed? (boolean (some :observed? obs))
+                       :observations n
+                       :answers freqs
+                       :entropy-bits (/ (Math/round (* 1000 entropy)) 1000.0)
+                       :collapsed-runs collapsed
+                       :trigger (cond
+                                  (pos? collapsed) :branches-collapsed
+                                  (and (>= n min-observations) (<= entropy entropy-floor-bits)) :entropy
+                                  :else nil)}])))
+        (group-by :peg observations)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} run-observations
+  "Per distinct peg presented in `run-dir`'s ledger: the answers its
+   mechanism's gate recorded in that run, or :unobserved."
+  [run-dir nodes gate-map]
+  (let [pegs (->> (:entries (ledger/read-ledger (str run-dir)))
+                  (mapcat :miss/pegs)
+                  (filter :id)
+                  (reduce (fn [acc p] (if (contains? acc (:id p)) acc (assoc acc (:id p) p))) {})
+                  vals)
+        history (delay (read-gate-history run-dir))]
+    (for [peg pegs
+          :let [mechanisms (peg-mechanisms peg nodes)
+                gate (some gate-map mechanisms)]]
+      {:peg (:id peg)
+       :mechanism (first mechanisms)
+       :collapsed? (branches-collapsed? peg)
+       :answers (if gate (gate-answers @history gate) [])
+       :observed? (some? gate)})))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} peg-telemetry
+  "The §7.7 record over every run directory under `checkpoint-root`
+   whose ledger presented pegs, using `nodes` ({id node}) for mechanism
+   pointers and `gate-map` for mechanism->gate. Returns
+   {:pegs {peg-id record} :runs-with-pegs n :runs-scanned n}."
+  [checkpoint-root nodes gate-map]
+  (let [run-dirs (->> (.listFiles (io/file checkpoint-root))
+                      (filter #(.isDirectory ^java.io.File %)))
+        per-run (map #(vec (run-observations % nodes gate-map)) run-dirs)
+        obs (vec (apply concat per-run))]
+    {:pegs (aggregate obs)
+     :runs-with-pegs (count (filter seq per-run))
+     :runs-scanned (count run-dirs)}))

--- a/components/codex-gap/src/ai/miniforge/codex_gap/peg_telemetry.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/peg_telemetry.clj
@@ -115,12 +115,14 @@
   (let [f (io/file run-dir gate-history-filename)]
     (if-not (.exists f)
       []
-      (into []
-            (keep (fn [line]
-                    (when-not (str/blank? line)
-                      (try (edn/read-string {:default (fn [_ v] v)} line)
-                           (catch Exception _ nil)))))
-            (str/split-lines (slurp f))))))
+      ;; Streamed line by line: the file is append-only and unbounded.
+      (with-open [rdr (io/reader f)]
+        (into []
+              (keep (fn [line]
+                      (when-not (str/blank? line)
+                        (try (edn/read-string {:default (fn [_ v] v)} line)
+                             (catch Exception _ nil)))))
+              (line-seq rdr))))))
 
 (defn ^{:stratum 1} aggregate
   "Fold per-run observations into the §7.7 record per peg."

--- a/components/codex-gap/test/ai/miniforge/codex_gap/peg_telemetry_test.clj
+++ b/components/codex-gap/test/ai/miniforge/codex_gap/peg_telemetry_test.clj
@@ -36,14 +36,15 @@
 (def ^{:stratum 0} gate-map {"miniforge/gate/stale-references" :stale-references})
 
 (def ^{:stratum 0} drift-peg
-  {:id "did-you-update-every-consumer"
-   :answers {"yes" ["other-problem"] "no" ["contract-drift-is-silent"]}})
+  ;; The production per-peg record: :answer nil, landings under :landings.
+  {:id "did-you-update-every-consumer" :answer nil
+   :landings {"yes" ["other-problem"] "no" ["contract-drift-is-silent"]}})
 
 (def ^{:stratum 0} collapsed-peg
-  {:id "collapsed" :answers {"a" ["other-problem"] "b" ["other-problem"]}})
+  {:id "collapsed" :answer nil :landings {"a" ["other-problem"] "b" ["other-problem"]}})
 
 (def ^{:stratum 0} unmapped-peg
-  {:id "unmapped" :answers {"x" ["unmapped-problem"] "y" ["other-problem"]}})
+  {:id "unmapped" :answer nil :landings {"x" ["unmapped-problem"] "y" ["other-problem"]}})
 
 (defn- ^{:stratum 0} run-dir!
   "A checkpoint run dir with one ledger entry presenting `pegs` and the
@@ -67,7 +68,7 @@
         "a deny on another gate is an allow for this one")))
 
 (deftest ^{:stratum 0} mechanisms-are-sorted-for-stable-choice
-  (let [peg {:id "p" :answers {"a" ["m-b"] "b" ["m-a"]}}
+  (let [peg {:id "p" :answer nil :landings {"a" ["m-b"] "b" ["m-a"]}}
         nodes {"m-a" {:id "m-a" :mechanism "z/mechanism"} "m-b" {:id "m-b" :mechanism "a/mechanism"}}]
     (is (= ["a/mechanism" "z/mechanism"] (sut/peg-mechanisms peg nodes)))))
 
@@ -94,7 +95,9 @@
   (is (= 0.0 (sut/entropy-bits {})))
   (is (true? (sut/branches-collapsed? collapsed-peg)))
   (is (false? (sut/branches-collapsed? drift-peg)))
-  (is (false? (sut/branches-collapsed? {:id "one" :answers {"only" ["x"]}}))))
+  (is (false? (sut/branches-collapsed? {:id "one" :landings {"only" ["x"]}})))
+  (is (true? (sut/branches-collapsed? {:id "raw" :answers {"a" ["x"] "b" ["x"]}}))
+      "the raw codex basis key is read too"))
 
 (deftest ^{:stratum 1} telemetry-over-runs
   (let [root (str (Files/createTempDirectory "peg-telemetry" (make-array FileAttribute 0)))]
@@ -134,7 +137,7 @@
 
 (deftest ^{:stratum 1} reported-mechanism-is-the-one-that-answered
   (let [root (str (Files/createTempDirectory "peg-telemetry-mech" (make-array FileAttribute 0)))
-        peg {:id "two-mechanisms" :answers {"a" ["unmapped-problem"] "b" ["contract-drift-is-silent"]}}]
+        peg {:id "two-mechanisms" :answer nil :landings {"a" ["unmapped-problem"] "b" ["contract-drift-is-silent"]}}]
     (run-dir! root "run-a" [peg]
               [{:phase :implement :decision :deny :phase/gate-failures [{:gate :stale-references}]}])
     (let [rec (get-in (sut/peg-telemetry root nodes gate-map) [:pegs "two-mechanisms"])]

--- a/components/codex-gap/test/ai/miniforge/codex_gap/peg_telemetry_test.clj
+++ b/components/codex-gap/test/ai/miniforge/codex_gap/peg_telemetry_test.clj
@@ -124,3 +124,13 @@
       (is (= {:denied sut/min-observations} (:answers drift)))
       (is (= 0.0 (:entropy-bits drift)))
       (is (= :entropy (:trigger drift))))))
+
+(deftest ^{:stratum 1} reported-mechanism-is-the-one-that-answered
+  (let [root (str (Files/createTempDirectory "peg-telemetry-mech" (make-array FileAttribute 0)))
+        peg {:id "two-mechanisms" :answers {"a" ["unmapped-problem"] "b" ["contract-drift-is-silent"]}}]
+    (run-dir! root "run-a" [peg]
+              [{:phase :implement :decision :deny :phase/gate-failures [{:gate :stale-references}]}])
+    (let [rec (get-in (sut/peg-telemetry root nodes gate-map) [:pegs "two-mechanisms"])]
+      (is (= "miniforge/gate/stale-references" (:mechanism rec))
+          "the unmapped mechanism sorts first but did not answer")
+      (is (= {:denied 1} (:answers rec))))))

--- a/components/codex-gap/test/ai/miniforge/codex_gap/peg_telemetry_test.clj
+++ b/components/codex-gap/test/ai/miniforge/codex_gap/peg_telemetry_test.clj
@@ -79,6 +79,13 @@
     (.mkdirs (io/file dir sut/gate-history-filename))
     (is (= [] (sut/read-gate-history dir)))))
 
+(deftest ^{:stratum 0} aggregate-prefers-the-mechanism-that-answered
+  (let [obs [{:peg "p" :mechanism "no/such/mechanism" :observed? false :answers [] :collapsed? false}
+             {:peg "p" :mechanism "miniforge/gate/stale-references" :observed? true :answers [:denied] :collapsed? false}]]
+    (is (= "miniforge/gate/stale-references" (get-in (sut/aggregate obs) ["p" :mechanism])))
+    (is (= "miniforge/gate/stale-references" (get-in (sut/aggregate (reverse obs)) ["p" :mechanism]))
+        "independent of observation order")))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (deftest ^{:stratum 1} entropy-and-collapse-primitives

--- a/components/codex-gap/test/ai/miniforge/codex_gap/peg_telemetry_test.clj
+++ b/components/codex-gap/test/ai/miniforge/codex_gap/peg_telemetry_test.clj
@@ -66,6 +66,19 @@
     (is (= [:denied :allowed :allowed] (sut/gate-answers history :stale-references))
         "a deny on another gate is an allow for this one")))
 
+(deftest ^{:stratum 0} mechanisms-are-sorted-for-stable-choice
+  (let [peg {:id "p" :answers {"a" ["m-b"] "b" ["m-a"]}}
+        nodes {"m-a" {:id "m-a" :mechanism "z/mechanism"} "m-b" {:id "m-b" :mechanism "a/mechanism"}}]
+    (is (= ["a/mechanism" "z/mechanism"] (sut/peg-mechanisms peg nodes)))))
+
+(deftest ^{:stratum 0} unreadable-gate-history-yields-no-entries
+  (let [root (str (Files/createTempDirectory "peg-telemetry-io" (make-array FileAttribute 0)))
+        dir (io/file root "run-x")]
+    (.mkdirs dir)
+    ;; a directory where the file should be: opening it as a file fails
+    (.mkdirs (io/file dir sut/gate-history-filename))
+    (is (= [] (sut/read-gate-history dir)))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (deftest ^{:stratum 1} entropy-and-collapse-primitives

--- a/components/codex-gap/test/ai/miniforge/codex_gap/peg_telemetry_test.clj
+++ b/components/codex-gap/test/ai/miniforge/codex_gap/peg_telemetry_test.clj
@@ -1,0 +1,113 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex-gap.peg-telemetry-test
+  "§7.7 per-peg telemetry from a ledger plus gate-history: mechanism
+   verdicts are the recorded answers; identical landing sets are a
+   collapsed branch; nothing is invented for unmapped pegs."
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.codex-gap.peg-telemetry :as sut])
+  (:import (java.nio.file Files)
+           (java.nio.file.attribute FileAttribute)))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} nodes
+  {"contract-drift-is-silent" {:id "contract-drift-is-silent" :type "problem"
+                               :mechanism "miniforge/gate/stale-references"}
+   "other-problem" {:id "other-problem" :type "problem"}
+   "unmapped-problem" {:id "unmapped-problem" :type "problem" :mechanism "no/such/mechanism"}})
+
+(def ^{:stratum 0} gate-map {"miniforge/gate/stale-references" :stale-references})
+
+(def ^{:stratum 0} drift-peg
+  {:id "did-you-update-every-consumer"
+   :answers {"yes" ["other-problem"] "no" ["contract-drift-is-silent"]}})
+
+(def ^{:stratum 0} collapsed-peg
+  {:id "collapsed" :answers {"a" ["other-problem"] "b" ["other-problem"]}})
+
+(def ^{:stratum 0} unmapped-peg
+  {:id "unmapped" :answers {"x" ["unmapped-problem"] "y" ["other-problem"]}})
+
+(defn- ^{:stratum 0} run-dir!
+  "A checkpoint run dir with one ledger entry presenting `pegs` and the
+   given gate-history `entries`."
+  [root name pegs entries]
+  (let [dir (io/file root name)]
+    (.mkdirs dir)
+    (spit (io/file dir "codex-gap-ledger.edn")
+          (pr-str {:miss/id (random-uuid) :miss/phase :implement :miss/pegs pegs}))
+    (spit (io/file dir sut/gate-history-filename)
+          (apply str (map #(str (pr-str %) "\n") entries)))
+    dir))
+
+(deftest ^{:stratum 0} gate-answers-read-implement-iterations-only
+  (let [history [{:phase :plan :decision :allow}
+                 {:phase :implement :decision :deny :phase/gate-failures [{:gate :stale-references}]}
+                 {:phase :implement :decision :allow}
+                 {:phase :verify :decision :deny :phase/gate-failures [{:gate :policy-verify}]}
+                 {:phase :implement :decision :deny :phase/gate-failures [{:gate :lint}]}]]
+    (is (= [:denied :allowed :allowed] (sut/gate-answers history :stale-references))
+        "a deny on another gate is an allow for this one")))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} entropy-and-collapse-primitives
+  (is (= 0.0 (sut/entropy-bits {:denied 5})))
+  (is (= 1.0 (sut/entropy-bits {:denied 5 :allowed 5})))
+  (is (= 0.0 (sut/entropy-bits {})))
+  (is (true? (sut/branches-collapsed? collapsed-peg)))
+  (is (false? (sut/branches-collapsed? drift-peg)))
+  (is (false? (sut/branches-collapsed? {:id "one" :answers {"only" ["x"]}}))))
+
+(deftest ^{:stratum 1} telemetry-over-runs
+  (let [root (str (Files/createTempDirectory "peg-telemetry" (make-array FileAttribute 0)))]
+    (run-dir! root "run-a" [drift-peg collapsed-peg unmapped-peg]
+              [{:phase :implement :decision :deny :phase/gate-failures [{:gate :stale-references}]}
+               {:phase :implement :decision :allow}])
+    (run-dir! root "run-b" [drift-peg]
+              [{:phase :implement :decision :deny :phase/gate-failures [{:gate :stale-references}]}])
+    (.mkdirs (io/file root "run-c-no-ledger"))
+    (let [{:keys [pegs runs-with-pegs runs-scanned]} (sut/peg-telemetry root nodes gate-map)
+          drift (get pegs "did-you-update-every-consumer")]
+      (testing "runs are counted honestly"
+        (is (= 3 runs-scanned))
+        (is (= 2 runs-with-pegs)))
+      (testing "the mechanism's verdicts are the recorded answers"
+        (is (= "miniforge/gate/stale-references" (:mechanism drift)))
+        (is (= {:denied 2 :allowed 1} (:answers drift)))
+        (is (= 3 (:observations drift)))
+        (is (true? (:observed? drift)))
+        (is (nil? (:trigger drift)) "three observations cannot trigger"))
+      (testing "a collapsed branch triggers regardless of counts"
+        (is (= :branches-collapsed (:trigger (get pegs "collapsed")))))
+      (testing "an unmapped mechanism yields no answers and no trigger"
+        (let [u (get pegs "unmapped")]
+          (is (false? (:observed? u)))
+          (is (= {} (:answers u)))
+          (is (nil? (:trigger u))))))))
+
+(deftest ^{:stratum 1} entropy-trigger-needs-enough-observations
+  (let [root (str (Files/createTempDirectory "peg-telemetry-ent" (make-array FileAttribute 0)))
+        deny {:phase :implement :decision :deny :phase/gate-failures [{:gate :stale-references}]}]
+    (run-dir! root "run-a" [drift-peg] (repeat sut/min-observations deny))
+    (let [drift (get-in (sut/peg-telemetry root nodes gate-map) [:pegs "did-you-update-every-consumer"])]
+      (is (= {:denied sut/min-observations} (:answers drift)))
+      (is (= 0.0 (:entropy-bits drift)))
+      (is (= :entropy (:trigger drift))))))


### PR DESCRIPTION
## Summary

Thesium Codex SPEC §7.7 requires per-peg telemetry (answer distribution and routing relevance) with no new collection surface; until it exists §4.4's retirement trigger cannot fire. This computes it from records miniforge already writes.

- A peg's recorded answer is the verdict of the mechanism its landing problem carries (`mechanism` pointer, SPEC §4.5), mapped to a gate keyword by `config/codex-gap/mechanism-gate-map.edn` (today: `miniforge/gate/stale-references` → `:stale-references`). Per implement iteration in the run's `gate-history.edn`: `:denied` when that gate is among the failures, `:allowed` otherwise.
- Pegs whose landings carry no mapped mechanism are reported `:observed? false` with no answers. Nothing is inferred from prose.
- Two §4.4.1 trigger signatures: `:entropy` (≤ 0.2 bits over ≥ 10 observations) and `:branches-collapsed` (every answer lands on the same problem set).
- `bb codex-gap-peg-telemetry [checkpoint-root]` prints the record; the codex comes from `MINIFORGE_CODEX_PATH`.

Data note: every bench series since gate-history shipped (#1860) ran the baseline arm, so those ledgers carry no `:miss/pegs`; the earlier treated-arm ledgers predate gate-history. The first real record needs a treated-arm series at the current pin (planned as series 8). The tool is tested on synthetic runs.

Commits unsigned: the local signing agent is refusing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)