### PR TITLE
refactor(workflow): stratum headings for runner test namespaces (rule 210)

### DIFF
--- a/components/workflow/test/ai/miniforge/workflow/anomaly/build_initial_context_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/build_initial_context_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.workflow.anomaly.build-initial-context-test
   "Coverage for `runner/build-initial-context` (anomaly-returning) and
    its failed-context conversion in `runner/run-pipeline`.
@@ -30,21 +29,24 @@
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.workflow.runner :as runner]))
 
-(def workflow
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} workflow
   {:workflow/id :test
    :workflow/version "1.0.0"
    :workflow/phases []
    :workflow/pipeline []})
 
-(def input {:repo-url "https://example.test/repo"})
+(def ^{:stratum 0} input {:repo-url "https://example.test/repo"})
+
+;------------------------------------------------------------------------------ Layer 1
 
 ;------------------------------------------------------------------------------ Anomaly-returning happy path
 ;;
 ;; :local mode bypasses the capsule check and assembles a context. We
 ;; only assert non-anomaly here because the assembled map's full shape
 ;; is the responsibility of the existing runner_pipeline_test suite.
-
-(deftest build-initial-context-local-mode-returns-context
+(deftest ^{:stratum 1} build-initial-context-local-mode-returns-context
   (testing ":local mode produces a context map (not an anomaly)"
     (let [result (runner/build-initial-context workflow input
                                                 {:execution-mode :local})]
@@ -52,15 +54,14 @@
       (is (= :local (:execution/mode result))))))
 
 ;------------------------------------------------------------------------------ Anomaly-returning failure path
-
-(deftest build-initial-context-governed-without-capsule
+(deftest ^{:stratum 1} build-initial-context-governed-without-capsule
   (testing ":governed mode with no executor + env-id yields :invalid-input anomaly"
     (let [result (runner/build-initial-context workflow input
                                                 {:execution-mode :governed})]
       (is (anomaly/anomaly? result))
       (is (= :invalid-input (:anomaly/type result))))))
 
-(deftest build-initial-context-anomaly-data-carries-flags
+(deftest ^{:stratum 1} build-initial-context-anomaly-data-carries-flags
   (testing "anomaly data carries enough triage info for the caller"
     (let [result (runner/build-initial-context workflow input
                                                 {:execution-mode :governed})
@@ -69,7 +70,7 @@
       (is (false? (:has-executor? data)))
       (is (false? (:has-environment-id? data))))))
 
-(deftest build-initial-context-governed-with-executor-only
+(deftest ^{:stratum 1} build-initial-context-governed-with-executor-only
   (testing "executor without env-id is still an anomaly — both must be present"
     (let [result (runner/build-initial-context workflow input
                                                 {:execution-mode :governed
@@ -85,8 +86,7 @@
 ;; helper so the context-building anomaly is exercised directly rather
 ;; than being masked by runner-environment's separate governed-mode
 ;; acquisition checks.
-
-(deftest run-pipeline-context-anomaly-returns-failed-context
+(deftest ^{:stratum 1} run-pipeline-context-anomaly-returns-failed-context
   (testing "run-pipeline converts build-initial-context anomaly to failed context"
     (with-redefs-fn {#'runner/acquire-environment
                      (fn [_workflow _input opts] [nil opts])}

--- a/components/workflow/test/ai/miniforge/workflow/environment_promotion_integration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/environment_promotion_integration_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.workflow.environment-promotion-integration-test
   "Integration tests for the environment promotion pipeline.
 
@@ -40,51 +39,35 @@
    [ai.miniforge.workflow.phase-test-support :as phase-test-support]
    [ai.miniforge.workflow.runner :as runner]))
 
-;------------------------------------------------------------------------------ Fixtures
+;------------------------------------------------------------------------------ Layer 0
 
-(def ^:private env-promotion-implement
+;------------------------------------------------------------------------------ Fixtures
+(def ^{:stratum 0} ^:private env-promotion-implement
   :env-promotion-test-implement)
 
-(def ^:private env-promotion-verify
+(def ^{:stratum 0} ^:private env-promotion-verify
   :env-promotion-test-verify)
 
-(def ^:private env-promotion-done
+(def ^{:stratum 0} ^:private env-promotion-done
   phase-test-support/runner-test-done)
 
-(def ^:dynamic *test-worktree* nil)
+(def ^{:stratum 0} ^:dynamic *test-worktree* nil)
 
-(def phase-test-config-resource
+(def ^{:stratum 0} phase-test-config-resource
   "config/phase/workflow-test-support-namespaces.edn")
 
-(defn create-temp-worktree []
+(defn ^{:stratum 0} create-temp-worktree []
   (let [temp-dir (io/file (System/getProperty "java.io.tmpdir")
                           (str "env-promotion-test-" (random-uuid)))]
     (.mkdirs temp-dir)
     (.getPath temp-dir)))
 
-(defn cleanup-temp-worktree [dir-path]
+(defn ^{:stratum 0} cleanup-temp-worktree [dir-path]
   (when dir-path
     (try (fs/delete-tree dir-path) (catch Exception _e nil))))
 
-(defn worktree-fixture [f]
-  (let [worktree (create-temp-worktree)]
-    (binding [*test-worktree* worktree]
-      (try (f)
-           (finally (cleanup-temp-worktree worktree))))))
-
-(defn phase-loader-fixture [f]
-  (phase/reset-phase-loader!)
-  (try
-    (binding [loader/phase-loader-config-resource phase-test-config-resource]
-      (f))
-    (finally
-      (phase/reset-phase-loader!))))
-
-(use-fixtures :each worktree-fixture phase-loader-fixture)
-
 ;------------------------------------------------------------------------------ Helpers
-
-(defn mock-curator
+(defn ^{:stratum 0} mock-curator
   "Default curator stub for tests that don't care about file-diff semantics.
 
    The real curator (agent/curate-implement-output) inspects the worktree
@@ -100,20 +83,14 @@
      :code/summary "test fixture wrote feature.clj"}
     {:metrics {:tokens 0 :duration-ms 0}}))
 
-(def ^:private env-promotion-phase-defaults
+(def ^{:stratum 0} ^:private env-promotion-phase-defaults
   {:agent :workflow-tester
    :gates []
    :budget {:tokens 1
             :iterations 1
             :time-seconds 1}})
 
-(defn- register-env-promotion-phase!
-  [phase-name]
-  (registry/register-phase-defaults!
-   phase-name
-   (assoc env-promotion-phase-defaults :phase phase-name)))
-
-(defn- implement-phase-result
+(defn- ^{:stratum 0} implement-phase-result
   [ctx]
   (let [agent-result (agent/invoke (agent/create-implementer nil) nil ctx)
         curated-result (when (response/success? agent-result)
@@ -129,33 +106,14 @@
        :result agent-result
        :metrics (:metrics agent-result)})))
 
-(defn- verify-phase-result
+(defn- ^{:stratum 0} verify-phase-result
   [ctx]
   {:status :completed
    :result {:status :success
             :environment-id (:execution/environment-id ctx)
             :output {:tests-passed? true}}})
 
-(defmethod registry/get-phase-interceptor env-promotion-implement
-  [config]
-  {:name ::env-promotion-implement
-   :config (registry/merge-with-defaults config)
-   :enter (fn [ctx] (assoc ctx :phase (implement-phase-result ctx)))
-   :leave identity
-   :error (fn [ctx _ex] ctx)})
-
-(defmethod registry/get-phase-interceptor env-promotion-verify
-  [config]
-  {:name ::env-promotion-verify
-   :config (registry/merge-with-defaults config)
-   :enter (fn [ctx] (assoc ctx :phase (verify-phase-result ctx)))
-   :leave identity
-   :error (fn [ctx _ex] ctx)})
-
-(register-env-promotion-phase! env-promotion-implement)
-(register-env-promotion-phase! env-promotion-verify)
-
-(defn make-workflow
+(defn ^{:stratum 0} make-workflow
   "Build a minimal workflow config with the given phase sequence.
 
    Gates are disabled because these tests target environment-promotion
@@ -168,15 +126,52 @@
    :workflow/version "1.0.0"
    :workflow/pipeline (mapv (fn [p] {:phase p :gates []}) phases)})
 
-(defn base-input []
+(defn ^{:stratum 0} base-input []
   {:task "Add a new feature"
    :description "Add a new feature to the codebase"
    :title "Add feature"
    :intent "implement"})
 
-;------------------------------------------------------------------------------ Test 1: Full pipeline — environment flows through all phases
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest full-pipeline-environment-flows-through-phases-test
+(defn ^{:stratum 1} worktree-fixture [f]
+  (let [worktree (create-temp-worktree)]
+    (binding [*test-worktree* worktree]
+      (try (f)
+           (finally (cleanup-temp-worktree worktree))))))
+
+(defn ^{:stratum 1} phase-loader-fixture [f]
+  (phase/reset-phase-loader!)
+  (try
+    (binding [loader/phase-loader-config-resource phase-test-config-resource]
+      (f))
+    (finally
+      (phase/reset-phase-loader!))))
+
+(defn- ^{:stratum 1} register-env-promotion-phase!
+  [phase-name]
+  (registry/register-phase-defaults!
+   phase-name
+   (assoc env-promotion-phase-defaults :phase phase-name)))
+
+(defmethod ^{:stratum 1} registry/get-phase-interceptor env-promotion-implement
+  [config]
+  {:name ::env-promotion-implement
+   :config (registry/merge-with-defaults config)
+   :enter (fn [ctx] (assoc ctx :phase (implement-phase-result ctx)))
+   :leave identity
+   :error (fn [ctx _ex] ctx)})
+
+(defmethod ^{:stratum 1} registry/get-phase-interceptor env-promotion-verify
+  [config]
+  {:name ::env-promotion-verify
+   :config (registry/merge-with-defaults config)
+   :enter (fn [ctx] (assoc ctx :phase (verify-phase-result ctx)))
+   :leave identity
+   :error (fn [ctx _ex] ctx)})
+
+;------------------------------------------------------------------------------ Test 1: Full pipeline — environment flows through all phases
+(deftest ^{:stratum 1} full-pipeline-environment-flows-through-phases-test
   (testing "Full plan→implement→verify→done pipeline with pre-acquired executor"
     (let [env-id      (random-uuid)
           release-env-called? (atom false)
@@ -223,8 +218,7 @@
               "File written by implement agent should exist in executor environment"))))))
 
 ;------------------------------------------------------------------------------ Test 2: Environment released on pipeline failure
-
-(deftest environment-released-on-pipeline-failure-test
+(deftest ^{:stratum 1} environment-released-on-pipeline-failure-test
   (testing "Environment is released in finally block even when pipeline fails"
     (let [acquired-env-id (random-uuid)
           release-called? (atom false)
@@ -262,8 +256,7 @@
                   "release-environment! should be called in the finally block even on failure"))))))))
 
 ;------------------------------------------------------------------------------ Test 3: Environment-id propagates through context via pre-acquired shortcut
-
-(deftest environment-id-propagates-via-pre-acquired-shortcut-test
+(deftest ^{:stratum 1} environment-id-propagates-via-pre-acquired-shortcut-test
   (testing "Pre-acquired :executor + :environment-id shortcut sets env-id on initial context"
     (let [env-id   (random-uuid)
           workflow (make-workflow env-promotion-implement env-promotion-done)]
@@ -294,8 +287,7 @@
               "Pipeline should complete when pre-acquired executor is provided"))))))
 
 ;------------------------------------------------------------------------------ Test 4: release-environment! NOT called when pre-acquired executor was passed
-
-(deftest pre-acquired-executor-not-released-by-runner-test
+(deftest ^{:stratum 1} pre-acquired-executor-not-released-by-runner-test
   (testing "Runner does not call release-environment! when executor was pre-acquired (caller owns lifecycle)"
     (let [env-id         (random-uuid)
           release-called? (atom false)
@@ -318,6 +310,12 @@
           ;; When executor is pre-acquired, runner should NOT release it
           (is (false? @release-called?)
               "Runner should not release a pre-acquired environment (caller owns lifecycle)"))))))
+
+(use-fixtures :each worktree-fixture phase-loader-fixture)
+
+(register-env-promotion-phase! env-promotion-implement)
+
+(register-env-promotion-phase! env-promotion-verify)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.workflow.run7-regression-test
   "Regression tests for Run 7+ bugs:
    1. Duration-ms always 0 — agent metrics fallback shadows real wall-clock time
@@ -31,15 +30,10 @@
    [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.workflow.execution :as exec]))
 
-(def phase-test-config-resource
-  "config/phase/workflow-test-support-namespaces.edn")
+;------------------------------------------------------------------------------ Layer 0
 
-(use-fixtures :each
-  (fn [f]
-    (phase/reset-phase-loader!)
-    (binding [loader/phase-loader-config-resource phase-test-config-resource]
-      (f))
-    (phase/reset-phase-loader!)))
+(def ^{:stratum 0} phase-test-config-resource
+  "config/phase/workflow-test-support-namespaces.edn")
 
 ;; ============================================================================
 ;; Fix 1: Duration-ms extraction in publish-phase-completed!
@@ -47,8 +41,7 @@
 ;; Root cause: (or [:metrics :duration-ms] ...) returned 0 (agent fallback)
 ;; before (:duration-ms result) (real wall-clock time) was tried.
 ;; ============================================================================
-
-(deftest duration-ms-extraction-order-test
+(deftest ^{:stratum 0} duration-ms-extraction-order-test
   (testing "phase result with real :duration-ms takes priority over :metrics fallback"
     ;; Simulate a phase result where:
     ;; - [:metrics :duration-ms] = 0 (agent didn't track time)
@@ -90,8 +83,7 @@
 ;; Root cause: an optional dynamic constructor lookup silently did nothing when
 ;; the constructor var was not resolvable.
 ;; ============================================================================
-
-(deftest publish-workflow-completed-fallback-test
+(deftest ^{:stratum 0} publish-workflow-completed-fallback-test
   (testing "publishes ad-hoc event when event-stream is provided"
     (let [_events (atom [])
           ;; Use a simple map as event-stream — publish-event! uses find-ns
@@ -119,8 +111,7 @@
 ;; the LLM client doesn't track wall-clock time. The phase leave function
 ;; computes real duration but the agent's 0 was used instead.
 ;; ============================================================================
-
-(deftest phase-leave-overrides-agent-duration-test
+(deftest ^{:stratum 0} phase-leave-overrides-agent-duration-test
   (testing "implement leave stores real duration in :phase :metrics :duration-ms"
     ;; We can't easily call leave-implement directly without a full context,
     ;; but we can verify the pattern: after applying the fix, the metrics map
@@ -150,8 +141,7 @@
 ;; ============================================================================
 ;; Fix 4: Stale :phase map cleared between phases (from PR #268, verify here)
 ;; ============================================================================
-
-(deftest phase-map-cleared-between-phases-test
+(deftest ^{:stratum 0} phase-map-cleared-between-phases-test
   (testing "execute-phase-lifecycle clears :phase before entering next phase"
     ;; Simulate a context with a stale :phase map from a previous phase
     ;; (e.g., verify left a redirect transition request on it)
@@ -176,7 +166,7 @@
       (is (nil? (get-in ctx-after [:phase :phase/transition-request]))
           "Stale phase transition request must not leak"))))
 
-(deftest enter-failure-skips-leave-test
+(deftest ^{:stratum 0} enter-failure-skips-leave-test
   (testing "execute-phase-lifecycle does not invoke :leave when :enter never established phase context"
     (let [leave-called? (atom false)
           interceptor {:name ::failing-enter
@@ -203,8 +193,7 @@
 ;; execute-phase-lifecycle clears :phase before entering next phase.
 ;; Implement now reads from [:execution/phase-results :review] instead.
 ;; ============================================================================
-
-(deftest review-feedback-survives-phase-clearing-test
+(deftest ^{:stratum 0} review-feedback-survives-phase-clearing-test
   (testing "implement reads review feedback from phase-results, not :phase"
     ;; Simulate context after review phase: :phase cleared, but phase-results has review output
     (let [review-feedback [{:type :blocking :message "Missing error handling for nil input"}]
@@ -238,3 +227,10 @@
   (testing "max-redirects is now 5"
     (is (= 5 exec/max-redirects)
         "Should allow 5 redirects for complex repair cycles")))
+
+(use-fixtures :each
+  (fn [f]
+    (phase/reset-phase-loader!)
+    (binding [loader/phase-loader-config-resource phase-test-config-resource]
+      (f))
+    (phase/reset-phase-loader!)))

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.workflow.runner-extended-test
   "Extended tests for workflow runner: output extraction, event publishing,
    and edge cases not covered by the main runner_test."
@@ -30,6 +29,8 @@
    [ai.miniforge.workflow.messages :as messages]
    [ai.miniforge.workflow.phase-test-support :as phase-test-support]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ---------------------------------------------------------------------------- mock capsule executor
 ;; The governed-mode tests below assert that run-pipeline routes mode/worktree
 ;; metadata correctly. They should never touch a real Docker daemon —
@@ -37,15 +38,14 @@
 ;; daemon is busy or stuck (which is exactly the hang documented in PR #893's
 ;; PR doc, where bb pre-commit's stable-derived sweep stalled here for 300s+).
 ;; Mock the dag-executor surface so these tests stay deterministic.
-
-(defn- mock-capsule-registry
+(defn- ^{:stratum 0} mock-capsule-registry
   "Drop-in for `dag-exec/create-executor-registry` that returns a synthetic
    capsule executor without ever talking to Docker."
   [_config]
   {:docker   ::mock-capsule
    :worktree ::mock-worktree})
 
-(defn- mock-capsule-select
+(defn- ^{:stratum 0} mock-capsule-select
   "Drop-in for `dag-exec/select-executor` — returns the stub capsule
    under governed mode and the stub worktree otherwise."
   ([registry] (:docker registry))
@@ -55,7 +55,7 @@
        :worktree (:worktree registry)
        (:docker registry)))))
 
-(defn- mock-capsule-acquire
+(defn- ^{:stratum 0} mock-capsule-acquire
   "Drop-in for `dag-exec/acquire-environment!`. Returns a host-path
    environment record so :execution/worktree-path looks like a real
    host worktree, not the container-internal /workspace."
@@ -64,7 +64,7 @@
                 :workdir        "/tmp/mock-host-worktree"
                 :metadata       {:base-branch "main"}}))
 
-(defn- mock-capsule-type
+(defn- ^{:stratum 0} mock-capsule-type
   "Drop-in for `dag-exec/executor-type`. The capsule stub is :docker,
    the worktree stub is :worktree — matches what the runner expects so
    N11 §7.4's no-silent-downgrade check still discriminates."
@@ -74,7 +74,135 @@
     ::mock-worktree :worktree
     :unknown))
 
-(defmacro ^:private with-mock-capsule-executor
+(def ^{:stratum 0} ^:private runner-test-plan
+  phase-test-support/runner-test-plan)
+
+(def ^{:stratum 0} ^:private runner-test-implement
+  phase-test-support/runner-test-implement)
+
+(def ^{:stratum 0} ^:private runner-test-verify
+  phase-test-support/runner-test-verify)
+
+(def ^{:stratum 0} ^:private runner-test-done
+  phase-test-support/runner-test-done)
+
+;; ---------------------------------------------------------------------------- extract-output
+(deftest ^{:stratum 0} extract-output-empty-results-test
+  (testing "extract-output handles empty phase-results"
+    (let [ctx {:execution/artifacts []
+               :execution/phase-results {}
+               :execution/current-phase nil
+               :execution/status :completed}
+          result (runner/extract-output ctx)
+          output (:execution/output result)]
+      (is (= [] (:artifacts output)))
+      (is (= {} (:phase-results output)))
+      (is (nil? (:last-phase-result output)))
+      (is (= :completed (:status output))))))
+
+(deftest ^{:stratum 0} build-pipeline-no-pipeline-no-phases-test
+  (testing "no pipeline and no phases returns empty"
+    (let [pipeline (runner/build-pipeline {})]
+      (is (empty? pipeline)))))
+
+;; ---------------------------------------------------------------------------- DAG metric rollup regression
+;; Two sets of fixture metrics back the rollup tests below.
+;; success-path fixture: arbitrary but ergonomic numbers chosen to be visually
+;; distinct from any wall-clock or framework default so an off-by-one or wrong-
+;; key bug surfaces as an exact-value mismatch in the assertion output.
+(def ^{:stratum 0} ^:private dag-success-fixture-metrics
+  "Synthetic metrics injected into a successful DAG result. Values are
+   deliberately chosen to be non-zero, non-round in cost, and well below any
+   real wall-clock duration so they cannot collide with `stamp-wall-clock-
+   duration`'s output."
+  {:tokens      12345
+   :cost-usd    9.87
+   :duration-ms 60000})
+
+;; failure-path fixture: REAL numbers from the 2026-06-04
+;; `eliminate-requiring-resolve` dogfood (3h26m, 20-task DAG, 20/20 failed).
+;; Pinning to the observed values turns the test into a regression anchor for
+;; the specific cost-zero bug the PR fixes — if these don't round-trip, the
+;; rollup is broken on the same failure shape that originally surfaced it.
+(def ^{:stratum 0} ^:private dag-failure-fixture-tokens
+  "Total tokens observed across all 20 sub-workflows of the
+   2026-06-04 eliminate-requiring-resolve dogfood run."
+  516816)
+
+(def ^{:stratum 0} ^:private dag-failure-fixture-cost-usd
+  "Total cost (USD) observed across all 20 sub-workflows of the
+   2026-06-04 eliminate-requiring-resolve dogfood run. Pre-fix this surfaced
+   as `Cost: $0.0000` at the top of the run summary."
+  42.22608595)
+
+(def ^{:stratum 0} ^:private dag-failure-fixture-duration-ms
+  "Total summed sub-workflow duration from the 2026-06-04 dogfood. Note this
+   value is INTENTIONALLY overwritten by wall-clock stamping in
+   `transition-to-failed`, so it's pinned for completeness but not asserted."
+  48356404)
+
+;; ---------------------------------------------------------------------------- publish-event edge cases
+(deftest ^{:stratum 0} publish-event-nil-stream-test
+  (testing "publish-event with nil stream is a no-op"
+    ;; Should not throw
+    (is (nil? (runner/publish-event! nil {:event/type :test})))))
+
+(deftest ^{:stratum 0} publish-event-in-memory-stream-test
+  (testing "publish-event no-ops for non-stream maps"
+    (is (nil? (runner/publish-event! {} {:event/type :test})))))
+
+;; ---------------------------------------------------------------------------- terminal-state?
+(deftest ^{:stratum 0} terminal-state-test
+  (testing "completed and failed are terminal"
+    (is (true? (runner/terminal-state? {:execution/status :completed})))
+    (is (true? (runner/terminal-state? {:execution/status :failed}))))
+
+  (testing "running is not terminal"
+    (is (false? (runner/terminal-state? {:execution/status :running})))))
+
+;; ---------------------------------------------------------------------------- handle-empty-pipeline
+(deftest ^{:stratum 0} handle-empty-pipeline-test
+  (testing "adds error and transitions to failed"
+    (let [ctx (ctx/create-context {:workflow/id :test} {} {})
+          result (runner/handle-empty-pipeline ctx)]
+      (is (= :failed (:execution/status result)))
+      (is (some #(= :empty-pipeline (:type %)) (:execution/errors result))))))
+
+;; ---------------------------------------------------------------------------- handle-max-phases-exceeded
+(deftest ^{:stratum 0} handle-max-phases-exceeded-test
+  (testing "adds error about max phases"
+    (let [ctx (ctx/create-context {:workflow/id :test} {} {})
+          result (runner/handle-max-phases-exceeded ctx 10)]
+      (is (= :failed (:execution/status result)))
+      (is (some #(= :max-phases-exceeded (:type %)) (:execution/errors result))))))
+
+;; ---------------------------------------------------------------------------- publish helpers with nil stream
+(deftest ^{:stratum 0} publish-workflow-started-nil-stream-test
+  (testing "no-op with nil event stream"
+    (is (nil? (runner/publish-workflow-started! nil {})))))
+
+(deftest ^{:stratum 0} publish-workflow-completed-nil-stream-test
+  (testing "no-op with nil event stream"
+    (is (nil? (runner/publish-workflow-completed! nil {})))))
+
+(deftest ^{:stratum 0} publish-phase-started-nil-stream-test
+  (testing "no-op with nil event stream"
+    (is (nil? (runner/publish-phase-started! nil {} :plan)))))
+
+(deftest ^{:stratum 0} publish-phase-completed-nil-stream-test
+  (testing "no-op with nil event stream"
+    (is (nil? (runner/publish-phase-completed! nil {} :plan {})))))
+
+;; ---------------------------------------------------------------------------- persist-workspace-at-phase-boundary!
+(def ^{:stratum 0} ^:private persist-fn
+  "Var accessor for persist-workspace-at-phase-boundary! (extracted to runner-environment)."
+  (do (require 'ai.miniforge.workflow.runner-environment)
+      (ns-resolve 'ai.miniforge.workflow.runner-environment
+                  'persist-workspace-at-phase-boundary!)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defmacro ^{:stratum 1} ^:private with-mock-capsule-executor
   "Run body with the dag-executor surface mocked out so governed-mode
    path doesn't reach a real Docker daemon. Also no-ops release and
    persist so the cleanup path doesn't log protocol-mismatch warnings
@@ -88,36 +216,7 @@
                  dag-exec/persist-workspace!       (fn [& _#] (dag-exec/ok {}))]
      ~@body))
 
-(use-fixtures :each phase-test-support/with-workflow-phase-test-support)
-
-(def ^:private runner-test-plan
-  phase-test-support/runner-test-plan)
-
-(def ^:private runner-test-implement
-  phase-test-support/runner-test-implement)
-
-(def ^:private runner-test-verify
-  phase-test-support/runner-test-verify)
-
-(def ^:private runner-test-done
-  phase-test-support/runner-test-done)
-
-;; ---------------------------------------------------------------------------- extract-output
-
-(deftest extract-output-empty-results-test
-  (testing "extract-output handles empty phase-results"
-    (let [ctx {:execution/artifacts []
-               :execution/phase-results {}
-               :execution/current-phase nil
-               :execution/status :completed}
-          result (runner/extract-output ctx)
-          output (:execution/output result)]
-      (is (= [] (:artifacts output)))
-      (is (= {} (:phase-results output)))
-      (is (nil? (:last-phase-result output)))
-      (is (= :completed (:status output))))))
-
-(deftest extract-output-failed-status-test
+(deftest ^{:stratum 1} extract-output-failed-status-test
   (testing "extract-output preserves failed status"
     (let [ctx {:execution/artifacts []
                :execution/phase-results {runner-test-plan {:phase/status :failed}}
@@ -127,7 +226,7 @@
       (is (= :failed (:status output)))
       (is (= {:phase/status :failed} (:last-phase-result output))))))
 
-(deftest extract-output-falls-back-to-pipeline-phase-order-test
+(deftest ^{:stratum 1} extract-output-falls-back-to-pipeline-phase-order-test
   (testing "extract-output chooses the last recorded phase using workflow pipeline order"
     (let [ctx {:execution/workflow {:workflow/pipeline [{:phase runner-test-plan}
                                                        {:phase runner-test-implement}
@@ -143,22 +242,15 @@
              (get-in output [:phase-results runner-test-done]))))))
 
 ;; ---------------------------------------------------------------------------- build-pipeline edge cases
-
-(deftest build-pipeline-nil-pipeline-falls-back-to-legacy-test
+(deftest ^{:stratum 1} build-pipeline-nil-pipeline-falls-back-to-legacy-test
   (testing "nil pipeline with phases falls back to legacy format"
     (let [wf {:workflow/phases [{:phase/id runner-test-plan}
                                 {:phase/id runner-test-done}]}
           pipeline (runner/build-pipeline wf)]
       (is (= 2 (count pipeline))))))
 
-(deftest build-pipeline-no-pipeline-no-phases-test
-  (testing "no pipeline and no phases returns empty"
-    (let [pipeline (runner/build-pipeline {})]
-      (is (empty? pipeline)))))
-
 ;; ---------------------------------------------------------------------------- run-pipeline edge cases
-
-(deftest run-pipeline-two-arity-test
+(deftest ^{:stratum 1} run-pipeline-two-arity-test
   (testing "run-pipeline works with 2-arity (no opts)"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
@@ -166,7 +258,7 @@
           result (runner/run-pipeline wf {:task "Test"})]
       (is (= :completed (:execution/status result))))))
 
-(deftest run-pipeline-skip-lifecycle-events-test
+(deftest ^{:stratum 1} run-pipeline-skip-lifecycle-events-test
   (testing "skip-lifecycle-events suppresses event publishing"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
@@ -175,7 +267,7 @@
                    {:skip-lifecycle-events true})]
       (is (= :completed (:execution/status result))))))
 
-(deftest run-pipeline-custom-control-state-test
+(deftest ^{:stratum 1} run-pipeline-custom-control-state-test
   (testing "run-pipeline accepts custom control-state atom"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
@@ -185,7 +277,7 @@
                    {:control-state cs})]
       (is (= :completed (:execution/status result))))))
 
-(deftest run-pipeline-completed-with-warnings-test
+(deftest ^{:stratum 1} run-pipeline-completed-with-warnings-test
   (testing "completed workflow with no artifacts gets warning status"
     ;; The :done phase produces a phase result, so this should complete normally.
     ;; This tests that the check is in place even if not triggered.
@@ -196,7 +288,7 @@
       ;; :done produces a phase result, so it should be :completed (not :completed-with-warnings)
       (is (contains? #{:completed :completed-with-warnings} (:execution/status result))))))
 
-(deftest run-pipeline-max-phases-1-with-done-test
+(deftest ^{:stratum 1} run-pipeline-max-phases-1-with-done-test
   (testing "max-phases 1 allows single :done phase to complete"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
@@ -204,7 +296,7 @@
           result (runner/run-pipeline wf {:task "Test"} {:max-phases 1})]
       (is (= :completed (:execution/status result))))))
 
-(deftest apply-dag-success-does-not-consume-redirect-budget-test
+(deftest ^{:stratum 1} apply-dag-success-does-not-consume-redirect-budget-test
   (testing "DAG fast-path advances with normal success events"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
@@ -227,49 +319,12 @@
       (is (= runner-test-verify (:execution/current-phase result)))
       (is (= 0 (:execution/redirect-count result))))))
 
-;; ---------------------------------------------------------------------------- DAG metric rollup regression
-;; Two sets of fixture metrics back the rollup tests below.
-
-;; success-path fixture: arbitrary but ergonomic numbers chosen to be visually
-;; distinct from any wall-clock or framework default so an off-by-one or wrong-
-;; key bug surfaces as an exact-value mismatch in the assertion output.
-(def ^:private dag-success-fixture-metrics
-  "Synthetic metrics injected into a successful DAG result. Values are
-   deliberately chosen to be non-zero, non-round in cost, and well below any
-   real wall-clock duration so they cannot collide with `stamp-wall-clock-
-   duration`'s output."
-  {:tokens      12345
-   :cost-usd    9.87
-   :duration-ms 60000})
-
-;; failure-path fixture: REAL numbers from the 2026-06-04
-;; `eliminate-requiring-resolve` dogfood (3h26m, 20-task DAG, 20/20 failed).
-;; Pinning to the observed values turns the test into a regression anchor for
-;; the specific cost-zero bug the PR fixes — if these don't round-trip, the
-;; rollup is broken on the same failure shape that originally surfaced it.
-(def ^:private dag-failure-fixture-tokens
-  "Total tokens observed across all 20 sub-workflows of the
-   2026-06-04 eliminate-requiring-resolve dogfood run."
-  516816)
-
-(def ^:private dag-failure-fixture-cost-usd
-  "Total cost (USD) observed across all 20 sub-workflows of the
-   2026-06-04 eliminate-requiring-resolve dogfood run. Pre-fix this surfaced
-   as `Cost: $0.0000` at the top of the run summary."
-  42.22608595)
-
-(def ^:private dag-failure-fixture-duration-ms
-  "Total summed sub-workflow duration from the 2026-06-04 dogfood. Note this
-   value is INTENTIONALLY overwritten by wall-clock stamping in
-   `transition-to-failed`, so it's pinned for completeness but not asserted."
-  48356404)
-
-(def ^:private dag-failure-fixture-metrics
+(def ^{:stratum 1} ^:private dag-failure-fixture-metrics
   {:tokens      dag-failure-fixture-tokens
    :cost-usd    dag-failure-fixture-cost-usd
    :duration-ms dag-failure-fixture-duration-ms})
 
-(def ^:private minimal-rollup-test-workflow
+(def ^{:stratum 1} ^:private minimal-rollup-test-workflow
   "Smallest pipeline that satisfies `create-context` for the rollup tests —
    we only exercise the metric merge, not phase advancement."
   {:workflow/id      :test
@@ -277,62 +332,7 @@
    :workflow/pipeline [{:phase runner-test-plan}
                        {:phase runner-test-done}]})
 
-(deftest create-context-adopts-caller-run-id-test
-  (testing "one run, one identity: a :workflow-id in opts becomes
-            :execution/id (uuid or uuid-shaped string), so lifecycle events
-            published by the caller and phase/agent events published by the
-            pipeline land under the same id"
-    (let [wid (random-uuid)]
-      (is (= wid (:execution/id (ctx/create-context minimal-rollup-test-workflow
-                                                    {:task "T"} {:workflow-id wid}))))
-      (is (= wid (:execution/id (ctx/create-context minimal-rollup-test-workflow
-                                                    {:task "T"} {:workflow-id (str wid)}))))))
-  (testing "a non-uuid session label never breaks event routing — fresh uuid"
-    (let [adopted (:execution/id (ctx/create-context minimal-rollup-test-workflow
-                                                     {:task "T"}
-                                                     {:workflow-id "session-label"}))]
-      (is (uuid? adopted)))))
-
-(deftest apply-dag-success-rolls-dag-metrics-into-execution-test
-  (testing "DAG sub-workflow tokens/cost/duration roll into :execution/metrics on success"
-    ;; `apply-phase-transition` ignores its `pipeline` arg (see _pipeline in
-    ;; the defn), so we pass nil rather than call `runner/build-pipeline`,
-    ;; which would force the phase loader and trip the same classpath error
-    ;; that affects the other pipeline-running tests in this file.
-    (let [context (ctx/create-context minimal-rollup-test-workflow {:task "Test"} {})
-          dag-result {:artifacts []
-                      :worktree-paths []
-                      :metrics dag-success-fixture-metrics}
-          result #_{:clj-kondo/ignore [:invalid-arity]}
-                 (exec/apply-dag-success context dag-result nil
-                                         ctx/transition-to-completed
-                                         ctx/transition-to-failed)]
-      (is (= (:tokens dag-success-fixture-metrics)
-             (get-in result [:execution/metrics :tokens])))
-      (is (= (:cost-usd dag-success-fixture-metrics)
-             (get-in result [:execution/metrics :cost-usd]))))))
-
-(deftest apply-dag-failure-rolls-dag-metrics-into-execution-test
-  (testing "DAG sub-workflow spend rolls into :execution/metrics on failure too"
-    ;; Without this rollup the run summary lies ($0.0000 on a real spend) —
-    ;; tokens were spent whether or not the DAG succeeded.
-    (let [context (ctx/create-context minimal-rollup-test-workflow {:task "Test"} {})
-          dag-result {:artifacts []
-                      :metrics dag-failure-fixture-metrics}
-          result (exec/apply-dag-failure context dag-result ctx/transition-to-failed)]
-      (is (= :failed (:execution/status result)))
-      (is (= dag-failure-fixture-tokens
-             (get-in result [:execution/metrics :tokens])))
-      (is (= dag-failure-fixture-cost-usd
-             (get-in result [:execution/metrics :cost-usd])))
-      ;; :duration-ms is intentionally overwritten by wall-clock stamping in
-      ;; transition-to-failed (see context/stamp-wall-clock-duration). The
-      ;; rollup still runs so mid-run reads stay consistent; just don't
-      ;; assert against the DAG-supplied value here.
-      (is (= dag-result (:execution/dag-result result))
-          "dag-result remains attached for downstream consumers"))))
-
-(deftest execute-phase-step-uses-machine-state-over-phase-index-test
+(deftest ^{:stratum 1} execute-phase-step-uses-machine-state-over-phase-index-test
   (testing "standard execution selects the active phase from the machine snapshot"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
@@ -349,66 +349,8 @@
       (is (= :completed (:execution/status result)))
       (is (contains? (:execution/phase-results result) runner-test-done)))))
 
-;; ---------------------------------------------------------------------------- publish-event edge cases
-
-(deftest publish-event-nil-stream-test
-  (testing "publish-event with nil stream is a no-op"
-    ;; Should not throw
-    (is (nil? (runner/publish-event! nil {:event/type :test})))))
-
-(deftest publish-event-in-memory-stream-test
-  (testing "publish-event no-ops for non-stream maps"
-    (is (nil? (runner/publish-event! {} {:event/type :test})))))
-
-;; ---------------------------------------------------------------------------- terminal-state?
-
-(deftest terminal-state-test
-  (testing "completed and failed are terminal"
-    (is (true? (runner/terminal-state? {:execution/status :completed})))
-    (is (true? (runner/terminal-state? {:execution/status :failed}))))
-
-  (testing "running is not terminal"
-    (is (false? (runner/terminal-state? {:execution/status :running})))))
-
-;; ---------------------------------------------------------------------------- handle-empty-pipeline
-
-(deftest handle-empty-pipeline-test
-  (testing "adds error and transitions to failed"
-    (let [ctx (ctx/create-context {:workflow/id :test} {} {})
-          result (runner/handle-empty-pipeline ctx)]
-      (is (= :failed (:execution/status result)))
-      (is (some #(= :empty-pipeline (:type %)) (:execution/errors result))))))
-
-;; ---------------------------------------------------------------------------- handle-max-phases-exceeded
-
-(deftest handle-max-phases-exceeded-test
-  (testing "adds error about max phases"
-    (let [ctx (ctx/create-context {:workflow/id :test} {} {})
-          result (runner/handle-max-phases-exceeded ctx 10)]
-      (is (= :failed (:execution/status result)))
-      (is (some #(= :max-phases-exceeded (:type %)) (:execution/errors result))))))
-
-;; ---------------------------------------------------------------------------- publish helpers with nil stream
-
-(deftest publish-workflow-started-nil-stream-test
-  (testing "no-op with nil event stream"
-    (is (nil? (runner/publish-workflow-started! nil {})))))
-
-(deftest publish-workflow-completed-nil-stream-test
-  (testing "no-op with nil event stream"
-    (is (nil? (runner/publish-workflow-completed! nil {})))))
-
-(deftest publish-phase-started-nil-stream-test
-  (testing "no-op with nil event stream"
-    (is (nil? (runner/publish-phase-started! nil {} :plan)))))
-
-(deftest publish-phase-completed-nil-stream-test
-  (testing "no-op with nil event stream"
-    (is (nil? (runner/publish-phase-completed! nil {} :plan {})))))
-
 ;; ---------------------------------------------------------------------------- execution mode: local (default)
-
-(deftest run-pipeline-local-mode-sets-execution-mode-test
+(deftest ^{:stratum 1} run-pipeline-local-mode-sets-execution-mode-test
   (testing ":local mode is the default and sets :execution/mode on context"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
@@ -416,7 +358,7 @@
           result (runner/run-pipeline wf {:task "Test"})]
       (is (= :local (:execution/mode result))))))
 
-(deftest run-pipeline-explicit-local-mode-test
+(deftest ^{:stratum 1} run-pipeline-explicit-local-mode-test
   (testing "explicit :local mode uses worktree"
     (let [wf {:workflow/id :test
               :workflow/version "1.0.0"
@@ -425,34 +367,7 @@
       (is (= :completed (:execution/status result)))
       (is (= :local (:execution/mode result))))))
 
-(deftest run-pipeline-governed-mode-sets-execution-mode-test
-  (testing ":governed mode sets :execution/mode :governed on context"
-    (let [wf {:workflow/id :test
-              :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase runner-test-done}]}]
-      (with-mock-capsule-executor
-        (let [result (runner/run-pipeline wf {:task "Test"}
-                                          {:execution-mode :governed})]
-          (is (= :governed (:execution/mode result))))))))
-
-(deftest run-pipeline-governed-mode-has-host-worktree-test
-  (testing ":governed mode provides a host-accessible worktree-path (not /workspace)"
-    (let [wf {:workflow/id :test
-              :workflow/version "1.0.0"
-              :workflow/pipeline [{:phase runner-test-done}]}]
-      (with-mock-capsule-executor
-        (let [result (runner/run-pipeline wf {:task "Test"}
-                                          {:execution-mode :governed})]
-          (is (some? (:execution/worktree-path result))
-              "Should have a worktree path")
-          (is (not= "/workspace" (:execution/worktree-path result))
-              "Worktree path should be host-accessible, not container-internal")
-          (is (some? (:execution/executor result))
-              "Should have a capsule executor")
-          (is (some? (:execution/environment-id result))
-              "Should have a capsule environment-id"))))))
-
-(deftest run-pipeline-governed-mode-rejects-worktree-fallback-test
+(deftest ^{:stratum 1} run-pipeline-governed-mode-rejects-worktree-fallback-test
   (testing ":governed mode does not fall through to worktree (N11 §7.4 no-silent-downgrade)"
     ;; Simulate all executors appearing as :worktree type so governed mode
     ;; rejects them and throws rather than silently falling back.
@@ -467,15 +382,7 @@
              (runner/run-pipeline wf {:task "Test"}
                                   {:execution-mode :governed})))))))
 
-;; ---------------------------------------------------------------------------- persist-workspace-at-phase-boundary!
-
-(def ^:private persist-fn
-  "Var accessor for persist-workspace-at-phase-boundary! (extracted to runner-environment)."
-  (do (require 'ai.miniforge.workflow.runner-environment)
-      (ns-resolve 'ai.miniforge.workflow.runner-environment
-                  'persist-workspace-at-phase-boundary!)))
-
-(deftest persist-workspace-noop-when-no-executor-test
+(deftest ^{:stratum 1} persist-workspace-noop-when-no-executor-test
   (testing "returns nil when context has no :execution/executor"
     (let [context {:execution/mode :governed
                    :execution/environment-id "env-1"
@@ -483,7 +390,7 @@
           phase-ctx {:execution/current-phase :implement}]
       (is (nil? (persist-fn context phase-ctx))))))
 
-(deftest persist-workspace-fires-in-local-mode-test
+(deftest ^{:stratum 1} persist-workspace-fires-in-local-mode-test
   (testing "persist fires in :local mode (parity with :governed) so worktree-tier work survives release"
     (let [call-args (atom nil)
           context {:execution/executor :stub
@@ -503,7 +410,7 @@
         (is (= "feat/foo" (get-in @call-args [:opts :base-branch])))
         (is (= "env-1" (get-in @call-args [:opts :task-id])))))))
 
-(deftest persist-workspace-calls-executor-in-governed-mode-test
+(deftest ^{:stratum 1} persist-workspace-calls-executor-in-governed-mode-test
   (testing "calls dag-exec/persist-workspace! with correct args in governed mode"
     (let [call-args (atom nil)
           context {:execution/executor :mock-executor
@@ -526,7 +433,7 @@
         (is (= (messages/t :env/persist-message {:phase "implement"})
                (get-in @call-args [:opts :message])))))))
 
-(deftest persist-workspace-uses-unknown-when-no-phase-test
+(deftest ^{:stratum 1} persist-workspace-uses-unknown-when-no-phase-test
   (testing "uses 'unknown' when phase-ctx has no :execution/current-phase"
     (let [call-args (atom nil)
           context {:execution/executor :mock
@@ -541,7 +448,7 @@
         (is (= (messages/t :env/persist-message {:phase "unknown"})
                (:message @call-args)))))))
 
-(deftest persist-workspace-catches-exceptions-test
+(deftest ^{:stratum 1} persist-workspace-catches-exceptions-test
   (testing "catches exceptions from persist-workspace! without propagating"
     (let [context {:execution/executor :mock
                    :execution/mode :governed
@@ -555,7 +462,7 @@
         ;; Should not throw
         (is (nil? (persist-fn context phase-ctx)))))))
 
-(defn- capture-persist-event-data
+(defn- ^{:stratum 1} capture-persist-event-data
   "Capture the data passed to es/workspace-persisted by running the
    persist boundary against a stub executor that always reports a
    successful persist."
@@ -579,7 +486,91 @@
       (persist-fn context phase-ctx)
       @event-data)))
 
-(deftest persist-tier-is-worktree-in-local-mode-test
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} create-context-adopts-caller-run-id-test
+  (testing "one run, one identity: a :workflow-id in opts becomes
+            :execution/id (uuid or uuid-shaped string), so lifecycle events
+            published by the caller and phase/agent events published by the
+            pipeline land under the same id"
+    (let [wid (random-uuid)]
+      (is (= wid (:execution/id (ctx/create-context minimal-rollup-test-workflow
+                                                    {:task "T"} {:workflow-id wid}))))
+      (is (= wid (:execution/id (ctx/create-context minimal-rollup-test-workflow
+                                                    {:task "T"} {:workflow-id (str wid)}))))))
+  (testing "a non-uuid session label never breaks event routing — fresh uuid"
+    (let [adopted (:execution/id (ctx/create-context minimal-rollup-test-workflow
+                                                     {:task "T"}
+                                                     {:workflow-id "session-label"}))]
+      (is (uuid? adopted)))))
+
+(deftest ^{:stratum 2} apply-dag-success-rolls-dag-metrics-into-execution-test
+  (testing "DAG sub-workflow tokens/cost/duration roll into :execution/metrics on success"
+    ;; `apply-phase-transition` ignores its `pipeline` arg (see _pipeline in
+    ;; the defn), so we pass nil rather than call `runner/build-pipeline`,
+    ;; which would force the phase loader and trip the same classpath error
+    ;; that affects the other pipeline-running tests in this file.
+    (let [context (ctx/create-context minimal-rollup-test-workflow {:task "Test"} {})
+          dag-result {:artifacts []
+                      :worktree-paths []
+                      :metrics dag-success-fixture-metrics}
+          result #_{:clj-kondo/ignore [:invalid-arity]}
+                 (exec/apply-dag-success context dag-result nil
+                                         ctx/transition-to-completed
+                                         ctx/transition-to-failed)]
+      (is (= (:tokens dag-success-fixture-metrics)
+             (get-in result [:execution/metrics :tokens])))
+      (is (= (:cost-usd dag-success-fixture-metrics)
+             (get-in result [:execution/metrics :cost-usd]))))))
+
+(deftest ^{:stratum 2} apply-dag-failure-rolls-dag-metrics-into-execution-test
+  (testing "DAG sub-workflow spend rolls into :execution/metrics on failure too"
+    ;; Without this rollup the run summary lies ($0.0000 on a real spend) —
+    ;; tokens were spent whether or not the DAG succeeded.
+    (let [context (ctx/create-context minimal-rollup-test-workflow {:task "Test"} {})
+          dag-result {:artifacts []
+                      :metrics dag-failure-fixture-metrics}
+          result (exec/apply-dag-failure context dag-result ctx/transition-to-failed)]
+      (is (= :failed (:execution/status result)))
+      (is (= dag-failure-fixture-tokens
+             (get-in result [:execution/metrics :tokens])))
+      (is (= dag-failure-fixture-cost-usd
+             (get-in result [:execution/metrics :cost-usd])))
+      ;; :duration-ms is intentionally overwritten by wall-clock stamping in
+      ;; transition-to-failed (see context/stamp-wall-clock-duration). The
+      ;; rollup still runs so mid-run reads stay consistent; just don't
+      ;; assert against the DAG-supplied value here.
+      (is (= dag-result (:execution/dag-result result))
+          "dag-result remains attached for downstream consumers"))))
+
+(deftest ^{:stratum 2} run-pipeline-governed-mode-sets-execution-mode-test
+  (testing ":governed mode sets :execution/mode :governed on context"
+    (let [wf {:workflow/id :test
+              :workflow/version "1.0.0"
+              :workflow/pipeline [{:phase runner-test-done}]}]
+      (with-mock-capsule-executor
+        (let [result (runner/run-pipeline wf {:task "Test"}
+                                          {:execution-mode :governed})]
+          (is (= :governed (:execution/mode result))))))))
+
+(deftest ^{:stratum 2} run-pipeline-governed-mode-has-host-worktree-test
+  (testing ":governed mode provides a host-accessible worktree-path (not /workspace)"
+    (let [wf {:workflow/id :test
+              :workflow/version "1.0.0"
+              :workflow/pipeline [{:phase runner-test-done}]}]
+      (with-mock-capsule-executor
+        (let [result (runner/run-pipeline wf {:task "Test"}
+                                          {:execution-mode :governed})]
+          (is (some? (:execution/worktree-path result))
+              "Should have a worktree path")
+          (is (not= "/workspace" (:execution/worktree-path result))
+              "Worktree path should be host-accessible, not container-internal")
+          (is (some? (:execution/executor result))
+              "Should have a capsule executor")
+          (is (some? (:execution/environment-id result))
+              "Should have a capsule environment-id"))))))
+
+(deftest ^{:stratum 2} persist-tier-is-worktree-in-local-mode-test
   (testing ":workspace/persisted event labels :local mode as :worktree tier"
     (let [data (capture-persist-event-data
                 {:execution/executor :stub
@@ -596,7 +587,7 @@
       (is (= :worktree (:persist-tier data))
           "local mode persists to a local archive — worktree tier"))))
 
-(deftest persist-tier-is-remote-in-governed-mode-test
+(deftest ^{:stratum 2} persist-tier-is-remote-in-governed-mode-test
   (testing ":workspace/persisted event labels :governed mode as :remote tier"
     (let [data (capture-persist-event-data
                 {:execution/executor :stub
@@ -608,3 +599,5 @@
                 {:execution/current-phase :implement})]
       (is (= :remote (:persist-tier data))
           "governed mode pushes to remote — remote tier label, not worktree"))))
+
+(use-fixtures :each phase-test-support/with-workflow-phase-test-support)

--- a/components/workflow/test/ai/miniforge/workflow/runner_iteration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_iteration_test.clj
@@ -15,9 +15,7 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 ;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-
 (ns ai.miniforge.workflow.runner-iteration-test
   "Tests for iteration helpers extracted from runner.clj.
    Includes slingshot try+/throw+ bb-compatibility tests."
@@ -31,19 +29,23 @@
 
 (use-fixtures :each phase-test-support/with-workflow-phase-test-support)
 
-(def ^:private runner-test-done
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private runner-test-done
   phase-test-support/runner-test-done)
 
 ;; Access private fns
-(def ^:private rate-limited? #'runner/rate-limited?)
-(defn- backoff-ms [n] (#'runner/backoff-ms n))
-(def ^:private make-execution-error #'runner/make-execution-error)
+(def ^{:stratum 0} ^:private rate-limited? #'runner/rate-limited?)
 
-(defn- running-control-state
+(defn- ^{:stratum 0} backoff-ms [n] (#'runner/backoff-ms n))
+
+(def ^{:stratum 0} ^:private make-execution-error #'runner/make-execution-error)
+
+(defn- ^{:stratum 0} running-control-state
   []
   (atom {:paused false :stopped false :adjustments {}}))
 
-(defn- halted-supervision-result
+(defn- ^{:stratum 0} halted-supervision-result
   []
   {:status :halt
    :halt-reason "workflow stalled"
@@ -52,32 +54,75 @@
              :data {:elapsed-ms 120000}}]})
 
 ;; ============================================================================
+;; slingshot try+/throw+ — bb compatibility tests
+;; ============================================================================
+(deftest ^{:stratum 0} slingshot-throw-plus-map-test
+  (testing "throw+ with map is caught by key-value selector"
+    (let [result (try+
+                   (throw+ {:type :rate-limited :status 429 :message "slow down"})
+                   (catch [:type :rate-limited] {:keys [status message]}
+                     {:caught true :status status :message message}))]
+      (is (true? (:caught result)))
+      (is (= 429 (:status result)))
+      (is (= "slow down" (:message result))))))
+
+(deftest ^{:stratum 0} slingshot-catches-ex-info-by-key-test
+  (testing "try+ catches existing ex-info throws by key-value selector"
+    (let [result (try+
+                   (throw (ex-info "gate failed" {:type :gate-failed :gate :lint}))
+                   (catch [:type :gate-failed] {:keys [gate]}
+                     {:caught true :gate gate}))]
+      (is (true? (:caught result)))
+      (is (= :lint (:gate result))))))
+
+(deftest ^{:stratum 0} slingshot-fallthrough-to-object-test
+  (testing "try+ falls through to Object catch for non-matching ex-info throws"
+    (let [result (try+
+                   (throw (ex-info "other error" {:type :unknown}))
+                   (catch [:type :rate-limited] _
+                     {:caught :rate-limited})
+                   (catch Object obj
+                     {:caught :fallback :type (:type obj)}))]
+      (is (= :fallback (:caught result)))
+      (is (= :unknown (:type result))))))
+
+(deftest ^{:stratum 0} slingshot-dashboard-stop-test
+  (testing "check-stopped! throw+ is caught by :type selector"
+    (let [result (try+
+                   (throw+ {:type :dashboard-stop :reason :dashboard-stop :message "stopped"})
+                   (catch [:type :dashboard-stop] {:keys [message]}
+                     {:caught true :message message}))]
+      (is (true? (:caught result)))
+      (is (= "stopped" (:message result))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; ============================================================================
 ;; rate-limited?
 ;; ============================================================================
-
-(deftest rate-limited-detects-429-test
+(deftest ^{:stratum 1} rate-limited-detects-429-test
   (testing "detects HTTP 429 in error message"
     (is (true? (rate-limited? "HTTP 429 Too Many Requests")))))
 
-(deftest rate-limited-detects-rate-limit-test
+(deftest ^{:stratum 1} rate-limited-detects-rate-limit-test
   (testing "detects 'rate limit' phrase"
     (is (true? (rate-limited? "You've hit your rate limit")))))
 
-(deftest rate-limited-detects-quota-exceeded-test
+(deftest ^{:stratum 1} rate-limited-detects-quota-exceeded-test
   (testing "detects quota exceeded"
     (is (true? (rate-limited? "API quota exceeded for this model")))))
 
-(deftest rate-limited-false-for-normal-errors-test
+(deftest ^{:stratum 1} rate-limited-false-for-normal-errors-test
   (testing "returns false for non-rate-limit errors"
     (is (false? (rate-limited? "Syntax error on line 10")))
     (is (false? (rate-limited? "Connection refused")))
     (is (false? (rate-limited? "")))))
 
-(deftest rate-limited-handles-nil-test
+(deftest ^{:stratum 1} rate-limited-handles-nil-test
   (testing "handles nil input"
     (is (false? (rate-limited? nil)))))
 
-(deftest rate-limited-recognises-shapes-the-resilience-layer-knows-test
+(deftest ^{:stratum 1} rate-limited-recognises-shapes-the-resilience-layer-knows-test
   (testing "Runner's rate-limited? now delegates to dag-resilience/rate-limit-in-text?,
             so the workflow-phase path catches every shape the resilience layer
             knows — not just the narrow set the prior inline regex covered. The
@@ -100,83 +145,37 @@
 ;; ============================================================================
 ;; backoff-ms
 ;; ============================================================================
-
-(deftest backoff-ms-first-retry-test
+(deftest ^{:stratum 1} backoff-ms-first-retry-test
   (testing "first retry uses base backoff"
     (is (= 1000 (backoff-ms 1)))))
 
-(deftest backoff-ms-doubles-test
+(deftest ^{:stratum 1} backoff-ms-doubles-test
   (testing "second retry doubles"
     (is (= 2000 (backoff-ms 2)))))
 
-(deftest backoff-ms-capped-test
+(deftest ^{:stratum 1} backoff-ms-capped-test
   (testing "large retry count is capped at max"
     (is (<= (backoff-ms 100) 30000))))
 
 ;; ============================================================================
 ;; make-execution-error
 ;; ============================================================================
-
-(deftest make-execution-error-basic-test
+(deftest ^{:stratum 1} make-execution-error-basic-test
   (testing "produces map with :type and :message"
     (let [err (make-execution-error :test-error "something broke")]
       (is (= :test-error (:type err)))
       (is (= "something broke" (:message err))))))
 
-(deftest make-execution-error-with-extra-test
+(deftest ^{:stratum 1} make-execution-error-with-extra-test
   (testing "merges extra data"
     (let [err (make-execution-error :test-error "broke" {:data {:code 42}})]
       (is (= :test-error (:type err)))
       (is (= 42 (get-in err [:data :code]))))))
 
 ;; ============================================================================
-;; slingshot try+/throw+ — bb compatibility tests
-;; ============================================================================
-
-(deftest slingshot-throw-plus-map-test
-  (testing "throw+ with map is caught by key-value selector"
-    (let [result (try+
-                   (throw+ {:type :rate-limited :status 429 :message "slow down"})
-                   (catch [:type :rate-limited] {:keys [status message]}
-                     {:caught true :status status :message message}))]
-      (is (true? (:caught result)))
-      (is (= 429 (:status result)))
-      (is (= "slow down" (:message result))))))
-
-(deftest slingshot-catches-ex-info-by-key-test
-  (testing "try+ catches existing ex-info throws by key-value selector"
-    (let [result (try+
-                   (throw (ex-info "gate failed" {:type :gate-failed :gate :lint}))
-                   (catch [:type :gate-failed] {:keys [gate]}
-                     {:caught true :gate gate}))]
-      (is (true? (:caught result)))
-      (is (= :lint (:gate result))))))
-
-(deftest slingshot-fallthrough-to-object-test
-  (testing "try+ falls through to Object catch for non-matching ex-info throws"
-    (let [result (try+
-                   (throw (ex-info "other error" {:type :unknown}))
-                   (catch [:type :rate-limited] _
-                     {:caught :rate-limited})
-                   (catch Object obj
-                     {:caught :fallback :type (:type obj)}))]
-      (is (= :fallback (:caught result)))
-      (is (= :unknown (:type result))))))
-
-(deftest slingshot-dashboard-stop-test
-  (testing "check-stopped! throw+ is caught by :type selector"
-    (let [result (try+
-                   (throw+ {:type :dashboard-stop :reason :dashboard-stop :message "stopped"})
-                   (catch [:type :dashboard-stop] {:keys [message]}
-                     {:caught true :message message}))]
-      (is (true? (:caught result)))
-      (is (= "stopped" (:message result))))))
-
-;; ============================================================================
 ;; execute-single-iteration
 ;; ============================================================================
-
-(deftest execute-single-iteration-halts-on-supervision-test
+(deftest ^{:stratum 1} execute-single-iteration-halts-on-supervision-test
   (testing "supervision halt transitions the workflow to failed"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"

--- a/docs/pull-requests/2026-09-03-refactor-stratum-headings-workflow-runner-tests.md
+++ b/docs/pull-requests/2026-09-03-refactor-stratum-headings-workflow-runner-tests.md
@@ -1,0 +1,58 @@
+# refactor(workflow): stratum headings for the runner test namespaces (rule 210)
+
+## Overview
+
+Mechanical output of `stratum-lint --fix` over six test namespaces that
+predate the pre-commit stratum gate (2026-08-10) and carried no `Layer N`
+headings. No def body changes: the tool tags each def with its inferred
+`^{:stratum n}` metadata, regroups defs under regenerated headings, and
+nothing else.
+
+## Motivation
+
+The pre-commit hook (`bb lint:stratum`, `lint/stratum-staged`) autofixes
+and re-stages every staged Clojure file. The first commit to touch one of
+these files after 2026-08-10 therefore carries the whole regroup along
+with whatever it meant to change. Landing the regroup on its own keeps
+the functional PR that follows
+(`fix/test-checkpoint-root-fixture`) reviewable as the ~100-line change
+it is.
+
+## Changes in Detail
+
+Workflow brick (`components/workflow/test/ai/miniforge/workflow/`):
+
+1. `runner_extended_test.clj`
+2. `runner_iteration_test.clj`
+3. `environment_promotion_integration_test.clj`
+4. `run7_regression_test.clj`
+5. `anomaly/build_initial_context_test.clj`
+
+Project `miniforge` (`projects/miniforge/test/ai/miniforge/workflow/`):
+
+1. `runner_integration_test.clj`
+
+Verification that the diff is metadata and ordering only: for each file,
+the multiset of non-comment, non-blank lines with `^{:stratum n}` stripped
+is identical before and after.
+
+## Testing Plan
+
+1. `bb lint:stratum` over the staged set reports no findings.
+2. `clojure -M:poly test brick:workflow` green.
+3. `bb test:integration` namespaces `runner-integration-test` green.
+
+## Deployment Plan
+
+Test-only, behaviour-neutral. No runtime code touched.
+
+## Related Issues/PRs
+
+Foundation for `fix/test-checkpoint-root-fixture`, which adds a shared
+temp-checkpoint-root fixture to these same namespaces.
+
+## Checklist
+
+- [x] Autofix output only, verified line-multiset identical
+- [x] Lint clean
+- [x] Tests green

--- a/projects/miniforge/test/ai/miniforge/workflow/runner_integration_test.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/runner_integration_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.workflow.runner-integration-test
   "Integration tests for the workflow runner that execute real phase pipelines."
   (:require
@@ -33,7 +32,9 @@
    [ai.miniforge.gate.test]
    [ai.miniforge.gate.policy]))
 
-(defn with-mocked-test-runner
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} with-mocked-test-runner
   "Run body-fn with run-tests! mocked to prevent recursive bb test."
   [body-fn]
   (let [run-var (resolve 'ai.miniforge.phase-software-factory.verify/run-tests!)]
@@ -41,7 +42,7 @@
       {run-var (fn [& _args] {:passed? true :test-count 1 :fail-count 0 :error-count 0})}
       body-fn)))
 
-(deftest run-pipeline-max-phases-test
+(deftest ^{:stratum 0} run-pipeline-max-phases-test
   (testing "run-pipeline respects max phases option"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
@@ -49,7 +50,7 @@
           result (runner/run-pipeline workflow {:task "Test"} {:max-phases 50})]
       (is (= :completed (:execution/status result))))))
 
-(deftest response-chain-records-phases-test
+(deftest ^{:stratum 0} response-chain-records-phases-test
   (testing "response chain records phase results"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"


### PR DESCRIPTION
## Summary

Mechanical output of `stratum-lint --fix` over six test namespaces that predate the pre-commit stratum gate (2026-08-10) and carried no `Layer N` headings: `runner_extended_test`, `runner_iteration_test`, `environment_promotion_integration_test`, `run7_regression_test`, `anomaly/build_initial_context_test` (workflow brick) and the project's `runner_integration_test`.

For each file the multiset of non-comment, non-blank lines with `^{:stratum n}` stripped is identical before and after. Only metadata, headings and def order change; no def body changes.

Landed on its own so the functional PR that follows (`fix/test-checkpoint-root-fixture`, which touches the same files) is reviewable as the small change it is. The pre-commit hook autofixes and re-stages every staged Clojure file, so the first commit to touch these files was going to carry this regroup regardless.

PR doc: `docs/pull-requests/2026-09-03-refactor-stratum-headings-workflow-runner-tests.md`.

MINIFORGE_PR_BUDGET_OVERRIDE: mechanical stratum-lint --fix output; per-file code-line multiset verified identical to main, only stratum metadata, Layer headings and def order change (616 reportable lines).

## Test plan

- [x] `bb lint:stratum` clean over the staged set
- [x] `clojure -M:poly test brick:workflow` — 219 namespaces, exit 0
- [x] `bb test:integration` namespace `runner-integration-test` — green (59 tests across the three project namespaces run directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
