### PR TITLE
fix(gate): :tests-pass reads verify's test metrics from the phase result

### DIFF
--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -172,7 +172,13 @@
                                " " (str/join ", " files)))
                         (str/join ""
                                   (for [{:keys [file line text]} (:hits error)]
-                                    (str "\n  - " file ":" line ": " text))))))
+                                    (str "\n  - " file ":" line ": " text)))
+                        ;; :tests-pass carries verify's failing tests here so
+                        ;; the denial names what to fix, not only how many.
+                        (str/join ""
+                                  (for [{:keys [test location]} (:failures error)]
+                                    (str "\n  - " test
+                                         (when location (str " (" location ")"))))))))
        "\n"))
 
 (defn- ^{:stratum 0} format-prior-attempts-section

--- a/components/agent/test/ai/miniforge/agent/implementer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_test.clj
@@ -376,6 +376,24 @@
               (implementer/task->text {:task/description "x"})
               "Gate denial")))))
 
+(deftest ^{:stratum 0} task->text-gate-failures-names-failing-tests-test
+  (testing "a :tests-pass denial lists each failing test with its location"
+    (let [text (implementer/task->text
+                {:task/description "Fix the ledger"
+                 :task/gate-failures
+                 [{:gate :tests-pass
+                   :errors [{:type :tests-failed
+                             :message "2 tests failed"
+                             :failures [{:kind :fail
+                                         :test "records-a-miss"
+                                         :location "gap_wiring_test.clj:106"}
+                                        {:kind :error
+                                         :test "reads-the-ledger"}]}]}]})]
+      (is (str/includes? text "[tests-pass] 2 tests failed"))
+      (is (str/includes? text "- records-a-miss (gap_wiring_test.clj:106)"))
+      (is (str/includes? text "- reads-the-ledger\n")
+          "a failure without a location renders bare"))))
+
 (deftest ^{:stratum 0} invoke-worktree-metadata-already-implemented-test
   (testing "worktree metadata artifact is canonical for already-implemented outcomes"
     (let [[logger _] (log/collecting-logger {:min-level :trace})

--- a/components/gate/resources/config/gate/messages/en-US.edn
+++ b/components/gate/resources/config/gate/messages/en-US.edn
@@ -112,6 +112,7 @@
 
   ;; Tests-pass gate — failing tests counted (phase result or artifact metadata)
   :tests-pass/failed "{fail-count} tests failed"
+  :tests-pass/failed-one "1 test failed"
 
   ;; Tests-pass gate — verify reported :error with no failing tests and no message
   :tests-pass/verify-error "Verify phase reported an error without test counts"

--- a/components/gate/resources/config/gate/messages/en-US.edn
+++ b/components/gate/resources/config/gate/messages/en-US.edn
@@ -108,4 +108,13 @@
   :opsv/actuation-remediation "Enable apply explicitly and allowlist every target service"
   :opsv/evidence-completeness-description "Validates OPSV evidence completeness"
   :opsv/evidence-completeness-failed "Required OPSV actuation evidence is incomplete"
-  :opsv/evidence-completeness-remediation "Attach the pack hash, environment fingerprint, and metric snapshots"}}
+  :opsv/evidence-completeness-remediation "Attach the pack hash, environment fingerprint, and metric snapshots"
+
+  ;; Tests-pass gate — failing tests counted (phase result or artifact metadata)
+  :tests-pass/failed "{fail-count} tests failed"
+
+  ;; Tests-pass gate — verify reported :error with no failing tests and no message
+  :tests-pass/verify-error "Verify phase reported an error without test counts"
+
+  ;; Tests-pass gate — neither a test-bearing phase result nor artifact metadata
+  :tests-pass/no-results "No test results found"}}

--- a/components/gate/src/ai/miniforge/gate/test.clj
+++ b/components/gate/src/ai/miniforge/gate/test.clj
@@ -20,35 +20,85 @@
 
    - :tests-pass - All tests pass
    - :coverage - Coverage meets threshold"
-  (:require [ai.miniforge.gate.registry :as registry]))
+  (:require [ai.miniforge.gate.messages :as messages]
+            [ai.miniforge.gate.registry :as registry]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
 ;; Test checking
-(defn ^{:stratum 0} check-tests-pass
-  "Check if tests pass.
+(defn- ^{:stratum 0} artifact-test-results
+  "Legacy source: test results stashed on the artifact's metadata."
+  [artifact]
+  (or (get-in artifact [:metadata :test-results])
+      (get-in artifact [:artifact/metadata :test-results])))
 
-   In real impl, this would run tests and check results.
-   Here we check for test results in artifact metadata."
-  [artifact _ctx]
-  (let [test-results (or (get-in artifact [:metadata :test-results])
-                         (get-in artifact [:artifact/metadata :test-results]))]
+(defn- ^{:stratum 0} phase-test-result
+  "The gated phase's own result when it carries test metrics, else nil.
+
+   `apply-gate-validation` hands gates the entered ctx, whose [:phase :result]
+   is the phase result (verify: `phase/success` or `phase/error` with
+   `phase/test-metrics`). A result is test-bearing when its :metrics has
+   :fail-count — that is the verify contract; other phases' :metrics
+   (tokens, cost) never carry it, so they fall through to the legacy source."
+  [ctx]
+  (let [result (get-in ctx [:phase :result])]
+    (when (contains? (:metrics result) :fail-count)
+      result)))
+
+(defn- ^{:stratum 0} check-phase-test-result
+  "Judge a test-bearing phase result. Fails on any failing test, and on a
+   phase :status :error with no failing tests (parse error, crashed or timed
+   out test command) — a verify that could not count its tests has not passed
+   them. The verify :failures ride on the gate error so the implementer's
+   gate-denial section names the tests to fix."
+  [result]
+  (let [metrics    (:metrics result)
+        fail-count (get metrics :fail-count 0)
+        pass-count (get metrics :pass-count 0)
+        failures   (vec (get metrics :failures []))]
     (cond
-      (nil? test-results)
-      {:passed? true
-       :warnings [{:type :no-tests
-                   :message "No test results found"}]}
+      (pos? fail-count)
+      {:passed? false
+       :pass-count pass-count
+       :fail-count fail-count
+       :errors [{:type :tests-failed
+                 :message (messages/t :tests-pass/failed {:fail-count fail-count})
+                 :failures failures}]}
 
-      (:passed? test-results)
-      {:passed? true
-       :test-count (:test-count test-results)
-       :pass-count (:pass-count test-results)}
+      (= :error (:status result))
+      {:passed? false
+       :pass-count pass-count
+       :fail-count fail-count
+       :errors [{:type :verify-error
+                 :message (or (get-in result [:error :message])
+                              (:summary result)
+                              (messages/t :tests-pass/verify-error))
+                 :failures failures}]}
 
       :else
-      {:passed? false
-       :errors [{:type :tests-failed
-                 :message (str (:fail-count test-results) " tests failed")
-                 :failures (:failures test-results)}]})))
+      {:passed? true
+       :test-count pass-count
+       :pass-count pass-count})))
+
+(defn- ^{:stratum 0} check-artifact-test-results
+  "Judge the legacy artifact-metadata shape; nil results only warn."
+  [test-results]
+  (cond
+    (nil? test-results)
+    {:passed? true
+     :warnings [{:type :no-tests
+                 :message (messages/t :tests-pass/no-results)}]}
+
+    (:passed? test-results)
+    {:passed? true
+     :test-count (:test-count test-results)
+     :pass-count (:pass-count test-results)}
+
+    :else
+    {:passed? false
+     :errors [{:type :tests-failed
+               :message (messages/t :tests-pass/failed {:fail-count (:fail-count test-results)})
+               :failures (:failures test-results)}]}))
 
 (defn ^{:stratum 0} check-coverage
   "Check if coverage meets threshold.
@@ -76,21 +126,41 @@
                  :coverage coverage
                  :threshold threshold}]})))
 
-(defmethod ^{:stratum 0} registry/get-gate :tests-pass
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} check-tests-pass
+  "Check if tests pass.
+
+   Reads, in order: the gated phase's own result (verify's test metrics at
+   [:phase :result :metrics] in the ctx — the production path, where the
+   phase :output is nil), then the legacy artifact-metadata :test-results.
+   With neither present the gate passes with a :no-tests warning.
+
+   Before the phase-result source existed, verify's nil :output meant the
+   gate saw no results and passed every run — including runs with failing
+   tests (checkpoint f413dd80, 2026-09-04)."
+  [artifact ctx]
+  (if-let [result (phase-test-result ctx)]
+    (check-phase-test-result result)
+    (check-artifact-test-results (artifact-test-results artifact))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defmethod ^{:stratum 2} registry/get-gate :tests-pass
   [_]
   {:name :tests-pass
    :description "Validates all tests pass"
    :check check-tests-pass
    :repair nil})
 
-(defmethod ^{:stratum 0} registry/get-gate :coverage
+(defmethod ^{:stratum 2} registry/get-gate :coverage
   [_]
   {:name :coverage
    :description "Validates test coverage meets threshold (default 80%)"
    :check check-coverage
    :repair nil})
 
-(defmethod ^{:stratum 0} registry/get-gate :test [_] (registry/get-gate :tests-pass))
+(defmethod ^{:stratum 2} registry/get-gate :test [_] (registry/get-gate :tests-pass))
 
 ;; Registry
 (registry/register-gate! :tests-pass)
@@ -103,6 +173,9 @@
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (check-tests-pass {:metadata {:test-results {:passed? true :test-count 10}}} {})
+  (check-tests-pass nil {:phase {:result {:status :error
+                                           :metrics {:pass-count 3 :fail-count 1
+                                                     :failures [{:test "t" :location "a.clj:1"}]}}}})
   (check-coverage {:metadata {:coverage 85}} {})
   (check-coverage {:metadata {:coverage 70}} {})
   :leave-this-here)

--- a/components/gate/src/ai/miniforge/gate/test.clj
+++ b/components/gate/src/ai/miniforge/gate/test.clj
@@ -45,6 +45,32 @@
     (when (contains? (:metrics result) :fail-count)
       result)))
 
+(defn ^{:stratum 0} check-coverage
+  "Check if coverage meets threshold.
+
+   Default threshold: 80%"
+  [artifact ctx]
+  (let [threshold (or (get-in ctx [:coverage-threshold]) 80)
+        coverage (or (get-in artifact [:metadata :coverage])
+                     (get-in artifact [:artifact/metadata :coverage]))]
+    (cond
+      (nil? coverage)
+      {:passed? true
+       :warnings [{:type :no-coverage
+                   :message "No coverage data found"}]}
+
+      (>= coverage threshold)
+      {:passed? true
+       :coverage coverage
+       :threshold threshold}
+
+      :else
+      {:passed? false
+       :errors [{:type :coverage-below-threshold
+                 :message (str "Coverage " coverage "% below threshold " threshold "%")
+                 :coverage coverage
+                 :threshold threshold}]})))
+
 (defn- ^{:stratum 0} check-phase-test-result
   "Judge a test-bearing phase result. Fails on any failing test, and on a
    phase :status :error with no failing tests (parse error, crashed or timed
@@ -62,7 +88,10 @@
        :pass-count pass-count
        :fail-count fail-count
        :errors [{:type :tests-failed
-                 :message (messages/t :tests-pass/failed {:fail-count fail-count})
+                 :message (messages/t (if (= 1 fail-count)
+                                        :tests-pass/failed-one
+                                        :tests-pass/failed)
+                                      {:fail-count fail-count})
                  :failures failures}]}
 
       (= :error (:status result))
@@ -97,34 +126,10 @@
     :else
     {:passed? false
      :errors [{:type :tests-failed
-               :message (messages/t :tests-pass/failed {:fail-count (:fail-count test-results)})
+               :message (let [n (get test-results :fail-count 0)]
+                          (messages/t (if (= 1 n) :tests-pass/failed-one :tests-pass/failed)
+                                      {:fail-count n}))
                :failures (:failures test-results)}]}))
-
-(defn ^{:stratum 0} check-coverage
-  "Check if coverage meets threshold.
-
-   Default threshold: 80%"
-  [artifact ctx]
-  (let [threshold (or (get-in ctx [:coverage-threshold]) 80)
-        coverage (or (get-in artifact [:metadata :coverage])
-                     (get-in artifact [:artifact/metadata :coverage]))]
-    (cond
-      (nil? coverage)
-      {:passed? true
-       :warnings [{:type :no-coverage
-                   :message "No coverage data found"}]}
-
-      (>= coverage threshold)
-      {:passed? true
-       :coverage coverage
-       :threshold threshold}
-
-      :else
-      {:passed? false
-       :errors [{:type :coverage-below-threshold
-                 :message (str "Coverage " coverage "% below threshold " threshold "%")
-                 :coverage coverage
-                 :threshold threshold}]})))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/gate/test/ai/miniforge/gate/tests_pass_test.clj
+++ b/components/gate/test/ai/miniforge/gate/tests_pass_test.clj
@@ -1,0 +1,150 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.gate.tests-pass-test
+  "Tests for the :tests-pass gate.
+
+   The production verify path (phase-software-factory `enter-verify`) leaves
+   the phase :output nil and puts the test counts in [:result :metrics]. The
+   gate must read them from the ctx it is handed — a nil artifact is not a
+   pass (checkpoint f413dd80, 2026-09-04: every verify entry logged
+   'Gate :tests-pass passed' with failing tests)."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.gate.interface :as gate]
+   [ai.miniforge.gate.test :as gate-test]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} failures
+  [{:kind :fail
+    :test "recording-is-a-no-op-without-a-configured-codex"
+    :location "gap_wiring_test.clj:106"
+    :detail "expected: {:skipped 0}\n  actual: {:torn-lines 0}"}
+   {:kind :error
+    :test "reads-the-ledger"
+    :location "ledger_test.clj:12"
+    :detail "NullPointerException"}])
+
+(defn- ^{:stratum 0} verify-ctx
+  "Ctx as `apply-gate-validation` hands it to a gate: the entered ctx with
+   the verify result at [:phase :result], shaped by `phase/success` /
+   `phase/error` + `phase/test-metrics`."
+  [result]
+  {:phase {:name :verify :status :running :result result}})
+
+(defn- ^{:stratum 0} verify-error-result
+  [pass-count fail-count failures]
+  {:status :error
+   :environment-id "env-1"
+   :summary (str fail-count " tests failed")
+   :error {:message (str fail-count " tests failed")}
+   :metrics {:tokens 0 :duration-ms 0
+             :pass-count pass-count :fail-count fail-count
+             :test-output "FAIL in ..." :failures failures}})
+
+(deftest ^{:stratum 0} non-test-bearing-phase-result-falls-through-test
+  (testing "a phase result whose :metrics has no :fail-count (implement: tokens,
+            cost) is not a test result — legacy artifact source applies"
+    (let [ctx {:phase {:result {:status :success
+                                :metrics {:tokens 1200 :cost-usd 0.02}}}}]
+      (is (true? (:passed? (gate-test/check-tests-pass
+                            {:metadata {:test-results {:passed? true :test-count 3}}}
+                            ctx))))
+      (let [result (gate-test/check-tests-pass
+                    {:metadata {:test-results {:passed? false :fail-count 1
+                                               :failures [{:test "t"}]}}}
+                    ctx)]
+        (is (false? (:passed? result)))
+        (is (= [{:test "t"}] (-> result :errors first :failures)))))))
+
+(deftest ^{:stratum 0} no-results-anywhere-warns-test
+  (testing "neither a test-bearing phase result nor artifact metadata: pass
+            with a :no-tests warning (unchanged legacy behavior)"
+    (let [result (gate-test/check-tests-pass nil {})]
+      (is (true? (:passed? result)))
+      (is (= :no-tests (-> result :warnings first :type))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} failing-tests-deny-test
+  (testing "positive :fail-count in the phase result fails the gate even with
+            a nil artifact (the production verify shape)"
+    (let [result (gate-test/check-tests-pass nil (verify-ctx (verify-error-result 41 2 failures)))
+          error  (first (:errors result))]
+      (is (false? (:passed? result)))
+      (is (= 2 (:fail-count result)))
+      (is (= 41 (:pass-count result)))
+      (is (= :tests-failed (:type error)))
+      (is (= "2 tests failed" (:message error)))
+      (is (= failures (:failures error))
+          "verify's failing tests ride on the gate error for the implementer"))))
+
+(deftest ^{:stratum 1} phase-error-without-failures-denies-test
+  (testing "phase :status :error with zero failing tests (parse error, crashed or
+            timed-out test command) fails — uncounted tests are not passed tests"
+    (let [result (gate-test/check-tests-pass
+                  nil
+                  (verify-ctx {:status :error
+                               :summary "bb test timed out after 300000 ms"
+                               :error {:message "bb test timed out after 300000 ms"}
+                               :metrics {:tokens 0 :duration-ms 0
+                                         :pass-count 0 :fail-count 0
+                                         :test-output "" :parse-error? true}}))
+          error  (first (:errors result))]
+      (is (false? (:passed? result)))
+      (is (= :verify-error (:type error)))
+      (is (= "bb test timed out after 300000 ms" (:message error)))
+      (is (= [] (:failures error))))))
+
+(deftest ^{:stratum 1} passing-tests-allow-test
+  (testing "a successful verify result with zero failures passes and reports counts"
+    (let [result (gate-test/check-tests-pass
+                  nil
+                  (verify-ctx {:status :success
+                               :environment-id "env-1"
+                               :summary "43 tests passed"
+                               :metrics {:tokens 0 :duration-ms 0
+                                         :pass-count 43 :fail-count 0
+                                         :test-output "Ran 43 tests"}}))]
+      (is (true? (:passed? result)))
+      (is (= 43 (:pass-count result)))
+      (is (empty? (:errors result)))
+      (is (empty? (:warnings result))))))
+
+(deftest ^{:stratum 1} phase-result-wins-over-artifact-metadata-test
+  (testing "when both sources exist the phase result is canonical"
+    (let [artifact {:metadata {:test-results {:passed? true :test-count 10}}}
+          result   (gate-test/check-tests-pass artifact (verify-ctx (verify-error-result 9 1 failures)))]
+      (is (false? (:passed? result))))))
+
+(deftest ^{:stratum 1} check-gates-through-registry-test
+  (testing "the registered :tests-pass gate denies a failing verify through
+            check-gates, and the structured error survives for
+            :phase/gate-failures"
+    (let [gate-result (gate/check-gates [:tests-pass] nil (verify-ctx (verify-error-result 41 2 failures)))
+          failed      (first (:failed-gates gate-result))]
+      (is (false? (:passed? gate-result)))
+      (is (= :tests-pass (:gate failed)))
+      (is (= failures (-> failed :errors first :failures)))))
+  (testing "the :test alias denies too"
+    (is (false? (:passed? (gate/check-gates [:test] nil (verify-ctx (verify-error-result 0 1 failures)))))))
+  (testing "and allows a green verify"
+    (is (true? (:passed? (gate/check-gates [:tests-pass] nil
+                                           (verify-ctx {:status :success
+                                                        :metrics {:pass-count 5 :fail-count 0
+                                                                  :test-output ""}})))))))

--- a/components/gate/test/ai/miniforge/gate/tests_pass_test.clj
+++ b/components/gate/test/ai/miniforge/gate/tests_pass_test.clj
@@ -141,8 +141,10 @@
       (is (false? (:passed? gate-result)))
       (is (= :tests-pass (:gate failed)))
       (is (= failures (-> failed :errors first :failures)))))
-  (testing "the :test alias denies too"
-    (is (false? (:passed? (gate/check-gates [:test] nil (verify-ctx (verify-error-result 0 1 failures)))))))
+  (testing "the :test alias denies too, with the singular message for one failure"
+    (let [gate-result (gate/check-gates [:test] nil (verify-ctx (verify-error-result 0 1 failures)))]
+      (is (false? (:passed? gate-result)))
+      (is (= "1 test failed" (-> gate-result :failed-gates first :errors first :message)))))
   (testing "and allows a green verify"
     (is (true? (:passed? (gate/check-gates [:tests-pass] nil
                                            (verify-ctx {:status :success

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -345,6 +345,18 @@
        (when location (str " (" location ")"))
        (when-not (str/blank? detail) (str "\n" detail))))
 
+(defn- ^{:stratum 0} prior-gate-failures
+  "Structured gate errors from the prior denied attempts that redirected
+   here, implement's own first, then verify's. Verify's gates (:tests-pass,
+   :policy-verify) deny on the verify result and redirect to implement, and
+   their errors travel the same [:phase/gate-failures] channel — so the
+   failing tests reach the implementer as a denial, not only as test output.
+   nil when no prior denial exists."
+  [ctx]
+  (seq (mapcat (fn [phase-name]
+                 (get-in ctx [:execution/phase-results phase-name :phase/gate-failures]))
+               [:implement :verify])))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} truncate-test-output
@@ -740,8 +752,7 @@
         ;; is cleared before every step). This is what turns a gate from
         ;; a wall into a repair instruction — deny, retry with the
         ;; evidence, fix, pass.
-        gate-failures (seq (get-in ctx [:execution/phase-results
-                                        :implement :phase/gate-failures]))
+        gate-failures (prior-gate-failures ctx)
         {:keys [formatted manifest]} (kb-helpers/inject-with-manifest
                                        (:knowledge-store ctx) :implementer (get input :tags []))
         base-task (assoc-optional-task-fields

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -1020,6 +1020,21 @@
                             failures))
           {:keys [task]} (implement/build-implement-task ctx)]
       (is (= failures (:task/gate-failures task)))))
+  (testing "verify's gate denial (:tests-pass on the verify result) rides the
+            same channel, after any implement denial"
+    (let [implement-failures [{:gate :stale-references
+                               :errors [{:message "':skipped' still referenced"}]}]
+          verify-failures    [{:gate :tests-pass
+                               :errors [{:type :tests-failed
+                                         :message "1 tests failed"
+                                         :failures [{:test "t" :location "t.clj:1"}]}]}]
+          ctx (-> (create-base-context)
+                  (assoc-in [:execution/phase-results :implement :phase/gate-failures]
+                            implement-failures)
+                  (assoc-in [:execution/phase-results :verify :phase/gate-failures]
+                            verify-failures))
+          {:keys [task]} (implement/build-implement-task ctx)]
+      (is (= (into implement-failures verify-failures) (:task/gate-failures task)))))
   (testing "no prior denial -> key absent"
     (let [{:keys [task]} (implement/build-implement-task (create-base-context))]
       (is (not (contains? task :task/gate-failures))))))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -1026,7 +1026,7 @@
                                :errors [{:message "':skipped' still referenced"}]}]
           verify-failures    [{:gate :tests-pass
                                :errors [{:type :tests-failed
-                                         :message "1 tests failed"
+                                         :message "1 test failed"
                                          :failures [{:test "t" :location "t.clj:1"}]}]}]
           ctx (-> (create-base-context)
                   (assoc-in [:execution/phase-results :implement :phase/gate-failures]

--- a/docs/pull-requests/2026-09-04-fix-tests-pass-gate-reads-verify-metrics.md
+++ b/docs/pull-requests/2026-09-04-fix-tests-pass-gate-reads-verify-metrics.md
@@ -1,0 +1,90 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix(gate): :tests-pass reads verify's test metrics from the phase result
+
+**Tier:** blocker / dogfood-enabler
+**Theme:** gates, verify, implementer feedback
+
+## Problem
+
+`check-tests-pass` in `components/gate/src/ai/miniforge/gate/test.clj` read
+`[:metadata :test-results]` off the artifact and returned a pass with a
+`:no-tests` warning when that was nil. On the production verify path
+(`enter-verify` in `phase_software_factory/verify.clj`) the phase result's
+`[:result :output]` is nil and the test counts live in `[:result :metrics]`
+(`:pass-count`, `:fail-count`, `:failures`, `:test-output`). The gate never
+saw a result, so it logged `Gate :tests-pass passed` on every verify run,
+including runs with failing tests. Checkpoint
+`f413dd80-394c-46d0-86b8-46d3dbb33dd8`, every verify entry in
+`gate-history.edn`, shows only `:policy-verify` denials; the failing tests
+never registered as a gate failure.
+
+A second gap sat downstream: `build-implement-task` read
+`:phase/gate-failures` only from the implement phase result. Verify's gates
+deny on the verify result and redirect to implement, so their structured
+errors never reached the implementer's gate-denial section.
+
+## Changes
+
+### Gate (`components/gate/src/ai/miniforge/gate/test.clj`)
+
+`apply-gate-validation` in `workflow/execution.clj` hands each gate the
+entered ctx, whose `[:phase :result]` is the phase result. The gate now reads
+that first:
+
+1. A result whose `:metrics` carries `:fail-count` is test-bearing (the
+   `phase/test-metrics` contract). Positive `:fail-count` denies with
+   `{:type :tests-failed :message "N tests failed" :failures [...]}`.
+2. A phase `:status :error` with zero counted failures (parse error, crashed
+   or timed-out test command) denies with `{:type :verify-error}` carrying
+   the phase's error message. Uncounted tests are not passed tests.
+3. Otherwise the gate passes and reports `:pass-count`.
+4. A phase result without `:fail-count` in its metrics (implement's
+   tokens/cost metrics) is not a test result. The legacy artifact-metadata
+   shape applies, and with neither source the `:no-tests` warning is
+   unchanged.
+
+New prose strings go through the gate messages catalog
+(`config/gate/messages/en-US.edn`, keys `:tests-pass/*`).
+
+### Implementer feedback
+
+- `prior-gate-failures` in `phase_software_factory/implement.clj` gathers
+  `:phase/gate-failures` from both the implement and verify phase results,
+  implement first. Verify's `:tests-pass` and `:policy-verify` denials now
+  render in the gate-denial section.
+- `format-gate-failures-section` in `agent/implementer.clj` prints each
+  `:failures` entry (test name and location) under its error line, so a
+  `:tests-pass` denial names the tests to fix.
+
+## Tests
+
+- New `components/gate/test/ai/miniforge/gate/tests_pass_test.clj`, 7 tests:
+  failing tests deny a nil artifact; phase error without failures denies;
+  green verify allows with counts; phase result wins over artifact metadata;
+  non-test-bearing phase result falls through; no source warns; the
+  registered gate and its `:test` alias deny through `check-gates` with
+  `:failures` intact.
+- `implementer_test.clj`: a `:tests-pass` denial renders each failing test
+  with its location.
+- `implement_test.clj`: verify's gate failures reach `:task/gate-failures`
+  after implement's own.
+
+Run:
+
+- `clojure -M:poly test brick:gate`
+- `clojure -M:poly test brick:agent`
+- `clojure -M:poly test brick:phase-software-factory`
+
+## Notes
+
+- The third commit used `MINIFORGE_STRATUM_BUDGET_MODE=warn`. `implement.clj`
+  and `implementer.clj` are over the SL003 layer budget on main already (7 and
+  8 layers, unchanged by this PR); the warn mode is the documented path for
+  files still mid namespace-split.
+- Behavior change beyond `:tests-pass`: verify's `:policy-verify` denials
+  now also reach the implementer as gate failures. They travelled the same
+  channel and were dropped by the same read.


### PR DESCRIPTION
## Summary

- `check-tests-pass` read `[:metadata :test-results]` off the artifact and passed with a `:no-tests` warning when nil. On the production verify path the phase `:output` is nil and the counts live in `[:result :metrics]`, so the gate logged `Gate :tests-pass passed` on every run, including runs with failing tests (checkpoint `f413dd80`, every verify entry).
- The gate now reads the gated phase's result from the ctx `apply-gate-validation` hands it (`[:phase :result]`). Positive `:fail-count` denies; phase `:status :error` with no counted failures denies; verify's `:failures` ride on the gate error. Artifact metadata stays as the fallback; no source still warns `:no-tests`.
- `build-implement-task` now gathers `:phase/gate-failures` from the verify phase result as well as implement's, and the gate-denial renderer prints each failing test with its location.

Doc: `docs/pull-requests/2026-09-04-fix-tests-pass-gate-reads-verify-metrics.md`

## Test plan

- [x] `clojure -M:poly test brick:gate` (new `tests_pass_test.clj`, 7 tests / 25 assertions)
- [x] `clojure -M:poly test brick:agent`
- [x] `clojure -M:poly test brick:phase-software-factory`
- [x] `bb pre-commit` on every commit

## Notes

- Third commit used `MINIFORGE_STRATUM_BUDGET_MODE=warn`: `implement.clj` and `implementer.clj` are over the SL003 layer budget on main already (7 and 8 layers, unchanged here).
- Side effect: verify's `:policy-verify` denials now also reach the implementer's gate-denial section. Same channel, same read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)