### PR TITLE
fix(preflight): retry the backend probe before refusing the workflow

### DIFF
--- a/bases/cli/resources/config/cli/workflow-runner.edn
+++ b/bases/cli/resources/config/cli/workflow-runner.edn
@@ -3,5 +3,10 @@
   {:prompt "Reply with exactly {\"ok\":true}"
    :timeout-ms 30000
    :version-timeout-ms 5000
+   ;; A single probe can time out while the CLI is still tearing down a
+   ;; previous session; retry up to :attempts times with :retry-pause-ms
+   ;; between failed attempts before the preflight fails closed.
+   :attempts 3
+   :retry-pause-ms 2000
    :claude-args ["--output-format" "json"
                  "--max-turns" "1"]}}}

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/preflight.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/preflight.clj
@@ -69,6 +69,15 @@
                             :cmd-version cmd-version
                             :probe-response (support/response-summary probe-response)}))
 
+(defn- ^{:stratum 0} context-logger
+  "The runtime context's `:logger`, else the stderr fallback. Built only
+   when needed: a `get` default would construct the fallback on every
+   call, even when the context already carries a logger."
+  [context]
+  (if-some [logger (get context :logger)]
+    logger
+    (retry/stderr-logger)))
+
 (defn- ^{:stratum 0} backend-stamp
   [llm-client]
   (when-let [backend (llm/client-backend llm-client)]
@@ -121,6 +130,6 @@
     (let [stamp (-> stamp
                     ensure-cli-command-path!
                     versioned-backend-stamp)
-          logger (get context :logger (retry/stderr-logger))]
+          logger (context-logger context)]
       (provenance/print-backend-provenance! quiet stamp)
       (verify-backend-probe! logger llm-client stamp (:worktree-path context)))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/preflight.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/preflight.clj
@@ -18,8 +18,12 @@
 (ns ai.miniforge.cli.workflow-runner.preflight
   "Backend preflight orchestration: resolve the backend's CLI stamp
    (path + version), print its provenance, and verify the health probe
-   before a workflow runs. Fails closed with anomalies carrying the
-   resolved stamp so failures are attributable. Split out of
+   before a workflow runs. The health probe runs through
+   `preflight-retry/probe-backend-with-retries`, so one transient CLI
+   timeout does not refuse the whole workflow. Fails closed with
+   anomalies carrying the resolved stamp so failures are attributable;
+   the anomaly shape is the same whether one attempt ran or all of them
+   did. Split out of
    `ai.miniforge.cli.workflow-runner` (rule 210: the parent namespace
    measured 10 real layers, max 3; each concern moves to its own
    layer-coherent file)."
@@ -28,6 +32,7 @@
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.workflow-runner.paths :as paths]
    [ai.miniforge.cli.workflow-runner.preflight-probe :as probe]
+   [ai.miniforge.cli.workflow-runner.preflight-retry :as retry]
    [ai.miniforge.cli.workflow-runner.preflight-support :as support]
    [ai.miniforge.cli.workflow-runner.provenance :as provenance]
    [ai.miniforge.response.interface :as response]))
@@ -99,8 +104,8 @@
       stamp)))
 
 (defn- ^{:stratum 1} verify-backend-probe!
-  [llm-client stamp workdir]
-  (let [probe-response (probe/run-backend-probe llm-client stamp workdir)]
+  [logger llm-client stamp workdir]
+  (let [probe-response (retry/probe-backend-with-retries logger llm-client stamp workdir)]
     (when-not (support/response-succeeded? probe-response)
       (backend-preflight-failed! stamp probe-response))
     stamp))
@@ -108,10 +113,14 @@
 ;------------------------------------------------------------------------------ Layer 2
 
 (defn ^{:stratum 2} run-backend-preflight!
+  "Resolve and print the backend stamp, then verify the health probe.
+   `context` supplies `:worktree-path` and may supply `:logger`; without
+   one, retry diagnostics go to a warn-level stderr logger."
   [quiet llm-client context]
   (when-let [stamp (cli-required-backend-stamp llm-client)]
     (let [stamp (-> stamp
                     ensure-cli-command-path!
-                    versioned-backend-stamp)]
+                    versioned-backend-stamp)
+          logger (get context :logger (retry/stderr-logger))]
       (provenance/print-backend-provenance! quiet stamp)
-      (verify-backend-probe! llm-client stamp (:worktree-path context)))))
+      (verify-backend-probe! logger llm-client stamp (:worktree-path context)))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/preflight_retry.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/preflight_retry.clj
@@ -1,0 +1,82 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.preflight-retry
+  "Bounded retry around the backend health probe. One 30s probe timeout
+   landing while the CLI is still releasing a previous session used to
+   refuse the whole workflow; this namespace runs the probe up to the
+   configured attempt count (`preflight-support/backend-preflight-attempts`),
+   pauses between failed attempts, and logs each failure as
+   `:llm/preflight-retry` so a refusal is attributable to N timeouts
+   rather than one. Split out of `ai.miniforge.cli.workflow-runner.preflight`
+   (rule 210: the retry loop pushed that namespace to a fourth layer)."
+  (:require
+   [ai.miniforge.logging.interface :as logging]
+   [ai.miniforge.cli.workflow-runner.preflight-probe :as probe]
+   [ai.miniforge.cli.workflow-runner.preflight-support :as support]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} stderr-logger
+  "Fallback logger for a runtime context that carries no `:logger`:
+   warn-and-above to stderr, so retry diagnostics survive `quiet` mode
+   without landing on stdout, which quiet callers may parse."
+  []
+  (logging/create-logger {:min-level :warn
+                          :config {:observability {:log-sinks [:stderr]}}}))
+
+(defn- ^{:stratum 0} log-attempt-failed!
+  "Record one failed health-probe attempt. `will-retry?` is false on the
+   final attempt, whose failure is what the anomaly then carries."
+  [logger {:keys [backend cmd-path]} attempt attempts elapsed-ms probe-response]
+  (logging/warn logger :llm :llm/preflight-retry
+                {:data {:backend backend
+                        :cmd-path cmd-path
+                        :attempt attempt
+                        :attempts attempts
+                        :elapsed-ms elapsed-ms
+                        :will-retry? (< attempt attempts)
+                        :error-type (get-in probe-response [:error :data :type])
+                        :error-message (get-in probe-response [:error :message])}}))
+
+(defn- ^{:stratum 0} pause-before-retry!
+  [pause-ms]
+  (when (pos? pause-ms)
+    (Thread/sleep ^long pause-ms)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} probe-backend-with-retries
+  "Run the health probe up to the configured attempt count, pausing
+   between failed attempts. Returns the first successful probe response,
+   or the last failure when every attempt failed."
+  [logger llm-client stamp workdir]
+  (let [attempts (support/backend-preflight-attempts)
+        pause-ms (support/backend-preflight-retry-pause-ms)]
+    (loop [attempt 1]
+      (let [started-ms (System/currentTimeMillis)
+            probe-response (probe/run-backend-probe llm-client stamp workdir)
+            elapsed-ms (- (System/currentTimeMillis) started-ms)]
+        (if (support/response-succeeded? probe-response)
+          probe-response
+          (do
+            (log-attempt-failed! logger stamp attempt attempts elapsed-ms probe-response)
+            (if (< attempt attempts)
+              (do
+                (pause-before-retry! pause-ms)
+                (recur (inc attempt)))
+              probe-response)))))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/preflight_retry.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/preflight_retry.clj
@@ -31,6 +31,11 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
+(def ^{:stratum 0} ^:private nanos-per-ms
+  "Nanoseconds in one millisecond; converts `System/nanoTime` deltas to
+   the millisecond unit the retry log reports."
+  1000000)
+
 (defn ^{:stratum 0} stderr-logger
   "Fallback logger for a runtime context that carries no `:logger`:
    warn-and-above to stderr, so retry diagnostics survive `quiet` mode
@@ -60,7 +65,15 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} probe-backend-with-retries
+(defn- ^{:stratum 1} elapsed-ms-since
+  "Milliseconds since a `System/nanoTime` reading. Monotonic, so a wall
+   clock adjustment mid-probe cannot log a negative duration."
+  [started-nanos]
+  (quot (- (System/nanoTime) started-nanos) nanos-per-ms))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} probe-backend-with-retries
   "Run the health probe up to the configured attempt count, pausing
    between failed attempts. Returns the first successful probe response,
    or the last failure when every attempt failed."
@@ -68,9 +81,9 @@
   (let [attempts (support/backend-preflight-attempts)
         pause-ms (support/backend-preflight-retry-pause-ms)]
     (loop [attempt 1]
-      (let [started-ms (System/currentTimeMillis)
+      (let [started-nanos (System/nanoTime)
             probe-response (probe/run-backend-probe llm-client stamp workdir)
-            elapsed-ms (- (System/currentTimeMillis) started-ms)]
+            elapsed-ms (elapsed-ms-since started-nanos)]
         (if (support/response-succeeded? probe-response)
           probe-response
           (do

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/preflight_retry.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/preflight_retry.clj
@@ -59,9 +59,16 @@
                         :error-message (get-in probe-response [:error :message])}}))
 
 (defn- ^{:stratum 0} pause-before-retry!
+  "Sleep between attempts. Cancellation (`InterruptedException`) is
+   propagated with the interrupt flag restored, never swallowed, so an
+   operator stop during the pause still reaches the caller."
   [pause-ms]
   (when (pos? pause-ms)
-    (Thread/sleep ^long pause-ms)))
+    (try
+      (Thread/sleep ^long pause-ms)
+      (catch InterruptedException e
+        (.interrupt (Thread/currentThread))
+        (throw e)))))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/preflight_support.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/preflight_support.clj
@@ -31,6 +31,21 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
+(def ^{:stratum 0} ^:private default-preflight-attempts
+  "Health-probe attempts before the preflight fails closed, when the
+   config is silent. Three: on 2026-09-03 four runs were refused on a
+   single 30s timeout that landed within ~30s of a previous long run
+   ending, while a hand probe answered inside a minute. One retry covers
+   that window; the third attempt is margin against a slower recovery."
+  3)
+
+(def ^{:stratum 0} ^:private default-preflight-retry-pause-ms
+  "Pause between failed probe attempts when the config is silent (2s):
+   long enough for a CLI still releasing a prior session to finish,
+   short enough that a hard failure still surfaces well inside two
+   minutes across three 30s attempts."
+  2000)
+
 (def ^{:stratum 0} ^:private workflow-runner-config
   "Merged workflow-runner resource config. Only the :backend-preflight
    section is consumed today, which is why the delay lives here rather
@@ -126,6 +141,12 @@
 
 (defn ^{:stratum 2} backend-version-timeout-ms []
   (:version-timeout-ms (backend-preflight-config)))
+
+(defn ^{:stratum 2} backend-preflight-attempts []
+  (get (backend-preflight-config) :attempts default-preflight-attempts))
+
+(defn ^{:stratum 2} backend-preflight-retry-pause-ms []
+  (get (backend-preflight-config) :retry-pause-ms default-preflight-retry-pause-ms))
 
 (defn ^{:stratum 2} claude-preflight-args []
   (:claude-args (backend-preflight-config)))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/preflight_support.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/preflight_support.clj
@@ -142,8 +142,12 @@
 (defn ^{:stratum 2} backend-version-timeout-ms []
   (:version-timeout-ms (backend-preflight-config)))
 
-(defn ^{:stratum 2} backend-preflight-attempts []
-  (get (backend-preflight-config) :attempts default-preflight-attempts))
+(defn ^{:stratum 2} backend-preflight-attempts
+  "Configured probe attempts, clamped to at least one: the probe always
+   runs once, so a zero or negative setting would make the logged
+   `:attempts` disagree with what happened."
+  []
+  (max 1 (get (backend-preflight-config) :attempts default-preflight-attempts)))
 
 (defn ^{:stratum 2} backend-preflight-retry-pause-ms []
   (get (backend-preflight-config) :retry-pause-ms default-preflight-retry-pause-ms))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
@@ -70,6 +70,14 @@
 (defn- ^{:stratum 0} retry-log-entries [entries]
   (filterv (fn [entry] (= :llm/preflight-retry (:log/event entry))) @entries))
 
+(deftest ^{:stratum 0} backend-preflight-attempts-clamps-to-at-least-one-test
+  (testing "a zero or negative configured attempt count still means one probe"
+    (doseq [configured [0 -2]]
+      (with-redefs-fn {#'support/backend-preflight-config (constantly {:attempts configured})}
+        (fn [] (is (= 1 (support/backend-preflight-attempts))))))
+    (with-redefs-fn {#'support/backend-preflight-config (constantly {:attempts 5})}
+      (fn [] (is (= 5 (support/backend-preflight-attempts)))))))
+
 (deftest ^{:stratum 0} await-stream-waits-for-reader-completion-test
   (testing "stream join waits for a completed reader instead of dropping late output"
     (let [started-at (System/currentTimeMillis)

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
@@ -27,6 +27,7 @@
    [ai.miniforge.cli.workflow-runner.paths :as paths]
    [ai.miniforge.cli.workflow-runner.preflight :as preflight]
    [ai.miniforge.cli.workflow-runner.preflight-probe :as probe]
+   [ai.miniforge.cli.workflow-runner.preflight-retry :as retry]
    [ai.miniforge.cli.workflow-runner.preflight-support :as support]
    [ai.miniforge.cli.workflow-runner.process :as process]
    [ai.miniforge.cli.workflow-runner.provenance :as provenance]))
@@ -69,6 +70,15 @@
 
 (defn- ^{:stratum 0} retry-log-entries [entries]
   (filterv (fn [entry] (= :llm/preflight-retry (:log/event entry))) @entries))
+
+(def ^{:stratum 0} ^:private interrupted-pause-ms
+  "Pause long enough that an already-interrupted thread fails the sleep
+   immediately rather than completing it; the assertion is on the
+   exception and the restored flag, not on the wait."
+  50)
+
+(defn- ^{:stratum 0} fallback-logger-must-not-be-built []
+  (throw (ex-info "stderr fallback logger built although :logger was supplied" {})))
 
 (deftest ^{:stratum 0} backend-preflight-attempts-clamps-to-at-least-one-test
   (testing "a zero or negative configured attempt count still means one probe"
@@ -232,6 +242,12 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
+(deftest ^{:stratum 1} pause-before-retry-propagates-interrupt-test
+  (testing "an interrupt during the retry pause is rethrown with the flag restored"
+    (.interrupt (Thread/currentThread))
+    (is (thrown? InterruptedException (#'retry/pause-before-retry! interrupted-pause-ms)))
+    (is (true? (Thread/interrupted)) "interrupt flag restored before rethrow")))
+
 (defn- ^{:stratum 1} timed-out-process-result []
   {:out ""
    :err (str "Process timed out after " stubbed-probe-timeout-ms "ms")
@@ -246,6 +262,7 @@
       (with-redefs-fn {#'paths/resolve-cli-command-path (fn [_] "/opt/homebrew/bin/claude")
                        #'probe/read-cli-version (fn [_] {:success true :version "2.1.126"})
                        #'support/backend-preflight-retry-pause-ms (constantly 0)
+                       #'retry/stderr-logger fallback-logger-must-not-be-built
                        #'process/run-cli-command (counting-process-runner calls [ok-claude-process-result])}
         (fn []
           (#'preflight/run-backend-preflight!

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
@@ -22,10 +22,12 @@
    [clojure.test :refer [deftest is testing]]
    [slingshot.slingshot :refer [try+]]
    [ai.miniforge.llm.interface :as llm]
+   [ai.miniforge.logging.interface :as logging]
    [ai.miniforge.cli.workflow-runner :as sut]
    [ai.miniforge.cli.workflow-runner.paths :as paths]
    [ai.miniforge.cli.workflow-runner.preflight :as preflight]
    [ai.miniforge.cli.workflow-runner.preflight-probe :as probe]
+   [ai.miniforge.cli.workflow-runner.preflight-support :as support]
    [ai.miniforge.cli.workflow-runner.process :as process]
    [ai.miniforge.cli.workflow-runner.provenance :as provenance]))
 
@@ -39,6 +41,34 @@
 (defn- ^{:stratum 0} shell-path []
   (or (some-> (fs/which "sh") str)
       "/bin/sh"))
+
+(def ^{:stratum 0} ^:private stubbed-probe-timeout-ms
+  "Timeout the stubbed process runner reports, matching the production
+   preflight budget so the stub's error text reads like the real one."
+  30000)
+
+(def ^{:stratum 0} ^:private probe-attempts-under-test
+  "Attempt budget the retry tests pin. Two failures then a success needs
+   at least three; the fail-closed test asserts exhaustion at this count."
+  3)
+
+(def ^{:stratum 0} ^:private ok-claude-process-result
+  "A successful `claude -p` round trip whose result envelope wraps the
+   canonical ok payload."
+  {:out "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"{\\\"ok\\\":true}\"}"
+   :err ""
+   :exit 0})
+
+(defn- ^{:stratum 0} counting-process-runner
+  "Stub for `process/run-cli-command` that answers from `results` in
+   order (repeating the last one) and counts invocations in `calls`."
+  [calls results]
+  (fn [_cmd _timeout-ms & _]
+    (let [n (swap! calls inc)]
+      (nth results (dec n) (last results)))))
+
+(defn- ^{:stratum 0} retry-log-entries [entries]
+  (filterv (fn [entry] (= :llm/preflight-retry (:log/event entry))) @entries))
 
 (deftest ^{:stratum 0} await-stream-waits-for-reader-completion-test
   (testing "stream join waits for a completed reader instead of dropping late output"
@@ -94,30 +124,6 @@
       (is (str/includes? output "Backend Version: 2.1.126"))
       (is (nil? @preflight-client)))))
 
-(deftest ^{:stratum 0} run-backend-preflight-fails-closed-on-bad-cli-health-test
-  (testing "backend preflight carries the resolved path and version when the probe fails"
-    (let [llm-client (llm/mock-client {:output "{\"ok\":true}"})]
-      (try+
-        (with-redefs-fn {#'paths/resolve-cli-command-path (fn [_] "/opt/homebrew/bin/claude")
-                         #'probe/read-cli-version (fn [_] {:success true :version "2.1.89"})
-                         #'probe/run-claude-backend-preflight (fn [_cmd-path _workdir]
-                                                              {:success false
-                                                               :error {:type "backend_preflight_timeout"
-                                                                       :message "Process timed out after 10000ms"}
-                                                               :exit-code -1})}
-          (fn []
-            (#'preflight/run-backend-preflight!
-             true
-             llm-client
-             {:worktree-path "/tmp/runtime-worktree"})))
-        (is false "expected backend preflight anomaly")
-        (catch [:anomaly/category :anomalies/unavailable]
-               {:keys [backend cmd-path cmd-version probe-response]}
-          (is (= :claude backend))
-          (is (= "/opt/homebrew/bin/claude" cmd-path))
-          (is (= "2.1.89" cmd-version))
-          (is (= "backend_preflight_timeout" (get-in probe-response [:error :type]))))))))
-
 (deftest ^{:stratum 0} run-backend-preflight-accepts-claude-result-wrapper-test
   (testing "Claude preflight accepts success envelopes whose result field contains the canonical payload"
     (let [llm-client (llm/mock-client {:output "{\"ok\":true}"})
@@ -143,6 +149,7 @@
       (try+
         (with-redefs-fn {#'paths/resolve-cli-command-path (fn [_] "/opt/homebrew/bin/claude")
                          #'probe/read-cli-version (fn [_] {:success true :version "2.1.118 (Claude Code)"})
+                         #'support/backend-preflight-retry-pause-ms (constantly 0)
                          #'process/run-cli-command (fn [_cmd _timeout-ms & _]
                                                  {:out "{\"type\":\"result\",\"subtype\":\"error\",\"is_error\":true,\"result\":\"{\\\"ok\\\":true}\"}"
                                                   :err ""
@@ -217,6 +224,30 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
+(defn- ^{:stratum 1} timed-out-process-result []
+  {:out ""
+   :err (str "Process timed out after " stubbed-probe-timeout-ms "ms")
+   :exit -1
+   :timeout-ms stubbed-probe-timeout-ms})
+
+(deftest ^{:stratum 1} run-backend-preflight-succeeds-first-time-without-retry-log-test
+  (testing "a probe that succeeds on the first attempt runs once and logs no retry"
+    (let [llm-client (llm/mock-client {:output "{\"ok\":true}"})
+          calls (atom 0)
+          [logger entries] (logging/collecting-logger)]
+      (with-redefs-fn {#'paths/resolve-cli-command-path (fn [_] "/opt/homebrew/bin/claude")
+                       #'probe/read-cli-version (fn [_] {:success true :version "2.1.126"})
+                       #'support/backend-preflight-retry-pause-ms (constantly 0)
+                       #'process/run-cli-command (counting-process-runner calls [ok-claude-process-result])}
+        (fn []
+          (#'preflight/run-backend-preflight!
+           true
+           llm-client
+           {:worktree-path "/tmp/runtime-worktree"
+            :logger logger})))
+      (is (= 1 @calls))
+      (is (empty? (retry-log-entries entries))))))
+
 (deftest ^{:stratum 1} run-cli-command-captures-short-lived-process-output-test
   (testing "probe helper captures stdout, stderr, and exit code for short-lived commands"
     (let [result (#'process/run-cli-command [(shell-path) "-lc" "printf ok; printf warn >&2"] 5000)]
@@ -285,3 +316,75 @@
         :worktree-path "/tmp/runtime-worktree"
         :execution/opts {:worktree-path "/tmp/runtime-worktree"}})
       (is true))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} run-backend-preflight-fails-closed-on-bad-cli-health-test
+  (testing "backend preflight carries the resolved path and version when every probe attempt fails"
+    (let [llm-client (llm/mock-client {:output "{\"ok\":true}"})
+          calls (atom 0)
+          [logger entries] (logging/collecting-logger)]
+      (try+
+        (with-redefs-fn {#'paths/resolve-cli-command-path (fn [_] "/opt/homebrew/bin/claude")
+                         #'probe/read-cli-version (fn [_] {:success true :version "2.1.89"})
+                         #'support/backend-preflight-attempts (constantly probe-attempts-under-test)
+                         #'support/backend-preflight-retry-pause-ms (constantly 0)
+                         #'process/run-cli-command (counting-process-runner calls [(timed-out-process-result)])}
+          (fn []
+            (#'preflight/run-backend-preflight!
+             true
+             llm-client
+             {:worktree-path "/tmp/runtime-worktree"
+              :logger logger})))
+        (is false "expected backend preflight anomaly")
+        (catch [:anomaly/category :anomalies/unavailable]
+               {:keys [backend cmd cmd-path cmd-version probe-response] :as anomaly-data}
+          (is (= :claude backend))
+          (is (= "claude" cmd))
+          (is (= "/opt/homebrew/bin/claude" cmd-path))
+          (is (= "2.1.89" cmd-version))
+          (is (= "backend_preflight_timeout" (get-in probe-response [:error :data :type])))
+          (testing "the anomaly data shape is unchanged by the retry loop"
+            (is (= #{:backend :cmd :cmd-path :cmd-version :probe-response}
+                   (set (remove (fn [k] (= "anomaly" (namespace k))) (keys anomaly-data))))))
+          (testing "every configured attempt ran and was logged before failing closed"
+            (is (= probe-attempts-under-test @calls))
+            (let [retries (retry-log-entries entries)]
+              (is (= [1 2 3] (mapv (comp :attempt :data) retries)))
+              (is (= [true true false] (mapv (comp :will-retry? :data) retries))))))))))
+
+(deftest ^{:stratum 2} run-backend-preflight-retries-timed-out-probe-test
+  (testing "two probe timeouts followed by a success pass preflight and log each failed attempt"
+    (let [llm-client (llm/mock-client {:output "{\"ok\":true}"})
+          calls (atom 0)
+          [logger entries] (logging/collecting-logger)
+          output (with-out-str
+                   (with-redefs-fn {#'paths/resolve-cli-command-path (fn [_] "/opt/homebrew/bin/claude")
+                                    #'probe/read-cli-version (fn [_] {:success true :version "2.1.126"})
+                                    #'support/backend-preflight-attempts (constantly probe-attempts-under-test)
+                                    #'support/backend-preflight-retry-pause-ms (constantly 0)
+                                    #'process/run-cli-command (counting-process-runner
+                                                               calls
+                                                               [(timed-out-process-result)
+                                                                (timed-out-process-result)
+                                                                ok-claude-process-result])}
+                     (fn []
+                       (#'preflight/run-backend-preflight!
+                        false
+                        llm-client
+                        {:worktree-path "/tmp/runtime-worktree"
+                         :logger logger}))))
+          retries (retry-log-entries entries)]
+      (is (str/includes? output "Backend: claude"))
+      (is (= 3 @calls))
+      (testing "one :llm/preflight-retry entry per failed attempt, at warn level, with attempt and elapsed"
+        (is (= 2 (count retries)))
+        (is (every? (fn [entry] (= :warn (:log/level entry))) retries))
+        (is (every? (fn [entry] (= :llm (:log/category entry))) retries))
+        (is (= [1 2] (mapv (comp :attempt :data) retries)))
+        (is (every? (fn [entry] (= probe-attempts-under-test (get-in entry [:data :attempts]))) retries))
+        (is (every? (fn [entry] (nat-int? (get-in entry [:data :elapsed-ms]))) retries))
+        (is (every? (fn [entry] (true? (get-in entry [:data :will-retry?]))) retries))
+        (is (every? (fn [entry] (= "backend_preflight_timeout" (get-in entry [:data :error-type]))) retries))
+        (is (every? (fn [entry] (= :claude (get-in entry [:data :backend]))) retries))
+        (is (every? (fn [entry] (= "/opt/homebrew/bin/claude" (get-in entry [:data :cmd-path]))) retries))))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
@@ -244,9 +244,16 @@
 
 (deftest ^{:stratum 1} pause-before-retry-propagates-interrupt-test
   (testing "an interrupt during the retry pause is rethrown with the flag restored"
+    ;; Read the flag before any `is`: clojure.test's pass counter commutes a
+    ;; ref, and that STM transaction clears a pending interrupt.
     (.interrupt (Thread/currentThread))
-    (is (thrown? InterruptedException (#'retry/pause-before-retry! interrupted-pause-ms)))
-    (is (true? (Thread/interrupted)) "interrupt flag restored before rethrow")))
+    (let [thrown (try
+                   (#'retry/pause-before-retry! interrupted-pause-ms)
+                   nil
+                   (catch InterruptedException e e))
+          flag-restored? (Thread/interrupted)]
+      (is (instance? InterruptedException thrown))
+      (is (true? flag-restored?) "interrupt flag restored before rethrow"))))
 
 (defn- ^{:stratum 1} timed-out-process-result []
   {:out ""

--- a/docs/pull-requests/2026-09-03-fix-preflight-probe-retry.md
+++ b/docs/pull-requests/2026-09-03-fix-preflight-probe-retry.md
@@ -2,9 +2,14 @@
 
 ## Overview
 
-The workflow runner probes the backend CLI once (`claude -p "Reply with
-exactly {"ok":true}"`, 30 s budget) before a workflow starts. One timeout
-refused the whole run with `Backend preflight failed for claude`.
+The workflow runner probes the backend CLI once before a workflow starts,
+with a 30 s budget:
+
+```bash
+claude -p 'Reply with exactly {"ok":true}' --output-format json --max-turns 1
+```
+
+One timeout refused the whole run with `Backend preflight failed for claude`.
 
 This PR retries the probe a bounded number of times (default 3 attempts,
 2 s pause between failed attempts, both operator-tunable), logs every

--- a/docs/pull-requests/2026-09-03-fix-preflight-probe-retry.md
+++ b/docs/pull-requests/2026-09-03-fix-preflight-probe-retry.md
@@ -58,7 +58,8 @@ SL003), so it lives in its own namespace.
    parse stdout are not affected), `log-attempt-failed!` (one
    `:llm/preflight-retry` warn entry with `:attempt`, `:attempts`,
    `:elapsed-ms`, `:will-retry?`, `:backend`, `:cmd-path`, `:error-type`,
-   `:error-message`), and `pause-before-retry!`.
+   `:error-message`), and `pause-before-retry!` (an `InterruptedException`
+   during the pause is rethrown with the interrupt flag restored).
 2. Layer 1: `probe-backend-with-retries` runs `probe/run-backend-probe`
    up to the configured count, logs each failure, pauses between
    attempts, and returns the first success or the last failure.
@@ -69,8 +70,9 @@ SL003), so it lives in its own namespace.
    `retry/probe-backend-with-retries` and throws the same
    `:anomalies/unavailable` anomaly as before, with the same data keys
    (`:backend :cmd :cmd-path :cmd-version :probe-response`).
-2. Layer 2: `run-backend-preflight!` reads `:logger` from the context,
-   falling back to the stderr logger.
+2. Layer 2: `run-backend-preflight!` reads `:logger` from the context via
+   `context-logger`, which builds the stderr fallback only when the
+   context carries none.
 
 Retries apply to every failed probe, not only timeouts. A non-timeout
 failure (non-zero exit, unexpected output) returns fast, so the extra

--- a/docs/pull-requests/2026-09-03-fix-preflight-probe-retry.md
+++ b/docs/pull-requests/2026-09-03-fix-preflight-probe-retry.md
@@ -1,0 +1,119 @@
+# fix: retry the backend preflight probe before refusing the workflow
+
+## Overview
+
+The workflow runner probes the backend CLI once (`claude -p "Reply with
+exactly {"ok":true}"`, 30 s budget) before a workflow starts. One timeout
+refused the whole run with `Backend preflight failed for claude`.
+
+This PR retries the probe a bounded number of times (default 3 attempts,
+2 s pause between failed attempts, both operator-tunable), logs every
+failed attempt as `:llm/preflight-retry` through the logging component,
+and keeps the anomaly data shape unchanged when every attempt fails.
+
+Base branch: `main`. Depends on: nothing.
+
+## Motivation
+
+On 2026-09-03 four `eval/codex-traps` reps (ru2, ru3, ru3b, and an
+earlier rep of the same shape) were refused with the inner message
+`Process timed out after 30000ms`. Each refusal landed within about 30 s
+of a previous long run ending. A hand probe (`claude -p "reply ok"`)
+answered inside a minute every time.
+
+The failure mode is a CLI still releasing a prior session when the probe
+arrives. A single 30 s sample cannot distinguish that from a CLI that is
+down, so the preflight fails closed on a transient condition and the
+operator loses the run.
+
+## Changes in Detail
+
+### `bases/cli/resources/config/cli/workflow-runner.edn`
+
+Two new keys under `:backend-preflight`: `:attempts 3` and
+`:retry-pause-ms 2000`. Both are configuration, not code constants,
+because different hosts want different values.
+
+### `preflight_support.clj`
+
+1. Layer 0: `default-preflight-attempts` (3) and
+   `default-preflight-retry-pause-ms` (2000) with docstrings stating the
+   rationale. These are the silent-config fallbacks only.
+2. Layer 2: `backend-preflight-attempts` and
+   `backend-preflight-retry-pause-ms` accessors, resolved through the
+   merged workflow-runner config with `get` and the default.
+
+### `preflight_retry.clj` (new)
+
+The retry loop pushed `preflight.clj` to a fourth layer (stratum-lint
+SL003), so it lives in its own namespace.
+
+1. Layer 0: `stderr-logger` (warn-and-above to stderr, used when the
+   runtime context carries no `:logger`; stderr so `quiet` callers that
+   parse stdout are not affected), `log-attempt-failed!` (one
+   `:llm/preflight-retry` warn entry with `:attempt`, `:attempts`,
+   `:elapsed-ms`, `:will-retry?`, `:backend`, `:cmd-path`, `:error-type`,
+   `:error-message`), and `pause-before-retry!`.
+2. Layer 1: `probe-backend-with-retries` runs `probe/run-backend-probe`
+   up to the configured count, logs each failure, pauses between
+   attempts, and returns the first success or the last failure.
+
+### `preflight.clj`
+
+1. Layer 1: `verify-backend-probe!` now calls
+   `retry/probe-backend-with-retries` and throws the same
+   `:anomalies/unavailable` anomaly as before, with the same data keys
+   (`:backend :cmd :cmd-path :cmd-version :probe-response`).
+2. Layer 2: `run-backend-preflight!` reads `:logger` from the context,
+   falling back to the stderr logger.
+
+Retries apply to every failed probe, not only timeouts. A non-timeout
+failure (non-zero exit, unexpected output) returns fast, so the extra
+cost is two short pauses; a timeout costs the full budget per attempt,
+which is the case the retry exists for.
+
+### `preflight_test.clj`
+
+1. New: `run-backend-preflight-retries-timed-out-probe-test`. A stubbed
+   `process/run-cli-command` times out twice then returns a successful
+   Claude result envelope. Asserts three invocations, preflight passes,
+   and exactly two `:llm/preflight-retry` warn entries with attempts
+   `[1 2]`, a non-negative `:elapsed-ms`, `:will-retry? true`, and
+   `:error-type "backend_preflight_timeout"`.
+2. New: `run-backend-preflight-succeeds-first-time-without-retry-log-test`.
+   One call, no retry entries.
+3. Updated: `run-backend-preflight-fails-closed-on-bad-cli-health-test`
+   now stubs the process runner (production shape) instead of the probe
+   function, asserts all three attempts ran and were logged, and pins the
+   anomaly data key set.
+4. The error-wrapper test pins the retry pause to zero so it stays fast
+   now that a failed probe retries.
+
+## Testing Plan
+
+1. `clojure -M:test:dev -e '(require ...) (clojure.test/run-tests
+   (quote ai.miniforge.cli.workflow-runner.preflight-test))'` — the
+   namespace passes locally.
+2. `clj-kondo` and `stratum-lint` on the four changed Clojure files.
+3. CI runs the full suite.
+
+## Deployment Plan
+
+Ships with the next CLI build. No migration. Operators who want the old
+behaviour set `:attempts 1` in `workflow-runner.edn`.
+
+## Related Issues/PRs
+
+1. The 2026-09-03 `eval/codex-traps` refusals (ru2, ru3, ru3b).
+2. Rule 006 named constants, rule 007 configuration is data, rule 716
+   tests ship with code.
+
+## Checklist
+
+- [x] Retry loop with configurable attempts and pause
+- [x] `:llm/preflight-retry` logged per failed attempt via the logging component
+- [x] Anomaly data shape unchanged on exhaustion
+- [x] Unit test: stubbed runner times out twice then succeeds
+- [x] Standards gap analysis (006, 007, 210, 716)
+- [ ] Copilot review cycle settled
+- [ ] Merged


### PR DESCRIPTION
## Summary

The workflow runner probes the backend CLI once (`claude -p`, 30 s budget) before a run starts, and one timeout refused the whole workflow with `Backend preflight failed for claude`. On 2026-09-03 four `eval/codex-traps` reps (ru2, ru3, ru3b, and an earlier rep) were refused this way within ~30 s of a previous long run ending, while a hand probe answered inside a minute.

This PR retries the probe a bounded number of times before failing closed.

- Probe runs up to `:attempts` times (default 3) with `:retry-pause-ms` (default 2000) between failed attempts. Both live in `config/cli/workflow-runner.edn`; the code carries named silent-config defaults with rationale.
- Every failed attempt is logged as `:llm/preflight-retry` (warn) via the logging component with `:attempt`, `:attempts`, `:elapsed-ms`, `:will-retry?`, `:backend`, `:cmd-path`, `:error-type`, `:error-message`. The runtime context may carry `:logger`; otherwise a warn-level stderr logger is used so `quiet` stdout stays clean.
- The `:anomalies/unavailable` anomaly on exhaustion has the same data keys as before (`:backend :cmd :cmd-path :cmd-version :probe-response`).
- The retry loop lives in a new `preflight-retry` namespace: it pushed `preflight.clj` to a fourth layer (stratum-lint SL003).

Retries apply to every failed probe, not only timeouts: a non-timeout failure returns fast, so the extra cost is two short pauses.

Two commits on the branch because the 200-line commit budget: source, config and PR doc first, tests second. Commits are unsigned via the repo-level `commit.gpgsign=false`; no signing override was needed.

## Tests

- New `run-backend-preflight-retries-timed-out-probe-test`: stubbed `process/run-cli-command` times out twice then returns a successful Claude result envelope. Asserts three invocations, preflight passes, exactly two retry log entries with attempts `[1 2]`, a non-negative `:elapsed-ms`, `:will-retry? true`, `:error-type "backend_preflight_timeout"`.
- New `run-backend-preflight-succeeds-first-time-without-retry-log-test`.
- `run-backend-preflight-fails-closed-on-bad-cli-health-test` now stubs the process runner (production shape), asserts all attempts ran and were logged, and pins the anomaly key set.
- `ai.miniforge.cli.workflow-runner.preflight-test`: 17 tests, 68 assertions, 0 failures locally. clj-kondo and stratum-lint clean on the four changed Clojure files. `bb pre-commit` passed on both commits.

PR doc: `docs/pull-requests/2026-09-03-fix-preflight-probe-retry.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
