### PR TITLE
test(hygiene): keep suites off the launch repo, ~/.miniforge, and the codex env

### DIFF
--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
@@ -34,6 +34,7 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.phase-software-factory.codex-pin :as codex-pin]
    [ai.miniforge.phase-software-factory.release :as release]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase.loader :as loader]
@@ -42,6 +43,21 @@
 ;------------------------------------------------------------------------------ Layer 0
 
 ;------------------------------------------------------------------------------ Test Fixtures
+(defn ^{:stratum 0} with-unconfigured-codex
+  "Run `f` with no codex configured.
+
+   `build-executor-context` consults the codex for the release situation
+   and appends the rendered landings to `:task/behavior-addendum`. The
+   codex location comes from the environment (`MINIFORGE_CODEX_PATH`),
+   so on a machine with one exported — the trap bench treated arm,
+   2026-09-03 — the addendum assertions below saw pack text plus codex
+   text where the test had stubbed only the pack. Nothing in this
+   namespace is about the consultation itself; the pinning contract lives
+   in codex-pin-test."
+  [f]
+  (with-redefs [codex-pin/configured-codex-dir (constantly nil)]
+    (f)))
+
 (def ^{:stratum 0} phase-test-config-resource
   "config/phase/test-support-namespaces.edn")
 
@@ -855,6 +871,7 @@
                   "every rehydrated file must carry content read from disk"))))))))
 
 (use-fixtures :each
+  with-unconfigured-codex
   (fn [f]
     (phase/reset-phase-loader!)
     (try

--- a/components/workflow/test/ai/miniforge/workflow/anomaly/build_initial_context_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/anomaly/build_initial_context_test.clj
@@ -25,7 +25,8 @@
    `:invalid-input`. `run-pipeline` converts that anomaly to a failed
    execution context so callers receive the runner's normal result
    shape."
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [ai.miniforge.workflow.isolation-test-support :as isolation]
+            [clojure.test :refer [deftest is testing]]
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.workflow.runner :as runner]))
 
@@ -99,3 +100,8 @@
                     (:execution/errors result)))
           (is (= :governed
                  (-> result :execution/errors first :data :execution-mode))))))))
+
+;; Every pipeline this namespace runs acquires its worktree from a
+;; throwaway host repository and checkpoints into a throwaway root — never
+;; the checkout the test JVM was launched in, never `~/.miniforge`.
+(clojure.test/use-fixtures :once isolation/with-isolated-host)

--- a/components/workflow/test/ai/miniforge/workflow/context_duration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/context_duration_test.clj
@@ -23,6 +23,7 @@
    into parent metrics). Post-fix it's the workflow wall-clock
    (`ended-at` − `started-at`)."
   (:require
+   [ai.miniforge.workflow.isolation-test-support :as isolation]
    [ai.miniforge.workflow.context :as context]
    [clojure.test :refer [deftest is testing]]))
 
@@ -131,6 +132,11 @@
              (get-in completed [:execution/metrics :duration-ms]))
           "Instant-shaped started-at coerces correctly AND stamps
            the right delta (not just survives without throwing)"))))
+
+;; Every pipeline this namespace runs acquires its worktree from a
+;; throwaway host repository and checkpoints into a throwaway root — never
+;; the checkout the test JVM was launched in, never `~/.miniforge`.
+(clojure.test/use-fixtures :once isolation/with-isolated-host)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/workflow/test/ai/miniforge/workflow/environment_promotion_integration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/environment_promotion_integration_test.clj
@@ -27,6 +27,7 @@
    No Docker or network access required: dag-executor and agent/invoke are
    mocked; verify/run-tests! is mocked to return passing results."
   (:require
+   [ai.miniforge.workflow.isolation-test-support :as isolation]
    [clojure.test :refer [deftest testing is use-fixtures]]
    [clojure.java.io :as io]
    [babashka.fs :as fs]
@@ -316,6 +317,11 @@
 (register-env-promotion-phase! env-promotion-implement)
 
 (register-env-promotion-phase! env-promotion-verify)
+
+;; Every pipeline this namespace runs acquires its worktree from a
+;; throwaway host repository and checkpoints into a throwaway root — never
+;; the checkout the test JVM was launched in, never `~/.miniforge`.
+(clojure.test/use-fixtures :once isolation/with-isolated-host)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/workflow/test/ai/miniforge/workflow/isolation_test_support.clj
+++ b/components/workflow/test/ai/miniforge/workflow/isolation_test_support.clj
@@ -1,0 +1,176 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.workflow.isolation-test-support
+  "Keeps pipeline-running tests off the developer's checkout and home.
+
+   `runner/run-pipeline` defaults `:repo-path` to \".\" and, in :local
+   mode, acquires a real git worktree from it: `git worktree add -b
+   task-<8hex>` against whatever repository the test JVM was launched in.
+   The worktree is removed on release; the branch is not. Checkpoints land
+   under `~/.miniforge/checkpoints`, and persisted task bundles under the
+   same root. Observed 2026-09-03 on the trap bench: one `bb test` inside
+   a linked worktree left 108 `task-*` branches on the enclosing
+   repository within a minute, and the developer checkout was carrying
+   38k of them.
+
+   `with-isolated-host` redirects every one of those sinks into a single
+   throwaway tree for the duration of a fixture:
+
+   - repo-path \".\" or absent  -> a fresh throwaway host repository
+   - worktree base path          -> <root>/worktrees
+   - persisted-bundle archive    -> <root>/archives
+   - default checkpoint root     -> <root>/checkpoints
+
+   An explicit non-\".\" repo-path and an explicit `:checkpoint/root`
+   execution option still win: a test that names its own target keeps
+   it. The tree is deleted when the fixture unwinds.
+
+   Registered as a `:once` fixture — one host repository per namespace is
+   enough, and `with-redefs` must wrap the whole run of that namespace."
+  (:require
+   [ai.miniforge.workflow.checkpoint-store-paths :as checkpoint-paths]
+   [ai.miniforge.workflow.runner-environment :as env]
+   [clojure.java.shell :as shell])
+  (:import
+   [java.io File]
+   [java.nio.file Files]
+   [java.nio.file.attribute FileAttribute]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} host-branch
+  "Branch the throwaway host repository is seeded on. Matches the
+   `:branch` default `run-pipeline` acquires from."
+  "main")
+
+(defn ^{:stratum 0} temp-root!
+  []
+  (str (Files/createTempDirectory "miniforge-isolated-host"
+                                  (make-array FileAttribute 0))))
+
+(defn ^{:stratum 0} delete-tree!
+  [path]
+  (let [f (File. (str path))]
+    (when (.exists f)
+      (when (.isDirectory f)
+        (doseq [child (.listFiles f)] (delete-tree! child)))
+      (.delete f))))
+
+(def ^{:stratum 0} inherited-git-env-keys
+  "Environment variables a git hook exports to its children. A `git init`
+   or `git commit` that inherits them acts on the hook's repository, not
+   the directory it was pointed at: under the pre-commit hook this fixture's
+   `git init` re-initialised the launch repository as bare
+   (`core.bare = true` in its shared config, 2026-09-03)."
+  ["GIT_INDEX_FILE" "GIT_DIR" "GIT_WORK_TREE" "GIT_COMMON_DIR"
+   ;; `git -c k=v` travels to child processes as GIT_CONFIG_PARAMETERS; a
+   ;; core.worktree override from the launching command would point the
+   ;; throwaway repository's commands back at the launch checkout.
+   "GIT_CONFIG_PARAMETERS"])
+
+(defn ^{:stratum 0} redirect-repo-path
+  "`env-config` with a \".\" or absent `:repo-path` pointed at `host`.
+   Any other explicit path is left alone."
+  [env-config host]
+  (let [repo-path (get env-config :repo-path)]
+    (if (or (nil? repo-path) (= "." (str repo-path)))
+      (assoc env-config :repo-path host)
+      env-config)))
+
+(defn ^{:stratum 0} worktree-config
+  "Executor config that keeps worktrees and bundle archives under `root`."
+  [root]
+  {:base-path   (str root "/worktrees")
+   :archive-dir (str root "/archives")})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} hermetic-git-env
+  "The current environment without `inherited-git-env-keys`."
+  []
+  (apply dissoc (into {} (System/getenv)) inherited-git-env-keys))
+
+(defn ^{:stratum 1} isolated-registry-config
+  "`registry-config-for-mode` with the worktree entry rooted under `root`.
+   Only the :local shape carries a worktree entry; governed configs pass
+   through untouched."
+  [original root]
+  (fn [mode executor-config]
+    (let [config (original mode executor-config)]
+      (cond-> config
+        (contains? config :worktree)
+        (update :worktree merge (worktree-config root))))))
+
+(defn ^{:stratum 1} isolated-acquire
+  "`acquire-execution-environment!` with a \".\" repo-path redirected to
+   `host`."
+  [original host]
+  (fn [workflow-id env-config]
+    (original workflow-id (redirect-repo-path env-config host))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} git!
+  "Run git in `dir` with a hermetic environment; throw on a non-zero exit.
+   Fixture setup that fails must fail here, not later as a confusing
+   acquisition warning."
+  [dir & args]
+  (let [{:keys [exit err] :as result}
+        (apply shell/sh "git" "-C" (str dir) (concat args [:env (hermetic-git-env)]))]
+    (when-not (zero? exit)
+      (throw (ex-info "isolation fixture git command failed"
+                      {:dir (str dir) :args (vec args) :exit exit :err err})))
+    result))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} init-host-repo!
+  "A stand-in for the checkout the test JVM was launched from: one commit
+   on `host-branch`, signing off, no remote."
+  [dir]
+  (.mkdirs (File. (str dir)))
+  (git! dir "init" "--quiet" "-b" host-branch)
+  (git! dir "config" "user.email" "isolation-test@example.invalid")
+  (git! dir "config" "user.name" "Isolation Test")
+  (git! dir "config" "commit.gpgsign" "false")
+  (spit (str (File. (str dir) "seed.txt")) "seed\n")
+  (git! dir "add" "seed.txt")
+  (git! dir "commit" "--quiet" "--no-verify" "-m" "seed")
+  (str dir))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} with-isolated-host
+  "clojure.test fixture: run `f` with every pipeline side effect that
+   would otherwise reach the developer's checkout or `~/.miniforge`
+   redirected into a throwaway tree, then delete the tree."
+  [f]
+  (let [root (temp-root!)
+        host (init-host-repo! (str root "/host"))]
+    (doseq [sub ["worktrees" "archives" "checkpoints"]]
+      (.mkdirs (File. (str root "/" sub))))
+    (try
+      (with-redefs [checkpoint-paths/default-checkpoint-root
+                    (fn [] (str root "/checkpoints"))
+                    env/registry-config-for-mode
+                    (isolated-registry-config env/registry-config-for-mode root)
+                    env/acquire-execution-environment!
+                    (isolated-acquire env/acquire-execution-environment! host)]
+        (f))
+      (finally
+        (delete-tree! root)))))

--- a/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
@@ -23,6 +23,7 @@
    4. Stale phase transition request cleared between phases
    5. Review feedback lost during phase clearing (Run 9)"
   (:require
+   [ai.miniforge.workflow.isolation-test-support :as isolation]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase.loader :as loader]
    [clojure.test :refer [deftest testing is use-fixtures]]
@@ -234,3 +235,8 @@
     (binding [loader/phase-loader-config-resource phase-test-config-resource]
       (f))
     (phase/reset-phase-loader!)))
+
+;; Every pipeline this namespace runs acquires its worktree from a
+;; throwaway host repository and checkpoints into a throwaway root — never
+;; the checkout the test JVM was launched in, never `~/.miniforge`.
+(clojure.test/use-fixtures :once isolation/with-isolated-host)

--- a/components/workflow/test/ai/miniforge/workflow/runner_environment_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_environment_test.clj
@@ -17,7 +17,8 @@
 ;; limitations under the License.
 (ns ai.miniforge.workflow.runner-environment-test
   "Regression tests for runner-environment's base-sha capture and phase-boundary persistence guard behavior."
-  (:require [clojure.java.io :as io]
+  (:require [ai.miniforge.workflow.isolation-test-support :as isolation]
+            [clojure.java.io :as io]
             [clojure.java.shell :as shell]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
@@ -152,3 +153,8 @@
               "build-env-record sets :base-sha to resolved worktree HEAD SHA")
           (is (= "main" (get-in record [:environment-metadata :base-branch]))
               "pre-existing metadata fields must survive the merge"))))))
+
+;; Every pipeline this namespace runs acquires its worktree from a
+;; throwaway host repository and checkpoints into a throwaway root — never
+;; the checkout the test JVM was launched in, never `~/.miniforge`.
+(clojure.test/use-fixtures :once isolation/with-isolated-host)

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -19,6 +19,7 @@
   "Extended tests for workflow runner: output extraction, event publishing,
    and edge cases not covered by the main runner_test."
   (:require
+   [ai.miniforge.workflow.isolation-test-support :as isolation]
    [clojure.test :refer [deftest testing is use-fixtures]]
    [ai.miniforge.dag-executor.interface :as dag-exec]
    [ai.miniforge.event-stream.interface :as es]
@@ -601,3 +602,8 @@
           "governed mode pushes to remote — remote tier label, not worktree"))))
 
 (use-fixtures :each phase-test-support/with-workflow-phase-test-support)
+
+;; Every pipeline this namespace runs acquires its worktree from a
+;; throwaway host repository and checkpoints into a throwaway root — never
+;; the checkout the test JVM was launched in, never `~/.miniforge`.
+(clojure.test/use-fixtures :once isolation/with-isolated-host)

--- a/components/workflow/test/ai/miniforge/workflow/runner_iteration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_iteration_test.clj
@@ -20,6 +20,7 @@
   "Tests for iteration helpers extracted from runner.clj.
    Includes slingshot try+/throw+ bb-compatibility tests."
   (:require
+   [ai.miniforge.workflow.isolation-test-support :as isolation]
    [clojure.test :refer [deftest testing is use-fixtures]]
    [ai.miniforge.workflow.context :as ctx]
    [ai.miniforge.workflow.monitoring :as monitoring]
@@ -196,3 +197,8 @@
                 (:execution/errors result)))
       (is (= :progress-monitor
              (:supervisor (last (:execution/errors result))))))))
+
+;; Every pipeline this namespace runs acquires its worktree from a
+;; throwaway host repository and checkpoints into a throwaway root — never
+;; the checkout the test JVM was launched in, never `~/.miniforge`.
+(clojure.test/use-fixtures :once isolation/with-isolated-host)

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -20,6 +20,7 @@
    Tests that execute real phase pipelines (plan, implement, etc.)
    live in runner-integration-test under project tests."
   (:require
+   [ai.miniforge.workflow.isolation-test-support :as isolation]
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing use-fixtures]]
    [ai.miniforge.event-stream.interface :as es]
@@ -607,3 +608,8 @@
 (use-fixtures :each
   phase-test-support/with-workflow-phase-test-support
   with-stubbed-acquire-environment)
+
+;; Every pipeline this namespace runs acquires its worktree from a
+;; throwaway host repository and checkpoints into a throwaway root — never
+;; the checkout the test JVM was launched in, never `~/.miniforge`.
+(clojure.test/use-fixtures :once isolation/with-isolated-host)

--- a/docs/pull-requests/2026-09-04-test-hygiene-codex-env-and-host-isolation.md
+++ b/docs/pull-requests/2026-09-04-test-hygiene-codex-env-and-host-isolation.md
@@ -1,0 +1,150 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# test: keep the suite off the developer's checkout, home, and codex
+
+## Overview
+
+Two test-hygiene defects observed on the trap bench, series 8 (2026-09-03):
+
+1. With `MINIFORGE_CODEX_PATH` exported, two release-phase tests fail
+   because the release executor context appends the codex consultation
+   to `:task/behavior-addendum` and the tests had stubbed only the
+   standards pack.
+2. `bb test` inside a linked worktree left 108 `task-<8hex>` branches on
+   the enclosing repository within a minute. The developer checkout here
+   carried 38,253 of them, and `~/.miniforge/checkpoints` held 187k run
+   directories, most of them one `runner-test-done.edn` phase file.
+
+Both are fixed at the test boundary. Production code is unchanged.
+
+## Defect 1 — codex read from the environment
+
+`codex-pin/configured-codex-dir` reads `MINIFORGE_CODEX_PATH`. `release`'s
+`build-executor-context` calls `codex-pin/landings-outcome :release` through
+the two-arity form, so the environment decides whether codex text lands in
+the addendum. `release-threads-behavior-addendum-onto-executor-context-test`
+and `release-omits-behavior-addendum-when-filter-returns-nil-test` assert
+the addendum is exactly the stubbed pack text, or absent.
+
+Reproduced by pointing `MINIFORGE_CODEX_PATH` at a copy of
+`components/codex/test-resources/codex-fixture` with the four phase
+situations added: exactly those two tests fail, nothing else in the brick.
+
+Fix: `release-test` gains a `with-unconfigured-codex` fixture that rebinds
+`configured-codex-dir` to nil for every test, composed into the existing
+`:each` registration (`use-fixtures :each` replaces earlier registrations,
+so a second call would have been silently dropped). The consultation
+contract itself is covered by `codex-pin-test` with explicit directories.
+
+The alternative — threading the codex directory through the execution
+context with the environment read only at the CLI boundary — was not taken
+here. Five call sites and every entry path that builds a context (CLI run,
+resume, DAG sub-workflows, the MCP server) would have to agree, and a path
+that missed the key would turn the capability off silently.
+
+## Defect 2 — pipelines acquire worktrees from "."
+
+`runner/run-pipeline` defaults `:repo-path` to `"."` and, in `:local`
+mode, `acquire-execution-environment!` builds a real worktree executor and
+runs `git worktree add -b task-<8hex>` against whatever repository the test
+JVM was launched in. `release-environment!` removes the worktree directory;
+the branch stays. Checkpoints resolve to `~/.miniforge/checkpoints` unless
+the run names `:checkpoint/root`, and persisted task bundles go to the same
+root.
+
+Measured before the fix, one namespace at a time, in this worktree:
+
+| Suite | New `task-*` branches | New checkpoint dirs |
+|---|---|---|
+| `brick:workflow` | 0 | 117 |
+| `brick:dag-executor` | 0 | 0 (mocks git) |
+| `runner-integration-test` (project level) | 2 | 20 |
+| `meta-agent-test` (project integration) | 3+ | — |
+
+The `dag-executor` unit tests all stub `run-git`; the producer is every
+namespace that calls `run-pipeline` without stubbing acquisition — the
+project-level tests, plus the DAG orchestrator tests whose sub-workflows
+acquire once per task.
+
+Fix: a new `ai.miniforge.workflow.isolation-test-support/with-isolated-host`
+fixture (workflow brick test dir) that, for the duration of a namespace,
+redirects every sink into one throwaway tree:
+
+- `:repo-path` `"."` or absent → a fresh `git init` host repository with one
+  commit on `main` (the branch `run-pipeline` acquires from)
+- worktree base path and bundle archive → under the tree, via the
+  `registry-config-for-mode` seam (`:local` mode ignores `:executor-config`,
+  so the worktree entry is merged there)
+- `checkpoint-store-paths/default-checkpoint-root` → under the tree
+
+An explicit non-`"."` repo-path and an explicit `:checkpoint/root` still win.
+The tree is deleted on unwind. Registered as a `:once` fixture in the 13
+namespaces that run pipelines: eight in `components/workflow/test`, three in
+`projects/miniforge/test`, `projects/miniforge/integration`'s
+`meta-agent-test`, and the e2e namespace.
+
+`host-git-fixtures` in `dag-executor` was the model for the throwaway
+repository. It is not required across bricks: a workflow test depending on
+a dag-executor non-interface namespace is the shape Polylith's dependency
+check refuses, and the fixture needs six lines of git.
+
+## Verification
+
+- `brick:phase-software-factory` with `MINIFORGE_CODEX_PATH` set: 488 tests,
+  0 failures (was 2).
+- `brick:workflow` after the fixture: 1894 tests, 0 failures. The run named
+  21 `task-*` branches in its logs; none exist in this repository.
+- Project-level namespaces (`runner-integration-test`,
+  `dag-orchestrator-test`, `opsv-lifecycle-integration-test`,
+  `meta-agent-test`) run directly: 13 branches named, none exist in this
+  repository, no new worktree directories under `~/.miniforge/worktrees`.
+- Other sessions were running the suite concurrently on this machine during
+  measurement; their runs kept adding branches and checkpoint directories
+  (bursts of 18 dirs in one second, none of whose ids appear in my logs).
+  Attribution therefore used the branch names each run logged, not
+  directory counts.
+
+## Hook environment
+
+The first commit of this branch failed its pre-commit smoke run, and the
+launch repository came out of it with `core.bare = true` in its shared
+`.git/config`. Mechanism: `git commit` exports `GIT_DIR` and
+`GIT_INDEX_FILE` to its hooks, the smoke runner passed them through to the
+test JVM, and the fixture's `git init` in a temp directory therefore
+re-initialised the hook's repository — with no work tree in sight, as bare.
+`bb test` (the stable-derived runner) already strips those four variables
+before spawning `poly test`; the smoke runner did not.
+
+Two fixes: the fixture runs every git command with `GIT_INDEX_FILE`,
+`GIT_DIR`, `GIT_WORK_TREE`, and `GIT_COMMON_DIR` removed from its
+environment, so it is hermetic whoever launches it; and `precommit-smoke`
+now spawns the test JVM through the same sanitizer `bb test` uses, so
+production git calls reached from a smoke namespace cannot act on the hook's
+repository either. Repair for a checkout that already carries the damage:
+`git config core.bare false` in that checkout.
+
+## Stratum lint
+
+`release_test.clj` already exceeds the SL003 layer budget at `main` (five
+strata; the limit is three). Touching it trips the block, so this commit ran
+with `MINIFORGE_STRATUM_BUDGET_MODE=warn`. Splitting that namespace is not
+in scope. The mechanical stratum rewrite of the other ten namespaces landed
+in the preceding PR (`2026-09-04-fix-stratum-lint-wave-workflow-pipeline-tests`).
+
+## Not in this PR
+
+- `meta-agent-test` (project integration) fails 13 assertions with and
+  without this change when run directly from `projects/miniforge`: every
+  pipeline finishes `:failed`. Pre-existing; not investigated here.
+- Checkpoint writers outside `run-pipeline` (`checkpoint-store-test`,
+  `dag-resilience-resume-test`) were not audited. The open chip about tests
+  writing to the real checkpoint root is narrowed, not closed.
+- The 38k `task-*` branches already on the developer checkout, and the
+  187k checkpoint directories, are not deleted. Only the branches this
+  session's own unfixtured runs created were removed.
+- Whether other bricks' tests create environments against the launch
+  repository was not measured beyond `workflow`, `dag-executor`, and the
+  project-level namespaces.

--- a/projects/miniforge/e2e/ai/miniforge/workflow/meta_agent_e2e_test.clj
+++ b/projects/miniforge/e2e/ai/miniforge/workflow/meta_agent_e2e_test.clj
@@ -25,6 +25,7 @@
 
    Run locally only, not in CI (for now)."
   (:require
+   [ai.miniforge.workflow.isolation-test-support :as isolation]
    [clojure.test :refer [deftest is testing use-fixtures]]
    [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.agent.interface :as agent]
@@ -230,6 +231,11 @@
 (use-fixtures :each skip-if-no-cli)
 
 ;------------------------------------------------------------------------------ Test summary comment
+;; Every pipeline this namespace runs acquires its worktree from a
+;; throwaway host repository and checkpoints into a throwaway root — never
+;; the checkout the test JVM was launched in, never `~/.miniforge`.
+(clojure.test/use-fixtures :once isolation/with-isolated-host)
+
 (comment
   ;; How to run these E2E tests locally:
   ;;

--- a/projects/miniforge/integration/ai/miniforge/workflow/meta_agent_test.clj
+++ b/projects/miniforge/integration/ai/miniforge/workflow/meta_agent_test.clj
@@ -22,6 +22,7 @@
    and integration points. For true end-to-end tests with real LLM backends,
    see the e2e/ directory."
   (:require
+   [ai.miniforge.workflow.isolation-test-support :as isolation]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.agent.interface :as agent]))
@@ -329,3 +330,8 @@
       ;; Should have artifacts vector
       (is (vector? (:execution/artifacts result))
           "Should have artifacts vector"))))
+
+;; Every pipeline this namespace runs acquires its worktree from a
+;; throwaway host repository and checkpoints into a throwaway root — never
+;; the checkout the test JVM was launched in, never `~/.miniforge`.
+(clojure.test/use-fixtures :once isolation/with-isolated-host)

--- a/projects/miniforge/test/ai/miniforge/workflow/dag_orchestrator_test.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/dag_orchestrator_test.clj
@@ -18,6 +18,7 @@
 (ns ai.miniforge.workflow.dag-orchestrator-test
   "Tests for DAG orchestration of multi-task plans."
   (:require
+   [ai.miniforge.workflow.isolation-test-support :as isolation]
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.workflow.dag-orchestrator :as dag-orch]
    [ai.miniforge.workflow.dag-plan :as dag-plan]
@@ -578,3 +579,8 @@
                            (make-task :c [:a])])
           result (dag-orch/execute-plan-as-dag plan {})]
       (is (= 0 (:tasks-unreached result))))))
+
+;; Every pipeline this namespace runs acquires its worktree from a
+;; throwaway host repository and checkpoints into a throwaway root — never
+;; the checkout the test JVM was launched in, never `~/.miniforge`.
+(clojure.test/use-fixtures :once isolation/with-isolated-host)

--- a/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_integration_test.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_integration_test.clj
@@ -17,6 +17,7 @@
 ;; limitations under the License.
 (ns ai.miniforge.workflow.opsv-lifecycle-integration-test
   (:require
+   [ai.miniforge.workflow.isolation-test-support :as isolation]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.evidence-bundle.interface :as evidence]
    [ai.miniforge.event-stream.interface :as event-stream]
@@ -148,3 +149,8 @@
     (testing "the default posture remains side-effect free"
       (is (= :recommend-only (:effective-actuation-mode actuation)))
       (is (= [] (:governed-effects actuation))))))
+
+;; Every pipeline this namespace runs acquires its worktree from a
+;; throwaway host repository and checkpoints into a throwaway root — never
+;; the checkout the test JVM was launched in, never `~/.miniforge`.
+(clojure.test/use-fixtures :once isolation/with-isolated-host)

--- a/projects/miniforge/test/ai/miniforge/workflow/runner_integration_test.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/runner_integration_test.clj
@@ -18,6 +18,7 @@
 (ns ai.miniforge.workflow.runner-integration-test
   "Integration tests for the workflow runner that execute real phase pipelines."
   (:require
+   [ai.miniforge.workflow.isolation-test-support :as isolation]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.workflow.runner :as runner]
    ;; Require phase implementations
@@ -70,3 +71,8 @@
       (is (= :plan (get-in chain [:response-chain 0 :operation])))
       (is (= :completed (get-in result [:execution/phase-results :implement :status])))
       (is (true? (:succeeded? chain))))))
+
+;; Every pipeline this namespace runs acquires its worktree from a
+;; throwaway host repository and checkpoints into a throwaway root — never
+;; the checkout the test JVM was launched in, never `~/.miniforge`.
+(clojure.test/use-fixtures :once isolation/with-isolated-host)

--- a/tasks/test_runner.clj
+++ b/tasks/test_runner.clj
@@ -18,6 +18,7 @@
 (ns test-runner
   (:require
    [ai.miniforge.bb-proc.interface :as proc]
+   [ai.miniforge.bb-test-runner.interface :as bb-test-runner]
    [babashka.process :as p]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
@@ -177,7 +178,13 @@
         expr (str "(require 'clojure.test" ns-args ") "
                   "(let [r (clojure.test/run-tests" ns-args ")] "
                   "  (System/exit (if (zero? (+ (:fail r 0) (:error r 0))) 0 1)))")
-        exit (run-stream! clojure-cmd "-M:test:dev" "-e" expr)]
+        ;; `git commit` exports GIT_DIR and GIT_INDEX_FILE to its hooks. A
+        ;; test JVM that inherits them points every `git init` at the hook's
+        ;; own repository — which, with no work tree named, comes back bare
+        ;; (core.bare = true in the shared config, 2026-09-03). Same strip
+        ;; `bb test` applies before spawning `poly test`.
+        env  (bb-test-runner/sanitize-git-worktree-env (into {} (System/getenv)))
+        exit (run-stream! {:env env} clojure-cmd "-M:test:dev" "-e" expr)]
     (when-not (zero? exit)
       (println "❌ Pre-commit smoke tests failed with exit code:" exit)
       (System/exit exit))


### PR DESCRIPTION
Stacked on #1892 (stratum-lint autofix of the same test namespaces). Doc: `docs/pull-requests/2026-09-04-test-hygiene-codex-env-and-host-isolation.md`.

## Overview

Two test-hygiene defects from the trap bench, series 8 (2026-09-03), both fixed at the test boundary. Production code is unchanged.

1. **Codex read from the environment.** With `MINIFORGE_CODEX_PATH` exported, `release-threads-behavior-addendum-onto-executor-context-test` and `release-omits-behavior-addendum-when-filter-returns-nil-test` fail: `build-executor-context` appends the codex consultation to `:task/behavior-addendum` and the tests had stubbed only the pack. Reproduced against a copy of the codex fixture with the four phase situations added: exactly those two fail, nothing else in the brick. Fix: a `with-unconfigured-codex` fixture in `release_test`, composed into the namespace's existing `:each` registration (a second `use-fixtures :each` call silently replaces the first).
2. **Pipelines acquire worktrees from `"."`.** `runner/run-pipeline` defaults `:repo-path` to `"."`; in `:local` mode acquisition runs `git worktree add -b task-<8hex>` against whatever repository the test JVM was launched in, removes the worktree on release, and keeps the branch. Checkpoints go to `~/.miniforge/checkpoints`. The developer checkout carried 38,253 such branches; the checkpoint root held ~187k run dirs. Fix: `ai.miniforge.workflow.isolation-test-support/with-isolated-host`, a `:once` fixture that redirects repo-path `"."`, the worktree base, the bundle archive, and the default checkpoint root into one throwaway tree, registered in the 13 namespaces that run pipelines. Explicit repo-paths and `:checkpoint/root` opts still win.

## Hook environment (found while landing this)

The first commit attempt failed its pre-commit smoke run and left the launch repository with `core.bare = true`: `git commit` exports `GIT_DIR`/`GIT_INDEX_FILE` to hooks, `precommit-smoke` passed them to the test JVM, and the fixture's `git init` in a temp dir re-initialised the hook's repository as bare. The same mechanism explains the `core.bare` regressions seen earlier today and in April ("set by release tests" — `release_test` also runs `git init`). Fixes: the fixture strips `GIT_INDEX_FILE`/`GIT_DIR`/`GIT_WORK_TREE`/`GIT_COMMON_DIR` for its git calls, and `precommit-smoke` now spawns the JVM through the sanitizer `bb test` already uses.

## Verification

- `brick:phase-software-factory` with a codex configured: 488 tests, 0 failures (was 2).
- `brick:workflow`: 1894 tests, 0 failures; none of the 21 `task-*` branches the run named exist in the repository; no new worktree directories.
- Project-level namespaces run directly: no leaked branches. `meta-agent-test` fails 13 assertions with and without this change (pre-existing, not investigated).
- Pre-commit (poly check, clj-kondo, stratum lint in warn mode for the pre-existing SL003 on `release_test`, smoke tests, GraalVM compatibility) passed.

## Not in this PR

- Checkpoint writers outside `run-pipeline` (`checkpoint-store-test`, `dag-resilience-resume-test`) not audited; the open chip is narrowed, not closed.
- The existing 38k `task-*` branches and 187k checkpoint dirs are not deleted.
- `scripts/test-changed-bricks.bb` strips only `GIT_INDEX_FILE`; not changed here.
- Splitting `release_test` to meet the SL003 layer budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
