### PR TITLE
fix(dag-executor): drain pipes concurrently and honour :timeout-ms in the worktree executor

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/process.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/process.clj
@@ -47,9 +47,10 @@
 (defn ^{:stratum 0} read-stream-future
   "Drain `stream` into a future of bytes and close it at end-of-stream.
    The future runs on the agent thread pool — fine for short-lived runtime
-   CLI output. Callers should `future-cancel` it if they destroy the
-   process before reading completes, otherwise the reader thread sits
-   blocked on a dead pipe."
+   CLI output. If the process is destroyed before the read completes,
+   `future-cancel` alone is not enough: a read parked on a pipe ignores
+   interrupts, so close the stream as well, or use `drain-stream` +
+   `cancel-drain!`, which do both."
   [^InputStream stream]
   (future (with-open [s stream] (.readAllBytes s))))
 

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/process.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/process.clj
@@ -15,27 +15,64 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.dag-executor.protocols.impl.runtime.process
-  "Shared process-tree helpers for the OCI-CLI runtime layer.
+  "Shared process-tree helpers for executors that shell out.
 
-   The runtime CLI executors (`descriptor` probes, `oci-cli` exec)
-   both shell out to short-lived child processes and need to (a) drain
-   stdout/stderr into futures and (b) kill the whole process tree on
-   timeout — the parent CLI typically forks an actual container runtime
-   child, and destroying only the parent leaks the child. Keeping the
-   helpers in one place means a fix to the grace period or kill order
-   lands in both call sites."
-  (:import (java.lang ProcessHandle)
+   The runtime CLI executors (`descriptor` probes, `oci-cli` exec) and the
+   worktree executor's `execute-command` all start child processes and
+   need to (a) drain stdout/stderr on background threads and (b) kill the
+   whole process tree on timeout — the parent typically forks a child
+   (a container runtime, or `sh -c` forking the real command), and
+   destroying only the parent leaks it. Keeping the helpers in one place
+   means a fix to the grace period or kill order lands in every call site."
+  (:import (java.io ByteArrayOutputStream InputStream)
+           (java.lang ProcessHandle)
            (java.util.concurrent TimeUnit)))
 
-(def graceful-shutdown-ms
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} timeout-exit-code
+  "Exit code reported when a child is killed for outrunning its deadline.
+   Mirrors coreutils `timeout(1)`, which exits 124 on expiry, so callers
+   and log readers see one convention whether the bound was enforced by
+   the shell utility or by this JVM."
+  124)
+
+(def ^{:stratum 0} graceful-shutdown-ms
   "Time we give a process to exit after .destroy before escalating to
    .destroyForcibly. Keep this small — the runtime CLI calls are
    short-lived probes/exec; a stuck child blocks the executor."
   1000)
 
-(defn destroy-process-tree!
+(defn ^{:stratum 0} read-stream-future
+  "Drain `stream` into a future of bytes. The future runs on the agent
+   thread pool — fine for short-lived runtime CLI output. Callers should
+   `future-cancel` it if they destroy the process before reading
+   completes, otherwise the reader thread sits blocked on a dead pipe."
+  [stream]
+  (future (.readAllBytes stream)))
+
+(defn ^{:stratum 0} drain-stream
+  "Copy `stream` into a growable byte buffer on a background thread.
+   Returns {:buffer ByteArrayOutputStream :future f}. Unlike
+   `read-stream-future`, the bytes copied so far can be read at any time
+   via `drained-text`, so a caller that kills the process at its deadline
+   can still surface the partial stdout/stderr the child managed to write.
+   `ByteArrayOutputStream` synchronizes its methods, so sampling from
+   another thread while the copy is still running is safe."
+  [^InputStream stream]
+  (let [buffer (ByteArrayOutputStream.)]
+    {:buffer buffer
+     :future (future (.transferTo stream buffer))}))
+
+(defn ^{:stratum 0} drained-text
+  "UTF-8 text copied so far by a `drain-stream` handle."
+  [{:keys [^ByteArrayOutputStream buffer]}]
+  (.toString buffer "UTF-8"))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} destroy-process-tree!
   "Kill `process` and every descendant. Tries SIGTERM first (children
    in reverse-discovery order, then the parent), waits up to
    `graceful-shutdown-ms` for the parent to exit, and escalates to
@@ -56,11 +93,3 @@
         (.destroyForcibly child)))
     (when (.isAlive process)
       (.destroyForcibly process))))
-
-(defn read-stream-future
-  "Drain `stream` into a future of bytes. The future runs on the agent
-   thread pool — fine for short-lived runtime CLI output. Callers should
-   `future-cancel` it if they destroy the process before reading
-   completes, otherwise the reader thread sits blocked on a dead pipe."
-  [stream]
-  (future (.readAllBytes stream)))

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/process.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/process.clj
@@ -45,16 +45,18 @@
   1000)
 
 (defn ^{:stratum 0} read-stream-future
-  "Drain `stream` into a future of bytes. The future runs on the agent
-   thread pool — fine for short-lived runtime CLI output. Callers should
-   `future-cancel` it if they destroy the process before reading
-   completes, otherwise the reader thread sits blocked on a dead pipe."
-  [stream]
-  (future (.readAllBytes stream)))
+  "Drain `stream` into a future of bytes and close it at end-of-stream.
+   The future runs on the agent thread pool — fine for short-lived runtime
+   CLI output. Callers should `future-cancel` it if they destroy the
+   process before reading completes, otherwise the reader thread sits
+   blocked on a dead pipe."
+  [^InputStream stream]
+  (future (with-open [s stream] (.readAllBytes s))))
 
 (defn ^{:stratum 0} drain-stream
-  "Copy `stream` into a growable byte buffer on a background thread.
-   Returns {:buffer ByteArrayOutputStream :future f}. Unlike
+  "Copy `stream` into a growable byte buffer on a background thread and
+   close it at end-of-stream. Returns {:buffer ByteArrayOutputStream
+   :future f}. Unlike
    `read-stream-future`, the bytes copied so far can be read at any time
    via `drained-text`, so a caller that kills the process at its deadline
    can still surface the partial stdout/stderr the child managed to write.
@@ -63,7 +65,7 @@
   [^InputStream stream]
   (let [buffer (ByteArrayOutputStream.)]
     {:buffer buffer
-     :future (future (.transferTo stream buffer))}))
+     :future (future (with-open [s stream] (.transferTo s buffer)))}))
 
 (defn ^{:stratum 0} drained-text
   "UTF-8 text copied so far by a `drain-stream` handle."

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/process.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/process.clj
@@ -56,21 +56,38 @@
 (defn ^{:stratum 0} drain-stream
   "Copy `stream` into a growable byte buffer on a background thread and
    close it at end-of-stream. Returns {:buffer ByteArrayOutputStream
-   :future f}. Unlike
-   `read-stream-future`, the bytes copied so far can be read at any time
-   via `drained-text`, so a caller that kills the process at its deadline
-   can still surface the partial stdout/stderr the child managed to write.
-   `ByteArrayOutputStream` synchronizes its methods, so sampling from
-   another thread while the copy is still running is safe."
+   :future f :stream InputStream}. Unlike `read-stream-future`, the bytes
+   copied so far can be read at any time via `drained-text`, so a caller
+   that kills the process at its deadline can still surface the partial
+   stdout/stderr the child managed to write. `ByteArrayOutputStream`
+   synchronizes its methods, so sampling from another thread while the
+   copy is still running is safe. Stop an unfinished drain with
+   `cancel-drain!`, not bare `future-cancel`."
   [^InputStream stream]
   (let [buffer (ByteArrayOutputStream.)]
     {:buffer buffer
+     :stream stream
      :future (future (with-open [s stream] (.transferTo s buffer)))}))
 
 (defn ^{:stratum 0} drained-text
   "UTF-8 text copied so far by a `drain-stream` handle."
   [{:keys [^ByteArrayOutputStream buffer]}]
   (.toString buffer "UTF-8"))
+
+(defn ^{:stratum 0} cancel-drain!
+  "Stop a `drain-stream` handle that has not reached end-of-stream. A
+   thread parked in a pipe read ignores interrupts, so `future-cancel`
+   alone would leave it blocked for as long as some orphan grandchild
+   holds the write end open; closing the stream first makes the pending
+   read fail and lets the thread exit. Both steps are no-ops on a drain
+   that already finished."
+  [{:keys [^InputStream stream future]}]
+  (try
+    (.close stream)
+    (catch java.io.IOException _
+      ;; Already closed by the drain's own with-open, or the pipe is gone.
+      nil))
+  (future-cancel future))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/process.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/process.clj
@@ -49,8 +49,10 @@
    The future runs on the agent thread pool — fine for short-lived runtime
    CLI output. If the process is destroyed before the read completes,
    `future-cancel` alone is not enough: a read parked on a pipe ignores
-   interrupts, so close the stream as well, or use `drain-stream` +
-   `cancel-drain!`, which do both."
+   interrupts, so the stream must be closed as well. Passing
+   `(.getInputStream process)` inline, as the runtime callers do, leaves
+   no reference to close; for a cancellable read prefer `drain-stream` +
+   `cancel-drain!`, which retain the stream and do both steps."
   [^InputStream stream]
   (future (with-open [s stream] (.readAllBytes s))))
 

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -25,11 +25,13 @@
    [ai.miniforge.dag-executor.result :as result]
    [ai.miniforge.dag-executor.scratch-commit :as scratch-commit]
    [ai.miniforge.dag-executor.protocols.executor :as proto]
+   [ai.miniforge.dag-executor.protocols.impl.runtime.process :as runtime-process]
    [clojure.java.shell :as shell]
    [clojure.string :as str])
   (:import
    [java.io File]
-   [java.nio.file Files StandardCopyOption CopyOption]))
+   [java.nio.file Files StandardCopyOption CopyOption]
+   [java.util.concurrent TimeUnit]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -185,36 +187,27 @@
 ;; ============================================================================
 ;; Command Execution
 ;; ============================================================================
-(defn ^{:stratum 0} execute-command
-  "Execute a command in a directory using ProcessBuilder.
+(def ^{:stratum 0} partial-output-drain-ms
+  "How long a deadline-bounded `execute-command` waits for the stdout/stderr
+   drain threads to reach end-of-stream — after killing a timed-out process
+   tree, and after the child exits on its own — before it samples whatever
+   bytes they copied. One second covers the pipe buffers emptying once the
+   writers are dead; if an orphan grandchild still holds a pipe open the
+   sample is taken anyway, so the deadline holds and the caller gets
+   partial output rather than a second hang."
+  1000)
 
-   Accepts either a string (passed to sh -c, suitable for shell builtins and
-   pipelines) or a vector of strings (exec'd directly without a shell —
-   preferred for user-supplied values to avoid shell injection).
-
-   This allows proper environment variable handling and working directory."
-  [workdir command env-map]
-  (let [cmd-args (if (string? command)
-                   ["sh" "-c" command]
-                   (vec command))
-        start-time (System/currentTimeMillis)]
-    (try
-      (let [pb (ProcessBuilder. ^java.util.List cmd-args)
-            _ (.directory pb (File. ^String workdir))
-            _ (when (seq env-map)
-                (let [pb-env (.environment pb)]
-                  (doseq [[k v] env-map]
-                    (.put pb-env (name k) (str v)))))
-            process (.start pb)
-            stdout (slurp (.getInputStream process))
-            stderr (slurp (.getErrorStream process))
-            exit-code (.waitFor process)]
-        (result/ok {:exit-code exit-code
-                    :stdout stdout
-                    :stderr stderr
-                    :duration-ms (- (System/currentTimeMillis) start-time)}))
-      (catch Exception e
-        (result/err :exec-failed (.getMessage e))))))
+(defn- ^{:stratum 0} timed-out-result
+  "Result for a child killed at its deadline: exit `timeout-exit-code`, the
+   partial stdout/stderr captured before the kill, and `:timed-out? true`
+   at the top level — the shape `verify/run-tests-in-capsule!` routes as a
+   non-actionable timeout instead of a test failure."
+  [start-time stdout-drain stderr-drain]
+  (assoc (result/ok {:exit-code   runtime-process/timeout-exit-code
+                     :stdout      (runtime-process/drained-text stdout-drain)
+                     :stderr      (runtime-process/drained-text stderr-drain)
+                     :duration-ms (- (System/currentTimeMillis) start-time)})
+         :timed-out? true))
 
 ;; ============================================================================
 ;; File Operations
@@ -229,6 +222,17 @@
         (str/starts-with? file-path root-path))))
 
 ;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} kill-and-collect!
+  "Destroy `process` and its descendants, give the drain threads a bounded
+   chance to hit end-of-stream, then cancel them so no reader sits on a
+   dead pipe."
+  [^Process process stdout-drain stderr-drain]
+  (runtime-process/destroy-process-tree! process)
+  (deref (:future stdout-drain) partial-output-drain-ms nil)
+  (deref (:future stderr-drain) partial-output-drain-ms nil)
+  (future-cancel (:future stdout-drain))
+  (future-cancel (:future stderr-drain)))
 
 (defn ^{:stratum 1} default-base-path
   "Default location for git worktrees acquired by the worktree executor.
@@ -581,6 +585,69 @@
 
 ;------------------------------------------------------------------------------ Layer 2
 
+(defn ^{:stratum 2} execute-command
+  "Execute a command in a directory using ProcessBuilder.
+
+   Accepts either a string (passed to sh -c, suitable for shell builtins and
+   pipelines) or a vector of strings (exec'd directly without a shell —
+   preferred for user-supplied values to avoid shell injection).
+
+   stdout and stderr are drained on separate threads while the child runs,
+   so a child that fills the OS pipe buffer (64 KB) on one stream before
+   closing the other cannot deadlock the parent.
+
+   When `timeout-ms` is a positive number the wait is bounded: on expiry
+   the whole process tree is destroyed and the result carries exit
+   `timeout-exit-code`, the partial output, and `:timed-out? true`. A nil
+   or non-positive `timeout-ms` waits without a deadline."
+  ([workdir command env-map]
+   (execute-command workdir command env-map nil))
+  ([workdir command env-map timeout-ms]
+   (let [cmd-args (if (string? command)
+                    ["sh" "-c" command]
+                    (vec command))
+         start-time (System/currentTimeMillis)]
+     (try
+       (let [pb (ProcessBuilder. ^java.util.List cmd-args)
+             _ (.directory pb (File. ^String workdir))
+             _ (when (seq env-map)
+                 (let [pb-env (.environment pb)]
+                   (doseq [[k v] env-map]
+                     (.put pb-env (name k) (str v)))))
+             process      (.start pb)
+             stdout-drain (runtime-process/drain-stream (.getInputStream process))
+             stderr-drain (runtime-process/drain-stream (.getErrorStream process))]
+         (try
+           (let [timed?     (and (number? timeout-ms) (pos? timeout-ms))
+                 completed? (if timed?
+                              (.waitFor process (long timeout-ms) TimeUnit/MILLISECONDS)
+                              (do (.waitFor process) true))]
+             (if completed?
+               (do
+                 ;; Wait for end-of-stream so the last pipe-buffered bytes land.
+                 ;; Bounded when a deadline was given: an orphan grandchild
+                 ;; holding the pipe must not outlive the caller's deadline.
+                 (if timed?
+                   (do (deref (:future stdout-drain) partial-output-drain-ms nil)
+                       (deref (:future stderr-drain) partial-output-drain-ms nil))
+                   (do @(:future stdout-drain)
+                       @(:future stderr-drain)))
+                 (result/ok {:exit-code   (.exitValue process)
+                             :stdout      (runtime-process/drained-text stdout-drain)
+                             :stderr      (runtime-process/drained-text stderr-drain)
+                             :duration-ms (- (System/currentTimeMillis) start-time)}))
+               (do
+                 (kill-and-collect! process stdout-drain stderr-drain)
+                 (timed-out-result start-time stdout-drain stderr-drain))))
+           (catch InterruptedException e
+             ;; The caller's thread was interrupted mid-wait: do not leak the
+             ;; child, and keep the interrupt visible to whoever is unwinding.
+             (kill-and-collect! process stdout-drain stderr-drain)
+             (.interrupt (Thread/currentThread))
+             (result/err :exec-interrupted (.getMessage e)))))
+       (catch Exception e
+         (result/err :exec-failed (.getMessage e)))))))
+
 (defn ^{:stratum 2} check-legacy-tmp-worktrees!
   "Warn once per JVM session when the legacy /tmp/miniforge-worktrees directory
    has entries.
@@ -912,7 +979,7 @@
     (let [worktree-path (str base-path "/" environment-id)
           workdir (get opts :workdir worktree-path)
           env-map (merge {} (:env opts))]
-      (execute-command workdir command env-map)))
+      (execute-command workdir command env-map (get opts :timeout-ms))))
 
   (copy-to! [_this environment-id local-path remote-path]
     (let [worktree-path (str base-path "/" environment-id)]

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -223,16 +223,16 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn- ^{:stratum 1} kill-and-collect!
-  "Destroy `process` and its descendants, give the drain threads a bounded
-   chance to hit end-of-stream, then cancel them so no reader sits on a
-   dead pipe."
-  [^Process process stdout-drain stderr-drain]
-  (runtime-process/destroy-process-tree! process)
+(defn- ^{:stratum 1} settle-drains!
+  "Wait up to `partial-output-drain-ms` for both drains to reach
+   end-of-stream, then close and cancel whatever is still running. The
+   cancel is a no-op on a finished drain; on an unfinished one it frees
+   the reader thread instead of leaking it on a pipe an orphan holds open."
+  [stdout-drain stderr-drain]
   (deref (:future stdout-drain) partial-output-drain-ms nil)
   (deref (:future stderr-drain) partial-output-drain-ms nil)
-  (future-cancel (:future stdout-drain))
-  (future-cancel (:future stderr-drain)))
+  (runtime-process/cancel-drain! stdout-drain)
+  (runtime-process/cancel-drain! stderr-drain))
 
 (defn ^{:stratum 1} default-base-path
   "Default location for git worktrees acquired by the worktree executor.
@@ -585,72 +585,12 @@
 
 ;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 2} execute-command
-  "Execute a command in a directory using ProcessBuilder.
-
-   Accepts either a string (passed to sh -c, suitable for shell builtins and
-   pipelines) or a vector of strings (exec'd directly without a shell —
-   preferred for user-supplied values to avoid shell injection).
-
-   stdout and stderr are drained on separate threads while the child runs,
-   so a child that fills the OS pipe buffer (64 KB) on one stream before
-   closing the other cannot deadlock the parent.
-
-   When `timeout-ms` is a positive number the wait is bounded: on expiry
-   the whole process tree is destroyed and the result carries exit
-   `timeout-exit-code`, the partial output, and `:timed-out? true`. A nil
-   or non-positive `timeout-ms` waits without a deadline."
-  ([workdir command env-map]
-   (execute-command workdir command env-map nil))
-  ([workdir command env-map timeout-ms]
-   (let [cmd-args (if (string? command)
-                    ["sh" "-c" command]
-                    (vec command))
-         start-time (System/currentTimeMillis)]
-     (try
-       (let [pb (ProcessBuilder. ^java.util.List cmd-args)
-             _ (.directory pb (File. ^String workdir))
-             _ (when (seq env-map)
-                 (let [pb-env (.environment pb)]
-                   (doseq [[k v] env-map]
-                     (.put pb-env (name k) (str v)))))
-             process      (.start pb)
-             stdout-drain (runtime-process/drain-stream (.getInputStream process))
-             stderr-drain (runtime-process/drain-stream (.getErrorStream process))]
-         (try
-           (let [timed?     (and (number? timeout-ms) (pos? timeout-ms))
-                 completed? (if timed?
-                              (.waitFor process (long timeout-ms) TimeUnit/MILLISECONDS)
-                              (do (.waitFor process) true))]
-             (if completed?
-               (do
-                 ;; Wait for end-of-stream so the last pipe-buffered bytes land.
-                 ;; Bounded when a deadline was given: an orphan grandchild
-                 ;; holding the pipe must not outlive the caller's deadline.
-                 (if timed?
-                   (do (deref (:future stdout-drain) partial-output-drain-ms nil)
-                       (deref (:future stderr-drain) partial-output-drain-ms nil)
-                       ;; No-ops when the drains finished; otherwise frees the
-                       ;; reader threads instead of leaking them on an open pipe.
-                       (future-cancel (:future stdout-drain))
-                       (future-cancel (:future stderr-drain)))
-                   (do @(:future stdout-drain)
-                       @(:future stderr-drain)))
-                 (result/ok {:exit-code   (.exitValue process)
-                             :stdout      (runtime-process/drained-text stdout-drain)
-                             :stderr      (runtime-process/drained-text stderr-drain)
-                             :duration-ms (- (System/currentTimeMillis) start-time)}))
-               (do
-                 (kill-and-collect! process stdout-drain stderr-drain)
-                 (timed-out-result start-time stdout-drain stderr-drain))))
-           (catch InterruptedException e
-             ;; The caller's thread was interrupted mid-wait: do not leak the
-             ;; child, and keep the interrupt visible to whoever is unwinding.
-             (kill-and-collect! process stdout-drain stderr-drain)
-             (.interrupt (Thread/currentThread))
-             (result/err :exec-interrupted (.getMessage e)))))
-       (catch Exception e
-         (result/err :exec-failed (.getMessage e)))))))
+(defn- ^{:stratum 2} kill-and-collect!
+  "Destroy `process` and its descendants, then settle the drains so no
+   reader sits on a pipe an orphan still holds open."
+  [^Process process stdout-drain stderr-drain]
+  (runtime-process/destroy-process-tree! process)
+  (settle-drains! stdout-drain stderr-drain))
 
 (defn ^{:stratum 2} check-legacy-tmp-worktrees!
   "Warn once per JVM session when the legacy /tmp/miniforge-worktrees directory
@@ -811,6 +751,68 @@
   (remove-worktree worktree-path))
 
 ;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} execute-command
+  "Execute a command in a directory using ProcessBuilder.
+
+   Accepts either a string (passed to sh -c, suitable for shell builtins and
+   pipelines) or a vector of strings (exec'd directly without a shell —
+   preferred for user-supplied values to avoid shell injection).
+
+   stdout and stderr are drained on separate threads while the child runs,
+   so a child that fills the OS pipe buffer (64 KB) on one stream before
+   closing the other cannot deadlock the parent.
+
+   When `timeout-ms` is a positive number the wait is bounded: on expiry
+   the whole process tree is destroyed and the result carries exit
+   `timeout-exit-code`, the partial output, and `:timed-out? true`. A nil
+   or non-positive `timeout-ms` waits without a deadline."
+  ([workdir command env-map]
+   (execute-command workdir command env-map nil))
+  ([workdir command env-map timeout-ms]
+   (let [cmd-args (if (string? command)
+                    ["sh" "-c" command]
+                    (vec command))
+         start-time (System/currentTimeMillis)]
+     (try
+       (let [pb (ProcessBuilder. ^java.util.List cmd-args)
+             _ (.directory pb (File. ^String workdir))
+             _ (when (seq env-map)
+                 (let [pb-env (.environment pb)]
+                   (doseq [[k v] env-map]
+                     (.put pb-env (name k) (str v)))))
+             process      (.start pb)
+             stdout-drain (runtime-process/drain-stream (.getInputStream process))
+             stderr-drain (runtime-process/drain-stream (.getErrorStream process))]
+         (try
+           (let [timed?     (and (number? timeout-ms) (pos? timeout-ms))
+                 completed? (if timed?
+                              (.waitFor process (long timeout-ms) TimeUnit/MILLISECONDS)
+                              (do (.waitFor process) true))]
+             (if completed?
+               (do
+                 ;; Wait for end-of-stream so the last pipe-buffered bytes land.
+                 ;; Bounded when a deadline was given: an orphan grandchild
+                 ;; holding the pipe must not outlive the caller's deadline.
+                 (if timed?
+                   (settle-drains! stdout-drain stderr-drain)
+                   (do @(:future stdout-drain)
+                       @(:future stderr-drain)))
+                 (result/ok {:exit-code   (.exitValue process)
+                             :stdout      (runtime-process/drained-text stdout-drain)
+                             :stderr      (runtime-process/drained-text stderr-drain)
+                             :duration-ms (- (System/currentTimeMillis) start-time)}))
+               (do
+                 (kill-and-collect! process stdout-drain stderr-drain)
+                 (timed-out-result start-time stdout-drain stderr-drain))))
+           (catch InterruptedException e
+             ;; The caller's thread was interrupted mid-wait: do not leak the
+             ;; child, and keep the interrupt visible to whoever is unwinding.
+             (kill-and-collect! process stdout-drain stderr-drain)
+             (.interrupt (Thread/currentThread))
+             (result/err :exec-interrupted (.getMessage e)))))
+       (catch Exception e
+         (result/err :exec-failed (.getMessage e)))))))
 
 (defn ^{:stratum 3} create-worktree
   "Create a git worktree for the task.

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -629,7 +629,11 @@
                  ;; holding the pipe must not outlive the caller's deadline.
                  (if timed?
                    (do (deref (:future stdout-drain) partial-output-drain-ms nil)
-                       (deref (:future stderr-drain) partial-output-drain-ms nil))
+                       (deref (:future stderr-drain) partial-output-drain-ms nil)
+                       ;; No-ops when the drains finished; otherwise frees the
+                       ;; reader threads instead of leaking them on an open pipe.
+                       (future-cancel (:future stdout-drain))
+                       (future-cancel (:future stderr-drain)))
                    (do @(:future stdout-drain)
                        @(:future stderr-drain)))
                  (result/ok {:exit-code   (.exitValue process)

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_execute_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_execute_test.clj
@@ -57,6 +57,12 @@
    under test is `returns at the deadline`, not the production default."
   500)
 
+(def ^{:stratum 0} ^:private pgrep-no-match-exit
+  "pgrep(1) exits 1 when no process matched. Asserting this exact code,
+   rather than any non-zero, keeps a missing binary or bad flag (exit 2/127)
+   from passing as a reaped sleeper."
+  1)
+
 (def ^{:stratum 0} ^:private deadline-slack-ms
   "Wall-clock allowance for the timeout path: the deadline, the one-second
    graceful-shutdown wait in `destroy-process-tree!`, and JVM scheduling."
@@ -77,7 +83,7 @@
       (is (true? (:timed-out? r)) ":timed-out? must sit at the top level of the result")
       (is (= runtime-process/timeout-exit-code (:exit-code (:data r))))
       (is (< took deadline-slack-ms) (str "returned after " took "ms"))
-      (is (not= 0 (:exit (shell/sh "pgrep" "-f" outlives-deadline-cmd)))
+      (is (= pgrep-no-match-exit (:exit (shell/sh "pgrep" "-f" outlives-deadline-cmd)))
           "the sleeper must be reaped, not orphaned"))))
 
 (deftest ^{:stratum 1} worktree-executor-execute-threads-timeout-test

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_execute_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_execute_test.clj
@@ -1,0 +1,103 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.dag-executor.protocols.impl.worktree-execute-test
+  "Tests for the worktree executor's command execution: pipe draining and
+   the :timeout-ms deadline."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]
+   [ai.miniforge.dag-executor.protocols.executor :as proto]
+   [ai.miniforge.dag-executor.protocols.impl.runtime.process :as runtime-process]
+   [ai.miniforge.dag-executor.protocols.impl.worktree :as worktree]
+   [ai.miniforge.dag-executor.result :as result]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private scratch-dir
+  "Working directory for the shell commands below. They touch no files, so
+   the JVM temp dir is enough and always exists."
+  (System/getProperty "java.io.tmpdir"))
+
+(def ^{:stratum 0} ^:private stderr-flood-bytes
+  "Bytes written to stderr before the child touches stdout. Three times the
+   64 KB pipe buffer on Linux and macOS, so a parent that reads stdout to
+   EOF before touching stderr blocks here forever."
+  (* 3 64 1024))
+
+(def ^{:stratum 0} ^:private regression-guard-ms
+  "Upper bound on the flood command. It normally finishes well under a
+   second; reaching this bound means the reader deadlocked again, and the
+   test fails instead of hanging the suite."
+  10000)
+
+(def ^{:stratum 0} ^:private outlives-deadline-cmd
+  "Sleeps far longer than any deadline used here. The odd duration doubles
+   as a process-table sentinel for the reap check, so a stray `sleep 30`
+   from another test cannot produce a false match."
+  "sleep 3607")
+
+(def ^{:stratum 0} ^:private aggressive-timeout-ms
+  "Deadline handed to the executor. Short so the test is fast; the contract
+   under test is `returns at the deadline`, not the production default."
+  500)
+
+(def ^{:stratum 0} ^:private deadline-slack-ms
+  "Wall-clock allowance for the timeout path: the deadline, the one-second
+   graceful-shutdown wait in `destroy-process-tree!`, and JVM scheduling."
+  5000)
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private stderr-flood-cmd
+  "Floods stderr past the pipe buffer, then writes `done` to stdout. Exits 0
+   so the assertions isolate the deadlock from a command failure."
+  (str "head -c " stderr-flood-bytes " /dev/zero | tr '\\0' x >&2; echo done"))
+
+(deftest ^{:stratum 1} execute-command-kills-process-tree-at-deadline-test
+  (testing "a positive timeout bounds the wait, kills the tree and flags the result"
+    (let [start (System/currentTimeMillis)
+          r     (worktree/execute-command scratch-dir outlives-deadline-cmd {} aggressive-timeout-ms)
+          took  (- (System/currentTimeMillis) start)]
+      (is (true? (:timed-out? r)) ":timed-out? must sit at the top level of the result")
+      (is (= runtime-process/timeout-exit-code (:exit-code (:data r))))
+      (is (< took deadline-slack-ms) (str "returned after " took "ms"))
+      (is (not= 0 (:exit (shell/sh "pgrep" "-f" outlives-deadline-cmd)))
+          "the sleeper must be reaped, not orphaned"))))
+
+(deftest ^{:stratum 1} worktree-executor-execute-threads-timeout-test
+  (testing "execute! forwards :timeout-ms so the deadline is honoured at the protocol boundary"
+    (let [exec (worktree/->WorktreeExecutor {} scratch-dir worktree/default-max-concurrent)
+          r    (proto/execute! exec "env-timeout" outlives-deadline-cmd
+                               {:workdir scratch-dir :timeout-ms aggressive-timeout-ms})]
+      (is (true? (:timed-out? r)))
+      (is (= runtime-process/timeout-exit-code (:exit-code (:data r)))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} execute-command-drains-stderr-flood-without-deadlock-test
+  (testing "a child that fills the stderr pipe before writing stdout still completes"
+    (let [r (deref (future (worktree/execute-command scratch-dir stderr-flood-cmd {}))
+                   regression-guard-ms ::hung)]
+      (is (not= ::hung r) "execute-command deadlocked on a stderr flood")
+      (when (not= ::hung r)
+        (is (result/ok? r))
+        (is (= 0 (:exit-code (:data r))))
+        (is (str/includes? (:stdout (:data r)) "done"))
+        (is (= stderr-flood-bytes (count (:stderr (:data r))))
+            "every stderr byte must be captured, not just the first pipe buffer")))))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_execute_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_execute_test.clj
@@ -98,8 +98,11 @@
 
 (deftest ^{:stratum 2} execute-command-drains-stderr-flood-without-deadlock-test
   (testing "a child that fills the stderr pipe before writing stdout still completes"
-    (let [r (deref (future (worktree/execute-command scratch-dir stderr-flood-cmd {}))
-                   regression-guard-ms ::hung)]
+    (let [run (future (worktree/execute-command scratch-dir stderr-flood-cmd {}))
+          r   (deref run regression-guard-ms ::hung)]
+      ;; On a regression, interrupt the waiter so its InterruptedException
+      ;; path kills the child instead of leaving it to outlive the suite.
+      (when (= ::hung r) (future-cancel run))
       (is (not= ::hung r) "execute-command deadlocked on a stderr flood")
       (when (not= ::hung r)
         (is (result/ok? r))


### PR DESCRIPTION
## Summary

`execute-command` in the worktree executor slurped stdout to EOF, then stderr, then called `waitFor` with no deadline. Two defects:

1. A child that writes more than the 64 KB pipe buffer to stderr before closing stdout blocks, so the parent never returns.
2. No deadline. `execute!` also dropped `(:timeout-ms opts)`, although `verify/run-tests-in-capsule!` passes it and its tests expect the executor to honour it.

## Change

- stdout and stderr drain on background threads into byte buffers while the child runs.
- A positive `:timeout-ms` bounds `waitFor`. On expiry the process tree (descendants first, then the parent) is destroyed and the result is `{:exit-code 124 :stdout <partial> :stderr <partial> :duration-ms n}` with `:timed-out? true` at the top level, the shape `run-tests-in-capsule-surfaces-executor-timeout-as-timed-out-test` expects.
- With a deadline set, the post-exit wait for end-of-stream is also bounded, so an orphan grandchild holding the pipe cannot outlive the deadline.
- An `InterruptedException` mid-wait now kills the child and re-sets the interrupt flag instead of leaking it.
- `execute!` forwards `:timeout-ms`.
- `timeout-exit-code` (124) and the buffered `drain-stream` / `drained-text` helpers live in `runtime.process` next to `destroy-process-tree!`, which the worktree executor now reuses.

## Tests

New namespace `worktree-execute-test`:

- 192 KB stderr flood then `done` on stdout completes with exit 0, stdout containing `done`, and every stderr byte captured. Bounded by a 10 s guard so a regression fails rather than hangs.
- `sleep 3607` with `:timeout-ms 500` returns `:timed-out? true` and exit 124 within 5 s, and `pgrep` confirms the sleeper is reaped.
- The same deadline through `execute!` on a `WorktreeExecutor`.

Verified: the full dag-executor suite (439 tests) and `phase-software-factory/verify-test` pass locally. Run against the pre-fix source, the new protocol-level test hangs on `sleep 3607`, which is the defect.

## Notes

- `oci_cli.clj` and `descriptor.clj` still inline `124`. Switching them to the shared constant was tried and dropped: staging either file triggers the stratum autofix, which rewrites the whole file (900+ lines for `oci_cli.clj`). Left for the namespace-split wave.
- `worktree.clj` was already over the layer budget (7 layers on main); the commits used `MINIFORGE_STRATUM_BUDGET_MODE=warn` for that pre-existing SL003 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)