### PR TITLE
fix(verify): sum every namespace and put the failing tests in front of the implementer

### DIFF
--- a/components/phase-software-factory/resources/config/phase/messages/en-US.edn
+++ b/components/phase-software-factory/resources/config/phase/messages/en-US.edn
@@ -31,6 +31,7 @@
   :verify/no-environment-hint "Workflow runner must acquire an execution environment before verify phase"
   :verify/tests-passed        "All {pass-count} test(s) passed"
   :verify/tests-failed        "Tests failed: {fail-count} failure(s), {error-count} error(s)"
+  :verify/failing-tests       "Failing: {tests}"
   :verify/output-unparseable  "Test output could not be parsed"
   :verify/gate-failed         "Gate validation failed"
   :verify/failed              "Verification failed"

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -337,6 +337,14 @@
   [ctx ex]
   (phase/handle-error ctx ex 5))
 
+(defn- ^{:stratum 0} render-failure-block
+  "One parsed failure back in clojure.test's own shape, so the implementer
+   reads it exactly as a local run would print it."
+  [{:keys [kind test location detail]}]
+  (str (if (= :fail kind) "FAIL" "ERROR") " in (" test ")"
+       (when location (str " (" location ")"))
+       (when-not (str/blank? detail) (str "\n" detail))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} truncate-test-output
@@ -452,15 +460,16 @@
 
 ;------------------------------------------------------------------------------ Layer 2
 
-(defn- ^{:stratum 2} build-verify-failures
-  "Extract lean verify-failure data from phase results.
-   In the environment model, test metrics are in :result :metrics."
-  [verify-result]
-  {:test-results {:pass-count (get-in verify-result [:result :metrics :pass-count] 0)
-                  :fail-count (get-in verify-result [:result :metrics :fail-count] 0)
-                  :summary    (get-in verify-result [:result :summary])}
-   :test-output (truncate-test-output
-                 (get-in verify-result [:result :metrics :test-output]))})
+(defn- ^{:stratum 2} failure-focused-output
+  "The failure blocks first, verbatim, then the head/tail excerpt. Head and
+   tail alone lost every failure of a 6,000-line run (series 8, 2026-09-04):
+   the first namespace's clean summary was the head, the runner's epilogue
+   the tail, and the three FAIL blocks sat in the omitted middle."
+  [failures output]
+  (let [excerpt (truncate-test-output output)]
+    (if (seq failures)
+      (str (str/join "\n\n" (map render-failure-block failures)) "\n\n" excerpt)
+      excerpt)))
 
 (defn- ^{:stratum 2} rate-limit-in-result?
   "Check if an agent result indicates an infrastructure failure that
@@ -477,72 +486,17 @@
 
 ;------------------------------------------------------------------------------ Layer 3
 
-(defn ^{:stratum 3} build-implement-task
-  "Build the task map for the implementer agent from execution context.
-   Returns {:task task-map :rules-manifest manifest-or-nil}."
-  [ctx]
-  (let [input (get-in ctx [:execution/input])
-        plan-result (get-in ctx [:execution/phase-results :plan :result :output])
-        verify-failure (get-in ctx [:execution/phase-results :verify])
-        worktree-path (resolve-worktree-path ctx)
-        files-in-scope (resolve-files-in-scope input)
-        pack-ctx (or (get-in ctx [:execution/pack-context])
-                     (build-context-pack worktree-path files-in-scope))
-        existing-files (resolve-existing-files ctx pack-ctx worktree-path files-in-scope)
-        ;; Thesium Codex blackboard pin (SPEC §7.4): pinned FIRST so the
-        ;; worries render before the content they apply to. Retry iterations
-        ;; reuse :execution/cached-files which already contains the previous
-        ;; pin — drop it so the fresh consultation replaces it instead of
-        ;; rendering twice.
-        codex-outcome (codex-pin/pin-outcome :implement (get-in ctx [:execution/logger]))
-        existing-files (vec (remove #(= codex-pin/pin-path (:path %))
-                                    (or existing-files [])))
-        existing-files (if-let [pin (:entry codex-outcome)]
-                         (into [pin] existing-files)
-                         existing-files)
-        behavior-addendum (phase/load-guidance-addendum
-                            :implement {:task {:task/intent (:intent input)}})
-        review-feedback (resolve-review-feedback ctx)
-        phase-handoff (resolve-phase-handoff ctx)
-        ;; A prior implement attempt DENIED by gates: its structured gate
-        ;; errors ride :execution/phase-results (the [:phase ...] channel
-        ;; is cleared before every step). This is what turns a gate from
-        ;; a wall into a repair instruction — deny, retry with the
-        ;; evidence, fix, pass.
-        gate-failures (seq (get-in ctx [:execution/phase-results
-                                        :implement :phase/gate-failures]))
-        {:keys [formatted manifest]} (kb-helpers/inject-with-manifest
-                                       (:knowledge-store ctx) :implementer (get input :tags []))
-        base-task (assoc-optional-task-fields
-                    {:task/id (random-uuid)
-                     :task/type :implement
-                     :task/description (:description input)
-                     :task/title (:title input)
-                     :task/intent (:intent input)
-                     :task/constraints (:constraints input)
-                     :task/plan plan-result
-                     :task/existing-files existing-files
-                     :task/behavior-addendum behavior-addendum}
-                    pack-ctx formatted)
-        iteration (get-in ctx [:phase :iterations] 0)
-        last-error (get-in ctx [:phase :last-error])
-        task (cond-> base-task
-               verify-failure
-               (assoc :task/verify-failures (build-verify-failures verify-failure))
-               gate-failures
-               (assoc :task/gate-failures (vec gate-failures))
-               review-feedback
-               (assoc :task/review-feedback review-feedback)
-               phase-handoff
-               (assoc :task/phase-handoff phase-handoff)
-               (pos? iteration)
-               (assoc :task/prior-attempts
-                      {:attempt-number (inc iteration)
-                       :prior-error    (or last-error (messages/t :implement/prior-error-default))
-                       :instruction    (messages/t :implement/retry-instruction)}))]
-    {:task task
-     :rules-manifest manifest
-     :codex-outcome codex-outcome}))
+(defn- ^{:stratum 3} build-verify-failures
+  "Extract lean verify-failure data from phase results.
+   In the environment model, test metrics are in :result :metrics."
+  [verify-result]
+  (let [metrics  (get-in verify-result [:result :metrics])
+        failures (get metrics :failures [])]
+    {:test-results (cond-> {:pass-count (get metrics :pass-count 0)
+                            :fail-count (get metrics :fail-count 0)
+                            :summary    (get-in verify-result [:result :summary])}
+                     (seq failures) (assoc :failing-tests (mapv :test failures)))
+     :test-output (failure-focused-output failures (get metrics :test-output))}))
 
 (defn ^{:stratum 3} leave-implement
   "Post-processing for implementation phase.
@@ -754,7 +708,76 @@
 
 ;------------------------------------------------------------------------------ Layer 4
 
-(defn ^{:stratum 4} enter-implement
+(defn ^{:stratum 4} build-implement-task
+  "Build the task map for the implementer agent from execution context.
+   Returns {:task task-map :rules-manifest manifest-or-nil}."
+  [ctx]
+  (let [input (get-in ctx [:execution/input])
+        plan-result (get-in ctx [:execution/phase-results :plan :result :output])
+        verify-failure (get-in ctx [:execution/phase-results :verify])
+        worktree-path (resolve-worktree-path ctx)
+        files-in-scope (resolve-files-in-scope input)
+        pack-ctx (or (get-in ctx [:execution/pack-context])
+                     (build-context-pack worktree-path files-in-scope))
+        existing-files (resolve-existing-files ctx pack-ctx worktree-path files-in-scope)
+        ;; Thesium Codex blackboard pin (SPEC §7.4): pinned FIRST so the
+        ;; worries render before the content they apply to. Retry iterations
+        ;; reuse :execution/cached-files which already contains the previous
+        ;; pin — drop it so the fresh consultation replaces it instead of
+        ;; rendering twice.
+        codex-outcome (codex-pin/pin-outcome :implement (get-in ctx [:execution/logger]))
+        existing-files (vec (remove #(= codex-pin/pin-path (:path %))
+                                    (or existing-files [])))
+        existing-files (if-let [pin (:entry codex-outcome)]
+                         (into [pin] existing-files)
+                         existing-files)
+        behavior-addendum (phase/load-guidance-addendum
+                            :implement {:task {:task/intent (:intent input)}})
+        review-feedback (resolve-review-feedback ctx)
+        phase-handoff (resolve-phase-handoff ctx)
+        ;; A prior implement attempt DENIED by gates: its structured gate
+        ;; errors ride :execution/phase-results (the [:phase ...] channel
+        ;; is cleared before every step). This is what turns a gate from
+        ;; a wall into a repair instruction — deny, retry with the
+        ;; evidence, fix, pass.
+        gate-failures (seq (get-in ctx [:execution/phase-results
+                                        :implement :phase/gate-failures]))
+        {:keys [formatted manifest]} (kb-helpers/inject-with-manifest
+                                       (:knowledge-store ctx) :implementer (get input :tags []))
+        base-task (assoc-optional-task-fields
+                    {:task/id (random-uuid)
+                     :task/type :implement
+                     :task/description (:description input)
+                     :task/title (:title input)
+                     :task/intent (:intent input)
+                     :task/constraints (:constraints input)
+                     :task/plan plan-result
+                     :task/existing-files existing-files
+                     :task/behavior-addendum behavior-addendum}
+                    pack-ctx formatted)
+        iteration (get-in ctx [:phase :iterations] 0)
+        last-error (get-in ctx [:phase :last-error])
+        task (cond-> base-task
+               verify-failure
+               (assoc :task/verify-failures (build-verify-failures verify-failure))
+               gate-failures
+               (assoc :task/gate-failures (vec gate-failures))
+               review-feedback
+               (assoc :task/review-feedback review-feedback)
+               phase-handoff
+               (assoc :task/phase-handoff phase-handoff)
+               (pos? iteration)
+               (assoc :task/prior-attempts
+                      {:attempt-number (inc iteration)
+                       :prior-error    (or last-error (messages/t :implement/prior-error-default))
+                       :instruction    (messages/t :implement/retry-instruction)}))]
+    {:task task
+     :rules-manifest manifest
+     :codex-outcome codex-outcome}))
+
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} enter-implement
   "Execute implementation phase.
 
    Reads plan from context, invokes implementer agent,
@@ -955,10 +978,10 @@
         (assoc-in [:phase :watchdog-state]
                   {:stalled? stalled? :stall/gap-duration-ms gap-ms}))))
 
-;------------------------------------------------------------------------------ Layer 5
+;------------------------------------------------------------------------------ Layer 6
 
 ;; Registry method
-(defmethod ^{:stratum 5} phase/get-phase-interceptor-method :implement
+(defmethod ^{:stratum 6} phase/get-phase-interceptor-method :implement
   [config]
   (let [merged (phase/merge-with-defaults config)]
     {:name ::implement

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
@@ -442,19 +442,22 @@
           summary-any? (some? (re-find namespace-summary-pattern output))]
       (if (and ran-any? summary-any?)
         (let [fail-count  (sum-groups namespace-summary-pattern 1 output)
-              error-count (sum-groups namespace-summary-pattern 2 output)]
-          ;; Exit code is authoritative alongside the parsed counts: a brick
-          ;; whose tests fail to COMPILE (or a runner that exits non-zero for
-          ;; any reason) can still leave a "Ran N tests ... 0 failures, 0
-          ;; errors" line from OTHER bricks in the output. Requiring a zero
-          ;; exit too means such a run fails verify instead of being reported
-          ;; as passing on the text alone.
-          {:passed? (and (zero? fail-count) (zero? error-count) (zero? exit-code))
+              error-count (sum-groups namespace-summary-pattern 2 output)
+              ;; Exit code is authoritative alongside the parsed counts: a brick
+              ;; whose tests fail to COMPILE (or a runner that exits non-zero for
+              ;; any reason) can still leave a "Ran N tests ... 0 failures, 0
+              ;; errors" line from OTHER bricks in the output. Requiring a zero
+              ;; exit too means such a run fails verify instead of being reported
+              ;; as passing on the text alone.
+              passed?     (and (zero? fail-count) (zero? error-count) (zero? exit-code))
+              ;; A passing run has no blocks to find; skip the scan.
+              failures    (if passed? [] (failure-blocks output))]
+          {:passed? passed?
            :test-count (sum-groups ran-tests-pattern 1 output)
            :assertion-count (sum-groups ran-tests-pattern 2 output)
            :fail-count fail-count
            :error-count (synthesized-error-count fail-count error-count exit-code)
-           :failures (failure-blocks output)
+           :failures failures
            :output output})
         (assoc (test-error-result output) :parse-error? true)))))
 

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
@@ -393,7 +393,7 @@
 
 ;------------------------------------------------------------------------------ Layer 3
 
-(defn ^{:stratum 3} failure-blocks
+(defn- ^{:stratum 3} failure-blocks
   "Every `FAIL in` / `ERROR in` block in clojure.test output, in order,
    capped at `max-failure-blocks`. Names the failing tests so a consumer
    three namespaces into a 6,000-line run is not hidden behind the first

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
@@ -67,6 +67,42 @@
   "Suffix appended when test-runner output is truncated for display."
   "\n...")
 
+(def ^{:stratum 0} ^:private ran-tests-pattern
+  "clojure.test's per-namespace count line. A Polylith run prints one per
+   namespace; the run's totals are the SUM over every match, never the
+   first match alone (series 8, 2026-09-04: the first namespace's
+   `Ran 3 tests` stood in for a 911-namespace run)."
+  #"Ran (\d+) tests? containing (\d+) assertions?")
+
+(def ^{:stratum 0} ^:private namespace-summary-pattern
+  "clojure.test's per-namespace `F failures, E errors.` line, anchored to
+   the start of a line so the runner's per-project roll-up
+   (`Test results: N passes, F failures, E errors.`), which repeats the
+   same numbers, is not counted a second time."
+  #"(?m)^(\d+) failures?,\s*(\d+) errors?")
+
+(def ^{:stratum 0} ^:private failure-header-pattern
+  "One clojure.test failure header: `FAIL in (test-name) (file:line)` or
+   `ERROR in (test-name) (file:line)`. The location group is optional —
+   a fixture that throws before any test runs prints none."
+  #"^(FAIL|ERROR) in \(([^)]*)\)(?: \(([^)]*)\))?")
+
+(def ^{:stratum 0} ^:private max-failure-blocks
+  "Failure blocks kept per run. A compile error can fail every test in a
+   namespace; twenty shows the pattern without flooding the implementer
+   prompt."
+  20)
+
+(def ^{:stratum 0} ^:private max-failure-block-lines
+  "Detail lines kept under one failure header — the `expected:`/`actual:`
+   pair plus a short stack is enough to act on."
+  12)
+
+(def ^{:stratum 0} ^:private max-named-failures
+  "Failing test names spelled out in the verify summary; any beyond this
+   are counted, not listed."
+  5)
+
 ;------------------------------------------------------------------------------ Layer 0.5
 ;; Test execution helpers
 (defn- ^{:stratum 0} test-error-result
@@ -176,64 +212,43 @@
   [ctx ex]
   (phase/handle-error ctx ex 3))
 
+(defn- ^{:stratum 0} sum-groups
+  "Sum capture group `group` over every match of `pattern` in `output`."
+  [pattern group output]
+  (reduce + 0 (map #(parse-long (nth % group)) (re-seq pattern output))))
+
+(defn- ^{:stratum 0} synthesized-error-count
+  "The parsed error count, or one phantom error when every parsed count is
+   clean yet the runner exited non-zero (a brick that failed to compile
+   leaves no summary line). Counted failures are never topped up."
+  [fail-count error-count exit-code]
+  (if (and (zero? fail-count) (zero? error-count) (not (zero? exit-code)))
+    1
+    error-count))
+
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} parse-test-output
-  "Parse test summary output. Handles Clojure (bb test) and Rust (cargo test) formats.
+(defn- ^{:stratum 1} failure-detail-line?
+  "A line that still belongs to the failure block above it: non-blank and
+   not the next failure header."
+  [line]
+  (and (not (str/blank? line))
+       (nil? (re-find failure-header-pattern line))))
 
-   Clojure: 'Ran N tests containing M assertions. F failures, E errors.'
-   Rust:    'test result: ok. N passed; M failed; ...' (exit code is authoritative)"
-  [output exit-code]
-  (cond
-    (re-find #"(?i)No changed bricks|nothing to test" output)
-    ;; "Nothing to test" is only a pass when the runner ALSO exited cleanly. A
-    ;; non-zero exit alongside this text means the runner failed to discover or
-    ;; compile the test namespaces (e.g. a load/compile error before any test
-    ;; ran) — that must not be reported as success.
-    ;; A non-zero exit is reflected as one error so the downstream failure
-    ;; message/metrics don't read "0 failures, 0 errors" on a failed run.
-    {:passed? (zero? exit-code) :test-count 0 :assertion-count 0 :fail-count 0
-     :error-count (if (zero? exit-code) 0 1)
-     :no-tests? true :output output}
+(defn- ^{:stratum 1} failure-header-index
+  "Index of `line` when it is a failure header, else nil (for keep-indexed)."
+  [index line]
+  (when (re-find failure-header-pattern line)
+    index))
 
-    ;; Rust / cargo test
-    (re-find #"test result:" output)
-    (let [result-match (re-find #"test result: (\w+)\. (\d+) passed; (\d+) failed" output)
-          passed (if result-match (parse-long (nth result-match 2)) 0)
-          failed (if result-match (parse-long (nth result-match 3)) 0)]
-      {:passed? (zero? exit-code)
-       :test-count (+ passed failed)
-       :assertion-count (+ passed failed)
-       :fail-count failed
-       :error-count 0
-       :output output})
-
-    ;; Clojure / bb test
-    :else
-    (let [ran-match  (re-find #"Ran (\d+) tests? containing (\d+) assertions?" output)
-          fail-match (re-find #"(\d+) failures?,\s*(\d+) errors?" output)]
-      (if (and ran-match fail-match)
-        (let [test-count  (parse-long (nth ran-match 1))
-              fail-count  (parse-long (nth fail-match 1))
-              error-count (parse-long (nth fail-match 2))]
-          ;; Exit code is authoritative alongside the parsed counts: a brick
-          ;; whose tests fail to COMPILE (or a runner that exits non-zero for
-          ;; any reason) can still leave a "Ran N tests ... 0 failures, 0
-          ;; errors" line from OTHER bricks in the output. Requiring a zero
-          ;; exit too means such a run fails verify instead of being reported
-          ;; as passing on the text alone.
-          {:passed? (and (zero? fail-count) (zero? error-count) (zero? exit-code))
-           :test-count test-count
-           :assertion-count (parse-long (nth ran-match 2))
-           :fail-count fail-count
-           ;; If the parsed counts are clean but the runner exited non-zero
-           ;; (e.g. another brick failed to compile), reflect that as at least
-           ;; one error so the failure metrics/message don't read "0 errors".
-           :error-count (if (and (zero? error-count) (not (zero? exit-code)))
-                          1
-                          error-count)
-           :output output})
-        (assoc (test-error-result output) :parse-error? true)))))
+(defn- ^{:stratum 1} failing-test-list
+  "Comma-separated failing test names, at most `max-named-failures`, with
+   the remainder counted."
+  [names]
+  (let [shown (take max-named-failures names)
+        extra (- (count names) (count shown))]
+    (cond-> (str/join ", " shown)
+      (pos? extra) (str " (+" extra " more)"))))
 
 (defn- ^{:stratum 1} bounded-output-preview
   "Return a bounded, trimmed preview of test runner output."
@@ -341,6 +356,19 @@
 
 ;------------------------------------------------------------------------------ Layer 2
 
+(defn- ^{:stratum 2} failure-block
+  "The failure header at the head of `lines` plus its detail lines, bounded
+   by `max-failure-block-lines`."
+  [lines]
+  (let [[_ kind test-name location] (re-find failure-header-pattern (first lines))
+        detail (->> (rest lines)
+                    (take-while failure-detail-line?)
+                    (take max-failure-block-lines))]
+    {:kind     (if (= "FAIL" kind) :fail :error)
+     :test     test-name
+     :location location
+     :detail   (str/join "\n" detail)}))
+
 (defn- ^{:stratum 2} verify-failure-message
   "Build the user-facing verify failure message from parsed test results."
   [test-results raw-fails raw-errors]
@@ -357,9 +385,82 @@
            (str "\n" preview)))
 
     :else
-    (messages/t :verify/tests-failed {:fail-count raw-fails :error-count raw-errors})))
+    (let [names (map :test (:failures test-results))
+          counts (messages/t :verify/tests-failed {:fail-count raw-fails :error-count raw-errors})]
+      (cond-> counts
+        (seq names) (str " " (messages/t :verify/failing-tests
+                                         {:tests (failing-test-list names)}))))))
 
-(defn ^{:stratum 2} run-tests!
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} failure-blocks
+  "Every `FAIL in` / `ERROR in` block in clojure.test output, in order,
+   capped at `max-failure-blocks`. Names the failing tests so a consumer
+   three namespaces into a 6,000-line run is not hidden behind the first
+   namespace's clean summary."
+  [output]
+  (let [lines (vec (str/split-lines (str output)))]
+    (->> (keep-indexed failure-header-index lines)
+         (take max-failure-blocks)
+         (mapv #(failure-block (subvec lines %))))))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} parse-test-output
+  "Parse test summary output. Handles Clojure (bb test) and Rust (cargo test) formats.
+
+   Clojure: 'Ran N tests containing M assertions. F failures, E errors.'
+   Rust:    'test result: ok. N passed; M failed; ...' (exit code is authoritative)"
+  [output exit-code]
+  (cond
+    (re-find #"(?i)No changed bricks|nothing to test" output)
+    ;; "Nothing to test" is only a pass when the runner ALSO exited cleanly. A
+    ;; non-zero exit alongside this text means the runner failed to discover or
+    ;; compile the test namespaces (e.g. a load/compile error before any test
+    ;; ran) — that must not be reported as success.
+    ;; A non-zero exit is reflected as one error so the downstream failure
+    ;; message/metrics don't read "0 failures, 0 errors" on a failed run.
+    {:passed? (zero? exit-code) :test-count 0 :assertion-count 0 :fail-count 0
+     :error-count (if (zero? exit-code) 0 1)
+     :no-tests? true :output output}
+
+    ;; Rust / cargo test
+    (re-find #"test result:" output)
+    (let [result-match (re-find #"test result: (\w+)\. (\d+) passed; (\d+) failed" output)
+          passed (if result-match (parse-long (nth result-match 2)) 0)
+          failed (if result-match (parse-long (nth result-match 3)) 0)]
+      {:passed? (zero? exit-code)
+       :test-count (+ passed failed)
+       :assertion-count (+ passed failed)
+       :fail-count failed
+       :error-count 0
+       :output output})
+
+    ;; Clojure / bb test
+    :else
+    (let [ran-any?     (some? (re-find ran-tests-pattern output))
+          summary-any? (some? (re-find namespace-summary-pattern output))]
+      (if (and ran-any? summary-any?)
+        (let [fail-count  (sum-groups namespace-summary-pattern 1 output)
+              error-count (sum-groups namespace-summary-pattern 2 output)]
+          ;; Exit code is authoritative alongside the parsed counts: a brick
+          ;; whose tests fail to COMPILE (or a runner that exits non-zero for
+          ;; any reason) can still leave a "Ran N tests ... 0 failures, 0
+          ;; errors" line from OTHER bricks in the output. Requiring a zero
+          ;; exit too means such a run fails verify instead of being reported
+          ;; as passing on the text alone.
+          {:passed? (and (zero? fail-count) (zero? error-count) (zero? exit-code))
+           :test-count (sum-groups ran-tests-pattern 1 output)
+           :assertion-count (sum-groups ran-tests-pattern 2 output)
+           :fail-count fail-count
+           :error-count (synthesized-error-count fail-count error-count exit-code)
+           :failures (failure-blocks output)
+           :output output})
+        (assoc (test-error-result output) :parse-error? true)))))
+
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} run-tests!
   "Run tests in the worktree. Infers the test command from the repo structure
    unless test-cmd is supplied explicitly.
 
@@ -405,7 +506,7 @@
       (catch Exception e
         (test-error-result (.getMessage e))))))
 
-(defn ^{:stratum 2} run-tests-in-capsule!
+(defn ^{:stratum 5} run-tests-in-capsule!
   "Run tests inside a task capsule via execute-fn (N11 §6).
    Routes the test command through the executor instead of host process/shell.
    execute-fn is dag-exec/execute! passed through context to avoid cross-component requires.
@@ -440,9 +541,9 @@
       (catch Exception e
         (test-error-result (.getMessage e))))))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 6
 
-(defn ^{:stratum 3} enter-verify
+(defn ^{:stratum 6} enter-verify
   "Execute verification phase.
 
    Runs the test suite directly inside the executor environment.
@@ -502,7 +603,9 @@
                                                 (+ raw-fails raw-errors)
                                                 (get test-results :output ""))
                      (:parse-error? test-results)
-                     (assoc :parse-error? true))
+                     (assoc :parse-error? true)
+                     (seq (:failures test-results))
+                     (assoc :failures (:failures test-results)))
         summary    (if passed?
                      (messages/t :verify/tests-passed {:pass-count pass-count})
                      (verify-failure-message test-results raw-fails raw-errors))
@@ -512,10 +615,10 @@
 
     (phase/enter-context ctx :verify nil gates budget start-time result)))
 
-;------------------------------------------------------------------------------ Layer 4
+;------------------------------------------------------------------------------ Layer 7
 
 ;; Registry method
-(defmethod ^{:stratum 4} phase/get-phase-interceptor-method :verify
+(defmethod ^{:stratum 7} phase/get-phase-interceptor-method :verify
   [config]
   (let [merged (phase/merge-with-defaults config)]
     {:name ::verify

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -21,6 +21,7 @@
   Tests artifact creation, validation, and error handling."
   (:require
    [clojure.test :refer [deftest testing is use-fixtures]]
+   [clojure.string :as str]
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.phase-software-factory.implement :as implement]
    [ai.miniforge.phase.interface :as phase]
@@ -1022,6 +1023,39 @@
   (testing "no prior denial -> key absent"
     (let [{:keys [task]} (implement/build-implement-task (create-base-context))]
       (is (not (contains? task :task/gate-failures))))))
+
+(deftest ^{:stratum 2} build-implement-task-puts-failing-tests-in-front-test
+  ;; Series 8 (2026-09-04): head 30 + tail 25 lines of a 6,681-line run
+  ;; carried no FAIL block; the implementer re-ran the suite itself and
+  ;; blamed unrelated timeout noise, five times, to the redirect cap.
+  (testing "verify's FAIL blocks lead the excerpt and their names ride on
+            :test-results, however long the raw run"
+    (let [filler (str/join "\n" (repeat 3000 "Ran 3 tests containing 4 assertions.\n0 failures, 0 errors."))
+          failure {:kind :fail
+                   :test "recording-is-a-no-op-without-a-configured-codex"
+                   :location "gap_wiring_test.clj:106"
+                   :detail "expected: {:skipped 0}\n  actual: {:torn-lines 0}"}
+          ctx (assoc-in (create-base-context) [:execution/phase-results :verify]
+                        {:result {:status :error
+                                  :summary "Tests failed: 1 failure(s), 0 error(s)"
+                                  :metrics {:pass-count 10 :fail-count 1
+                                            :failures [failure] :test-output filler}}})
+          {:keys [task]} (implement/build-implement-task ctx)
+          {:keys [test-results test-output]} (:task/verify-failures task)]
+      (is (= ["recording-is-a-no-op-without-a-configured-codex"] (:failing-tests test-results)))
+      (is (str/starts-with? test-output
+                            "FAIL in (recording-is-a-no-op-without-a-configured-codex) (gap_wiring_test.clj:106)"))
+      (is (str/includes? test-output "actual: {:torn-lines 0}"))
+      (is (str/includes? test-output "lines omitted")
+          "the head/tail excerpt still follows the blocks")))
+  (testing "no failure blocks -> the excerpt alone, no :failing-tests key"
+    (let [ctx (assoc-in (create-base-context) [:execution/phase-results :verify]
+                        {:result {:status :error :summary "Tests failed: 0 failure(s), 1 error(s)"
+                                  :metrics {:pass-count 0 :fail-count 1 :test-output "boom"}}})
+          {:keys [task]} (implement/build-implement-task ctx)
+          {:keys [test-results test-output]} (:task/verify-failures task)]
+      (is (= "boom" test-output))
+      (is (not (contains? test-results :failing-tests))))))
 
 (deftest ^{:stratum 2} gate-denial-evidence-reaches-the-rendered-prompt-test
   (testing "end to end: a stored denied attempt -> build-implement-task ->

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_failure_modes_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_failure_modes_test.clj
@@ -89,6 +89,20 @@
            :execution/metrics {:tokens 0 :duration-ms 0}}
     on-fail (assoc :phase-config {:on-fail on-fail})))
 
+(def ^{:stratum 0} ^:private multi-namespace-run
+  "Two namespaces the way the Polylith runner prints them: the first clean,
+   the second with one failure, then the runner's colored project roll-up
+   that repeats the same numbers."
+  (str "Testing ai.miniforge.anomaly.interface.timestamp-test\n\n"
+       "Ran 3 tests containing 4 assertions.\n0 failures, 0 errors.\n\n"
+       "Testing ai.miniforge.phase-software-factory.gap-wiring-test\n\n"
+       "FAIL in (recording-is-a-no-op-without-a-configured-codex) (gap_wiring_test.clj:106)\n"
+       "no codex configured -> no gap to measure -> nothing written\n"
+       "expected: (= {:entries [], :skipped 0} (gap/read-ledger dir))\n"
+       "  actual: (not (= {:entries [], :skipped 0} {:entries [], :torn-lines 0}))\n\n"
+       "Ran 7 tests containing 16 assertions.\n1 failures, 0 errors.\n\n"
+       "\u001b[31mTest results: 15 passes, 1 failures, 0 errors.\u001b[0m\n"))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} with-passing-tests [body-fn]
@@ -265,6 +279,42 @@
           result (verify/leave-verify ctx)]
       (is (= :exhausted (get-in result [:phase :verdict])))
       (is (phase/failed? (get result :phase))))))
+
+(deftest ^{:stratum 1} parse-test-output-sums-every-namespace-test
+  ;; Series 8 (2026-09-04): the first namespace's "Ran 3 tests ... 0
+  ;; failures" stood in for a 911-namespace run, so the summary read
+  ;; "0 failure(s), 1 error(s)" while three FAIL blocks sat in the middle.
+  (testing "counts are the sum over namespaces, not the first match"
+    (let [r (verify/parse-test-output multi-namespace-run 1)]
+      (is (false? (:passed? r)))
+      (is (= 10 (:test-count r)))
+      (is (= 20 (:assertion-count r)))
+      (is (= 1 (:fail-count r)))
+      (is (= 0 (:error-count r))
+          "a counted failure is never topped up with a phantom error")))
+  (testing "the roll-up line is not counted a second time"
+    (is (= 1 (:fail-count (verify/parse-test-output multi-namespace-run 1))))))
+
+(deftest ^{:stratum 1} parse-test-output-names-failing-tests-test
+  (testing "every FAIL block is kept with its name, location and detail"
+    (let [[block :as failures] (:failures (verify/parse-test-output multi-namespace-run 1))]
+      (is (= 1 (count failures)))
+      (is (= :fail (:kind block)))
+      (is (= "recording-is-a-no-op-without-a-configured-codex" (:test block)))
+      (is (= "gap_wiring_test.clj:106" (:location block)))
+      (is (str/includes? (:detail block) "actual: (not (= {:entries [], :skipped 0} {:entries [], :torn-lines 0}))"))
+      (is (not (str/includes? (:detail block) "Ran 7 tests"))
+          "the block stops at the blank line")))
+  (testing "an ERROR header without a location parses too"
+    (let [output (str "ERROR in (boom-test)\njava.lang.Exception: kaboom\n\n"
+                      "Ran 1 tests containing 1 assertions.\n0 failures, 1 errors.\n")
+          [block] (:failures (verify/parse-test-output output 1))]
+      (is (= :error (:kind block)))
+      (is (= "boom-test" (:test block)))
+      (is (nil? (:location block)))
+      (is (= "java.lang.Exception: kaboom" (:detail block)))))
+  (testing "a clean run has no failure blocks"
+    (is (= [] (:failures (verify/parse-test-output "Ran 3 tests containing 4 assertions.\n0 failures, 0 errors.\n" 0))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_test.clj
@@ -49,7 +49,7 @@
                      :intent "testing"}
    :execution/metrics {:tokens 0 :duration-ms 0}})
 
-;------------------------------------------------------------------------------ Layer 0: Defaults tests
+;; Defaults tests
 (deftest ^{:stratum 0} default-config-test
   (testing "default config has correct structure"
     (is (nil? (:agent verify/default-config))
@@ -280,6 +280,20 @@
           (is (str/includes? (str (get-in result [:error :message])) "timed out")
               ":error :message must carry the fragment — leave-verify branches on this"))))))
 
+(defn ^{:stratum 1} with-named-failure-runner
+  "Run body-fn with run-tests! mocked to return one parsed failure block."
+  [body-fn]
+  (with-redefs-fn
+    {run-tests-var (fn [_ & _opts]
+                     {:passed? false :test-count 10 :assertion-count 20
+                      :fail-count 1 :error-count 0
+                      :failures [{:kind :fail
+                                  :test "recording-is-a-no-op-without-a-configured-codex"
+                                  :location "gap_wiring_test.clj:106"
+                                  :detail "expected: {:skipped 0}\n  actual: {:torn-lines 0}"}]
+                      :output "Ran 10 tests containing 20 assertions.\n1 failures, 0 errors."})}
+    body-fn))
+
 ;------------------------------------------------------------------------------ Layer 2
 
 ;; Interceptor enter tests
@@ -325,6 +339,18 @@
           ;; Fail count captured in metrics for implement-retry loop
           (is (pos? (get-in result [:phase :result :metrics :fail-count]))
               "Fail count captured in metrics when tests fail"))))))
+
+(deftest ^{:stratum 2} enter-verify-names-failing-tests-test
+  (testing "the summary names the failing test and the metrics carry the block"
+    (with-named-failure-runner
+      (fn []
+        (let [ctx (assoc (create-base-context) :phase-config {:phase :verify})
+              result (verify/enter-verify ctx)
+              summary (get-in result [:phase :result :summary])]
+          (is (str/includes? summary "1 failure(s), 0 error(s)"))
+          (is (str/includes? summary "Failing: recording-is-a-no-op-without-a-configured-codex"))
+          (is (= "gap_wiring_test.clj:106"
+                 (get-in result [:phase :result :metrics :failures 0 :location]))))))))
 
 (use-fixtures :each
   (fn [f]


### PR DESCRIPTION
## Summary

Root cause of the verify loop seen in every trap-bench series since 5 (Falsifier D). On series 8 rx3 the verify run had 6,681 lines and three `FAIL in` blocks, one of them the trap's own consequence (a consumer test in another component still expecting the renamed key). Two defects hid it:

1. `parse-test-output` used `re-find`, so the first namespace's `Ran 3 tests … 0 failures, 0 errors` stood in for the whole run and a non-zero exit became one phantom error. The summary read "0 failure(s), 1 error(s)".
2. The implementer's excerpt kept 30 head + 25 tail lines; every FAIL block sat in the omitted middle. The implementer re-ran the suite, blamed unrelated timeout noise, and returned `:already-implemented` five times to the cap.

## Changes

- Counts are sums over every per-namespace line (line-anchored so the runner's `Test results:` roll-up is not counted twice). A counted failure is never topped up with a phantom error.
- Every `FAIL in` / `ERROR in` block is kept as `{:kind :test :location :detail}` (20 blocks, 12 detail lines each), on the test results and on the phase metrics.
- The verify summary appends `Failing: <names>` (five named, the rest counted). New message key `:verify/failing-tests`.
- The implementer's `:test-output` leads with the blocks rendered in clojure.test's own shape, then the head/tail excerpt; `:test-results` carries `:failing-tests`.

Checked against the real rx3 output: all three failures named with file:line and expected/actual.

## Tests

- Parser sums two namespaces and ignores the roll-up; extracts FAIL with location and ERROR without; clean run has no blocks.
- `enter-verify` summary names the failing test and metrics carry the block.
- `build-implement-task` puts the block first and keeps `:failing-tests`; no blocks means the excerpt alone.

Commit unsigned: the local signing agent is refusing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)