### PR TITLE
fix: report, account, and stop promoting a run cut at the LLM max-total ceiling

### DIFF
--- a/components/agent/resources/prompts/implementer.edn
+++ b/components/agent/resources/prompts/implementer.edn
@@ -9,6 +9,23 @@
  :prompt/agent :implementer
  :prompt/max-turns 40
 
+ ;; Main-turn progress monitor (loaded by prompts/load-progress-monitor).
+ ;; :max-total-ms is the hard ceiling on ONE implement turn; the LLM
+ ;; client cuts the subprocess when it is exceeded. The framework default
+ ;; is 10 minutes (components/llm/resources/llm/client-defaults.edn). On
+ ;; 2026-09-04 (trap bench series 9, run `baseline-trap-a-ry1`) two
+ ;; implement turns given 35-40k-char verify-failure prompts hit that
+ ;; ceiling: one was cut mid-write and left components/codex-gap/deps.edn
+ ;; without its :paths line, which failed every later verify; the other
+ ;; was cut after ten context_read calls before any write. Implement
+ ;; turns write many files and re-read context between writes, so they
+ ;; get 30 minutes. Stagnation and activity spacing stay at the framework
+ ;; defaults — the stream keepalive covers legitimate model silence.
+ :prompt/progress-monitor
+ {:stagnation-threshold-ms     120000
+  :max-total-ms                1800000
+  :min-activity-interval-ms    5000}
+
  :prompt/system
  "You are an Implementation Agent for an autonomous software development team.
 
@@ -201,6 +218,13 @@ are what they review — what you say in chat is just narration."
  ;; useful implementation analysis but wrote NO files and submitted no
  ;; artifact. Re-feeds the prior output and asks only for the Write.
  :prompt/submission-retry-max-turns 6
+
+ ;; The recovery turn only re-issues writes, so it keeps the framework's
+ ;; 10-minute ceiling rather than the main turn's 30.
+ :prompt/submission-retry-monitor
+ {:stagnation-threshold-ms     120000
+  :max-total-ms                600000
+  :min-activity-interval-ms    5000}
 
  :prompt/submission-retry-template
  "You already worked out the implementation for this task.

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -535,6 +535,22 @@
                    (str "origin/" base-branch)
                    (str "refs/heads/" base-branch)])))))
 
+(defn- ^{:stratum 1} create-implementer-progress-monitor
+  "Implementer main-turn progress monitor. Thresholds live in
+   resources/prompts/implementer.edn (:prompt/progress-monitor) — the
+   ceiling an implement turn gets before the LLM client cuts it
+   (`:max-total-ms`). Returns nil when the block is absent so the LLM
+   client's framework default applies. Mirrors the planner/reviewer
+   factories."
+  []
+  (prompts/load-progress-monitor @implementer-prompt-data :prompt/progress-monitor))
+
+(defn- ^{:stratum 1} create-implementer-retry-progress-monitor
+  "Progress monitor for the short submission-only recovery turn
+   (:prompt/submission-retry-monitor in implementer.edn); nil when absent."
+  []
+  (prompts/load-progress-monitor @implementer-prompt-data :prompt/submission-retry-monitor))
+
 (defn- ^{:stratum 1} submission-retry-prompt
   "Submission-only retry prompt: re-feed the task + the prior (prose) output
    and ask the implementer to deliver the actual file writes now."
@@ -618,10 +634,12 @@
   (let [budget-usd (budget/resolve-cost-budget-usd :implementer config context)
         max-turns (get @implementer-prompt-data :prompt/max-turns 10)
         resume-id (read-session-checkpoint working-dir)
+        monitor (create-implementer-progress-monitor)
         mcp-opts (cond-> (artifact-session/session->mcp-opts session budget-usd max-turns)
                    true        (assoc :disallowed-tools implementer-disallowed-tools)
                    working-dir (assoc :workdir working-dir)
-                   resume-id   (assoc :resume resume-id))
+                   resume-id   (assoc :resume resume-id)
+                   monitor     (assoc :progress-monitor monitor))
         result (if on-chunk
                  (llm/chat-stream llm-client user-prompt on-chunk
                                   (merge {:system effective-system-prompt} mcp-opts))
@@ -859,11 +877,13 @@
                                   (let [budget-usd      (budget/resolve-cost-budget-usd
                                                          :implementer config context)
                                         retry-max-turns (get @implementer-prompt-data
-                                                             :prompt/submission-retry-max-turns 6)]
+                                                             :prompt/submission-retry-max-turns 6)
+                                        retry-monitor   (create-implementer-retry-progress-monitor)]
                                     (cond-> (artifact-session/session->mcp-opts
                                              session budget-usd retry-max-turns)
-                                      true        (assoc :disallowed-tools implementer-disallowed-tools)
-                                      working-dir (assoc :workdir working-dir))))})
+                                      true          (assoc :disallowed-tools implementer-disallowed-tools)
+                                      working-dir   (assoc :workdir working-dir)
+                                      retry-monitor (assoc :progress-monitor retry-monitor))))})
         recovered (normalize-implementer-result raw context working-dir)]
     (when (or (:structured-artifact recovered)
               (:parsed-content recovered)
@@ -883,6 +903,17 @@
           #(invoke-implementer-session % llm-client user-prompt effective-system-prompt
                                        config context on-chunk existing-files working-dir))
         response llm-result
+        ;; The LLM client cut the run at its `:max-total-ms` ceiling. The
+        ;; files on disk are whatever the agent had written when the clock
+        ;; ran out — mid-write on the 2026-09-04 trap-bench series 9 run,
+        ;; which left a deps.edn without its :paths line and failed every
+        ;; later verify. Such a turn is NOT promoted from the working tree;
+        ;; it fails with the timeout envelope so the phase routes it as a
+        ;; backend timeout (retry from the session checkpoint within the
+        ;; iteration budget, then the terminal :implement/backend-timeout
+        ;; verdict). Stream-idle / stagnation keep the container-promotion
+        ;; precedence below: there the model finished writing and hung.
+        cut-by-ceiling? (= :max-total (:llm/terminated-by response))
         file-artifact (collect-session-artifact context
                                                 session-mode
                                                 working-dir
@@ -892,14 +923,25 @@
                      :response response
                      :worktree-artifacts worktree-artifacts
                      :artifact artifact
-                     :fallback-artifact file-artifact
+                     :fallback-artifact (when-not cut-by-ceiling? file-artifact)
                      :parse-response parse-code-response
-                     :derive-artifact code-from-blocks})]
+                     :derive-artifact code-from-blocks})
+        partial-files (mapv :path (:code/files file-artifact))]
     (when (seq context-misses)
       (log/info logger :implementer :implementer/context-cache-misses
                 {:data {:miss-count (count context-misses)
                         :misses context-misses}}))
-    (when file-artifact
+    (when cut-by-ceiling?
+      (log/warn logger :implementer :implementer/llm-max-total-exceeded
+                {:data {:elapsed-ms (get-in response [:error :timeout :elapsed-ms])
+                        :max-ms (get-in response [:error :timeout :max-ms])
+                        :tool-call-count (get response :tool-call-count
+                                              (count (get response :tools-called [])))
+                        :tools-called (get response :tools-called [])
+                        :partial-file-count (count partial-files)
+                        :partial-files partial-files
+                        :working-dir working-dir}}))
+    (when (and file-artifact (not cut-by-ceiling?))
       (log/warn logger :implementer :implementer/file-artifact-fallback
                 {:data {:file-count (count (:code/files file-artifact))
                         :tools-called (get response :tools-called [])}}))
@@ -913,6 +955,8 @@
                               ;; a write/scan dir mismatch is diagnosable.
                               :working-dir working-dir
                               :tools-called (:tools-called normalized)}
+                       (:llm/terminated-by response)
+                       (assoc :terminated-by (:llm/terminated-by response))
                        (:stop-reason response)
                        (assoc :stop-reason (:stop-reason response))
                        (:num-turns response)
@@ -937,36 +981,55 @@
           ;; produced usable code blocks does NOT trigger an unnecessary
           ;; recovery LLM call.
           parsed    (or (:parsed-content normalized) (:derived-artifact normalized))
-          recovered (when (submission-recovery/submission-retry?
-                           response submitted parsed (:content normalized))
+          ;; No recovery turn after a ceiling cut: the turn was still
+          ;; working, not narrating; the phase-level retry resumes the
+          ;; session instead.
+          recovered (when (and (not cut-by-ceiling?)
+                               (submission-recovery/submission-retry?
+                                response submitted parsed (:content normalized)))
                       (recover-implementer-submission
                        {:llm-client llm-client :config config :context context
                         :on-chunk on-chunk :working-dir working-dir
                         :effective-system-prompt effective-system-prompt
                         :input input :normalized normalized :logger logger}))
-          final     (or recovered normalized)]
-      ;; Container-promotion precedence: if the agent wrote files into
-      ;; the worktree (file-artifact via collect-written-files) or
-      ;; submitted via the MCP artifact path, honor that even when the
-      ;; CLI itself terminated with a timeout/error. Iter-20 of the
-      ;; planner-convergence dogfood showed Claude stalling AFTER a
-      ;; successful stream of edits; the old path discarded a real
-      ;; artifact because the LLM response was classified as failure.
-      (let [result (if (result-boundary/usable-content? final)
-                     (process-llm-response final context logger input)
-                     ;; LLM call failed, no artifact (even after recovery) —
-                     ;; preserve the full llm-error shape into :data so the
-                     ;; phase-completed event carries :type / :stderr /
-                     ;; :stdout / :timeout / :exit-code for post-mortem.
-                     (result-boundary/error-response final
-                                                     (messages/t :error/llm-failed)))]
-        ;; Session channel: which files the agent actually read (Codex SPEC
-        ;; §7.4.2). The phase layer turns this into consultation provenance.
-        ;; some?, not seq: an EMPTY reads log is "known: nothing was read",
-        ;; which is a different fact from "no log surfaced" (capsule mode) —
-        ;; dropping it would turn a real unread into unknown downstream.
-        (cond-> result
-          (some? context-reads) (assoc :context-reads context-reads))))))
+          final     (or recovered normalized)
+          ;; Container-promotion precedence: if the agent wrote files into
+          ;; the worktree (file-artifact via collect-written-files) or
+          ;; submitted via the MCP artifact path, honor that even when the
+          ;; CLI itself terminated with a timeout/error. Iter-20 of the
+          ;; planner-convergence dogfood showed Claude stalling AFTER a
+          ;; successful stream of edits; the old path discarded a real
+          ;; artifact because the LLM response was classified as failure.
+          result    (cond
+                      cut-by-ceiling?
+                      ;; Ceiling cut: always a failed result, whatever is on
+                      ;; disk. `:data` keeps the llm-error (with its
+                      ;; `:timeout` envelope, which the phase classifies as
+                      ;; a backend timeout) plus the marker and the partial
+                      ;; files for post-mortem.
+                      (result-boundary/error-response
+                       final
+                       (messages/t :error/llm-max-total-exceeded)
+                       {:data {:llm/terminated-by :max-total
+                               :partial-files partial-files}})
+
+                      (result-boundary/usable-content? final)
+                      (process-llm-response final context logger input)
+
+                      :else
+                      ;; LLM call failed, no artifact (even after recovery) —
+                      ;; preserve the full llm-error shape into :data so the
+                      ;; phase-completed event carries :type / :stderr /
+                      ;; :stdout / :timeout / :exit-code for post-mortem.
+                      (result-boundary/error-response final
+                                                      (messages/t :error/llm-failed)))]
+      ;; Session channel: which files the agent actually read (Codex SPEC
+      ;; §7.4.2). The phase layer turns this into consultation provenance.
+      ;; some?, not seq: an EMPTY reads log is "known: nothing was read",
+      ;; which is a different fact from "no log surfaced" (capsule mode) —
+      ;; dropping it would turn a real unread into unknown downstream.
+      (cond-> result
+        (some? context-reads) (assoc :context-reads context-reads)))))
 
 ;------------------------------------------------------------------------------ Layer 7
 

--- a/components/agent/test/ai/miniforge/agent/implementer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_test.clj
@@ -26,6 +26,7 @@
    [ai.miniforge.agent.core :as core]
    [ai.miniforge.agent.file-artifacts :as file-artifacts]
    [ai.miniforge.agent.implementer :as implementer]
+   [ai.miniforge.agent.submission-recovery :as submission-recovery]
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.repo-index.interface :as messages]
@@ -429,6 +430,37 @@
       (is (= "found in worktree metadata" (:summary result)))
       (is (= [] (get-in result [:output :code/files]))))))
 
+;------------------------------------------------------------------------------ Ceiling cut (2026-09-04 trap-bench series 9)
+;;
+;; Two implement turns hit the LLM client's :max-total ceiling mid-work.
+;; The implementer promoted whatever was on disk (one file was a deps.edn
+;; missing its :paths line), logged `:tokens 0 :tools-called []`, and the
+;; phase reported success. A ceiling cut must be a failed result that
+;; carries the timeout envelope, and the log must say what was cut.
+(def ^{:stratum 0} ^:private min-implement-total-budget-ms
+  "Floor for the implementer main-turn :max-total-ms — 30 minutes. Implement
+   turns write many files and re-read context between writes; the 10-minute
+   framework default cut two of them mid-work on 2026-09-04."
+  1800000)
+
+(defn- ^{:stratum 0} cut-response
+  "LLM response shape `streaming-error-response` emits when the run hits
+   the :max-total ceiling: timeout envelope + marker + the bookkeeping the
+   client now carries for a cut run."
+  []
+  {:success false
+   :error {:type "adaptive_timeout"
+           :message "Adaptive timeout: Hard timeout: exceeded 600000ms limit (type: hard-limit, elapsed: 600042ms)"
+           :timeout {:type :hard-limit :elapsed-ms 600042 :max-ms 600000}
+           :stdout "Now let me write all the files"
+           :exit-code -1}
+   :anomaly {}
+   :llm/terminated-by :max-total
+   :tools-called ["mcp__context__context_read" "mcp__context__context_write"]
+   :tool-call-count 2
+   :tokens 8000
+   :stop-reason "tool_use"})
+
 ;------------------------------------------------------------------------------ Layer 1
 
 ;; Invoke tests
@@ -730,6 +762,143 @@
       (is (map? (:actions summary)))
       (is (string? (:language summary)))
       (is (boolean? (:tests-needed? summary))))))
+
+(deftest ^{:stratum 1} implementer-max-total-cut-is-a-failed-result-test
+  (testing "a run cut by :max-total fails even with files on disk, and logs the cut"
+    (let [[logger entries] (log/collecting-logger {:min-level :trace})
+          partial-artifact {:code/files [{:path "components/codex-gap/deps.edn"
+                                          :content "{:deps {}}"
+                                          :action :create}
+                                         {:path "src/partial.clj"
+                                          :content "(ns partial)"
+                                          :action :create}]
+                            :code/summary "written before the cut"
+                            :code/language "clojure"
+                            :code/tests-needed? true}
+          recovery-calls (atom 0)
+          result (with-redefs [artifact-session/create-session!
+                               (fn [& _] (session-map))
+                               artifact-session/write-mcp-config!
+                               identity
+                               artifact-session/read-artifact
+                               (constantly nil)
+                               artifact-session/read-context-misses
+                               (constantly nil)
+                               artifact-session/cleanup-session!
+                               (constantly nil)
+                               budget/resolve-cost-budget-usd
+                               (fn [& _] 1.0)
+                               llm/chat
+                               (fn [& _] (cut-response))
+                               submission-recovery/run-recovery-session
+                               (fn [& _] (swap! recovery-calls inc) nil)
+                               file-artifacts/collect-written-files
+                               (fn [_ _] partial-artifact)
+                               file-artifacts/collect-worktree-files
+                               (fn [_ _] nil)]
+                   (@#'implementer/invoke-with-llm
+                    nil "prompt" "system" {} {} nil logger [] {}))
+          cut-log (find-log-entry entries :implementer/llm-max-total-exceeded)
+          called-log (find-log-entry entries :implementer/llm-called)]
+      (is (response/error? result)
+          "files on disk do not turn a ceiling cut into a success")
+      (is (nil? (get-in result [:output :code/files])))
+      (is (= :hard-limit (get-in result [:error :data :timeout :type]))
+          "timeout envelope survives so the phase routes it as a backend timeout")
+      (is (= :max-total (get-in result [:error :data :llm/terminated-by])))
+      (is (= ["components/codex-gap/deps.edn" "src/partial.clj"]
+             (get-in result [:error :data :partial-files])))
+      (is (= 8000 (get-in result [:metrics :tokens]))
+          "tokens the cut run consumed are reported")
+      (is (= 0 @recovery-calls) "no submission-recovery turn after a ceiling cut")
+      (is (nil? (find-log-entry entries :implementer/file-artifact-fallback))
+          "no silent file-artifact promotion")
+      (is (some? cut-log) "the cut is logged")
+      (is (= :warn (:log/level cut-log)))
+      (is (= 600042 (get-in cut-log [:data :elapsed-ms])))
+      (is (= 600000 (get-in cut-log [:data :max-ms])))
+      (is (= 2 (get-in cut-log [:data :tool-call-count])))
+      (is (= 2 (get-in cut-log [:data :partial-file-count])))
+      (is (= :max-total (get-in called-log [:data :terminated-by])))
+      (is (false? (get-in called-log [:data :success])))
+      (is (= 8000 (get-in called-log [:data :tokens])))
+      (is (= ["mcp__context__context_read" "mcp__context__context_write"]
+             (get-in called-log [:data :tools-called]))))))
+
+(deftest ^{:stratum 1} implementer-stream-idle-cut-keeps-file-promotion-test
+  (testing "a stream-idle after successful writes still promotes the files (iter-20 precedence)"
+    ;; Only :max-total refuses promotion: there the client cut a turn that
+    ;; was still writing. Stream-idle / stagnation mean the model finished
+    ;; and hung, so the work on disk is the work.
+    (let [[logger _] (log/collecting-logger {:min-level :trace})
+          fallback-artifact {:code/files [{:path "src/done.clj"
+                                           :content "(ns done)"
+                                           :action :create}]
+                             :code/summary "written before the hang"
+                             :code/language "clojure"
+                             :code/tests-needed? true}
+          idle-response (-> (cut-response)
+                            (assoc :llm/terminated-by :stream-idle)
+                            (assoc-in [:error :timeout] {:type :stream-idle :elapsed-ms 420000}))
+          result (with-redefs [artifact-session/create-session!
+                               (fn [& _] (session-map))
+                               artifact-session/write-mcp-config!
+                               identity
+                               artifact-session/read-artifact
+                               (constantly nil)
+                               artifact-session/read-context-misses
+                               (constantly nil)
+                               artifact-session/cleanup-session!
+                               (constantly nil)
+                               budget/resolve-cost-budget-usd
+                               (fn [& _] 1.0)
+                               llm/chat
+                               (fn [& _] idle-response)
+                               file-artifacts/collect-written-files
+                               (fn [_ _] fallback-artifact)
+                               file-artifacts/collect-worktree-files
+                               (fn [_ _] nil)]
+                   (@#'implementer/invoke-with-llm
+                    nil "prompt" "system" {} {} nil logger [] {}))]
+      (is (response/success? result))
+      (is (= [{:path "src/done.clj" :content "(ns done)" :action :create}]
+             (get-in result [:output :code/files]))))))
+
+(deftest ^{:stratum 1} implementer-progress-monitor-thresholds-loaded-test
+  ;; Mirrors planner-progress-monitor-thresholds-loaded-test: guards the
+  ;; implementer.edn ceiling at the LLM boundary so a prompt-loading
+  ;; regression cannot silently drop the implementer back to the
+  ;; 10-minute framework default.
+  (testing ":progress-monitor passed to the LLM reflects implementer.edn's ceiling"
+    (let [[logger _] (log/collecting-logger {:min-level :trace})
+          captured (atom nil)
+          _ (with-redefs [artifact-session/create-session!
+                          (fn [& _] (session-map))
+                          artifact-session/write-mcp-config!
+                          identity
+                          artifact-session/read-artifact
+                          (constantly nil)
+                          artifact-session/read-context-misses
+                          (constantly nil)
+                          artifact-session/cleanup-session!
+                          (constantly nil)
+                          budget/resolve-cost-budget-usd
+                          (fn [& _] 1.0)
+                          llm/chat
+                          (fn [_client _prompt opts]
+                            (reset! captured opts)
+                            (llm-response :content "" :tokens 1))
+                          file-artifacts/collect-written-files
+                          (fn [_ _] nil)
+                          file-artifacts/collect-worktree-files
+                          (fn [_ _] nil)]
+              (@#'implementer/invoke-with-llm
+               nil "prompt" "system" {} {} nil logger [] {}))
+          monitor (:progress-monitor @captured)]
+      (is (some? @captured) "LLM client should have been called")
+      (is (some? monitor) ":progress-monitor opt must reach the LLM client")
+      (is (>= (:max-total-ms @monitor) min-implement-total-budget-ms)
+          "implement turns write many files; the ceiling must be ≥ 30 minutes"))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/test/ai/miniforge/agent/implementer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_test.clj
@@ -825,6 +825,43 @@
       (is (= ["mcp__context__context_read" "mcp__context__context_write"]
              (get-in called-log [:data :tools-called]))))))
 
+(deftest ^{:stratum 1} implementer-max-total-cut-before-any-write-test
+  (testing "a cut before the first write (nothing on disk) is still a failed result"
+    ;; Iteration 5 of the 2026-09-04 run: ten context_read calls, cut
+    ;; before any write. No file artifact at all — the partial-files
+    ;; derivation and the cut log must handle a nil artifact.
+    (let [[logger entries] (log/collecting-logger {:min-level :trace})
+          recovery-calls (atom 0)
+          result (with-redefs [artifact-session/create-session!
+                               (fn [& _] (session-map))
+                               artifact-session/write-mcp-config!
+                               identity
+                               artifact-session/read-artifact
+                               (constantly nil)
+                               artifact-session/read-context-misses
+                               (constantly nil)
+                               artifact-session/cleanup-session!
+                               (constantly nil)
+                               budget/resolve-cost-budget-usd
+                               (fn [& _] 1.0)
+                               llm/chat
+                               (fn [& _] (cut-response))
+                               submission-recovery/run-recovery-session
+                               (fn [& _] (swap! recovery-calls inc) nil)
+                               file-artifacts/collect-written-files
+                               (fn [_ _] nil)
+                               file-artifacts/collect-worktree-files
+                               (fn [_ _] nil)]
+                   (@#'implementer/invoke-with-llm
+                    nil "prompt" "system" {} {} nil logger [] {}))
+          cut-log (find-log-entry entries :implementer/llm-max-total-exceeded)]
+      (is (response/error? result))
+      (is (= :hard-limit (get-in result [:error :data :timeout :type])))
+      (is (= :max-total (get-in result [:error :data :llm/terminated-by])))
+      (is (= [] (get-in result [:error :data :partial-files])))
+      (is (= 0 (get-in cut-log [:data :partial-file-count])))
+      (is (= 0 @recovery-calls)))))
+
 (deftest ^{:stratum 1} implementer-stream-idle-cut-keeps-file-promotion-test
   (testing "a stream-idle after successful writes still promotes the files (iter-20 precedence)"
     ;; Only :max-total refuses promotion: there the client cut a turn that

--- a/components/llm/resources/llm/client-defaults.edn
+++ b/components/llm/resources/llm/client-defaults.edn
@@ -9,6 +9,12 @@
  {:anthropic {:api-version "2023-06-01"
               :default-max-tokens 16000}}
 
+ ;; Framework defaults for a monitored streaming run. A role overrides
+ ;; them per turn through its prompt config's :prompt/progress-monitor
+ ;; block (components/agent/resources/prompts/{planner,reviewer,implementer}.edn);
+ ;; the implementer carries a 30-minute :max-total-ms because its turns
+ ;; write many files (2026-09-04 trap-bench series 9 cut two of them at
+ ;; this 10-minute default).
  :stream
  {:default-stagnation-threshold-ms 120000
   :default-max-total-ms 600000

--- a/components/llm/src/ai/miniforge/llm/progress_monitor.clj
+++ b/components/llm/src/ai/miniforge/llm/progress_monitor.clj
@@ -34,7 +34,9 @@
 (def ^{:stratum 0} ^:private default-max-total-ms
   "Hard ceiling on a single monitored run regardless of progress. 10 minutes —
    a backstop for an agent that keeps emitting just enough to look active but
-   never actually finishes."
+   never actually finishes. Roles override it per turn via their prompt
+   config's :prompt/progress-monitor block (the implementer runs 30 minutes);
+   a run that hits it is reported with `:llm/terminated-by :max-total`."
   600000)
 
 (def ^{:stratum 0} ^:private default-min-activity-interval-ms

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -2240,7 +2240,11 @@
                                                 (model-registry/context-window-for-model-id
                                                  (:model request-with-model)))
                 (seq tools)   (assoc :tools-called tools)
-                (some? usage) (assoc :cost-usd resolved-cost)
+                ;; Cost is known when the backend reported one
+                ;; (total_cost_usd) or usage lets us estimate it —
+                ;; same two sources the success branch draws on.
+                (or (some? @accumulated-cost) (some? usage))
+                (assoc :cost-usd resolved-cost)
                 session-id    (assoc :session-id session-id)))))))))
 
 ;------------------------------------------------------------------------------ Layer 10

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -120,6 +120,29 @@
         (number? cache-creation) (assoc :cache-creation-input-tokens cache-creation)
         (number? cache-read)     (assoc :cache-read-input-tokens cache-read)))))
 
+(defn ^{:stratum 0} fold-message-usage
+  "Fold one assistant message's usage into the running usage map.
+
+   - Input-side counts (:input-tokens, :cache-*-input-tokens) describe
+     that API call's whole context, so the LATEST one is the run's
+     current context size. Summing them would inflate
+     `context-overflow-by-usage?` into a false overflow on any long run
+     that was cut before its result frame.
+   - :output-tokens is per call and accumulates.
+   - Claude Code emits one `assistant` event per content block, each
+     carrying the same message `usage`; `message-id` dedupes those so a
+     text + tool_use message folds once. The id rides as metadata so the
+     usage map keeps the plain `{:input-tokens .. :output-tokens ..}`
+     shape callers compare and serialize."
+  [prev message-id usage]
+  (let [prev (or prev {})]
+    (if (and message-id (= message-id (::message-id (meta prev))))
+      prev
+      (-> (merge prev (dissoc usage :output-tokens))
+          (cond-> (contains? usage :output-tokens)
+            (update :output-tokens (fnil + 0) (:output-tokens usage)))
+          (vary-meta assoc ::message-id message-id)))))
+
 (defn- ^{:stratum 0} normalize-codex-finish-reason
   "Normalize a Codex finish_reason string to the canonical stop-reason strings
    used across all backends.
@@ -567,16 +590,17 @@
     :else
     (pm/record-chunk! progress-monitor @accumulated-content)))
 
-(defn ^{:stratum 0} log-streaming-result [logger timeout-info content-length]
-  (when logger
-    (if timeout-info
-      (log/warn logger :system :agent/streaming-timeout
-                {:message (:message timeout-info)
-                 :data {:type (:type timeout-info)
-                        :elapsed-ms (:elapsed-ms timeout-info)
-                        :stats (:stats timeout-info)}})
-      (log/debug logger :system :agent/streaming-complete
-                 {:data {:response-length content-length}}))))
+(def ^{:stratum 0} ^:private timeout-type->terminated-by
+  "Adaptive-timeout `:type` → the `:llm/terminated-by` marker a cut run
+   carries on its response. The marker names the CLIENT-SIDE reason the
+   run ended before the model finished, so a role can branch on it
+   without re-parsing the timeout envelope. `:hard-limit` is renamed to
+   `:max-total` because that is the knob (`:max-total-ms`) an operator
+   turns to change it."
+  {:hard-limit   :max-total
+   :stagnation   :stagnation
+   :stream-idle  :stream-idle
+   :network-drop :network-drop})
 
 (defn- ^{:stratum 0} message-preview
   "Return the last up-to-500 characters of content for post-mortem diagnostics.
@@ -659,6 +683,13 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
+(defn ^{:stratum 1} terminated-by
+  "Return the `:llm/terminated-by` marker for an adaptive-timeout envelope,
+   or nil when the run was not cut by the client (no envelope, or an
+   envelope type outside the known taxonomy)."
+  [timeout-info]
+  (get timeout-type->terminated-by (:type timeout-info)))
+
 (def ^{:stratum 1} ^:private client-defaults
   (delay (load-client-defaults)))
 
@@ -730,12 +761,25 @@
                 ;; "tool_use" | "max_turns" (Claude Code adds the last).
                 ;; The accumulator tracks the LATEST — that's the reason
                 ;; the overall turn ended.
-                stop-reason (get-in data [:message :stop_reason])]
+                stop-reason (get-in data [:message :stop_reason])
+                ;; Per-message usage. The authoritative totals arrive on
+                ;; the final `result` frame — which a run cut by an
+                ;; adaptive timeout never sees. Carrying each message's
+                ;; usage lets the accumulator report what a cut run
+                ;; consumed (2026-09-04 trap-bench series 9: two cut
+                ;; implement turns logged `:tokens 0`).
+                message-usage (parsed-usage (get-in data [:message :usage]))
+                message-id (get-in data [:message :id])
+                with-usage (fn [parsed]
+                             (cond-> parsed
+                               message-usage (assoc :message-usage message-usage)
+                               (and message-usage message-id)
+                               (assoc :message-id message-id)))]
             (cond
               (seq tool-names)
               (let [first-tool (first tool-blocks)]
-                (cond-> {:delta (or text "") :done? false
-                         :tool-use true :tool-names tool-names}
+                (cond-> (with-usage {:delta (or text "") :done? false
+                                     :tool-use true :tool-names tool-names})
                   stop-reason               (assoc :stop-reason stop-reason)
                   ;; Additive: :tool-call-id and :tool-input from the first
                   ;; tool_use block. Present only when the fields are
@@ -745,13 +789,13 @@
                   (some? (:input first-tool)) (assoc :tool-input (:input first-tool))))
 
               (not (str/blank? text))
-              (cond-> {:delta text :done? false}
+              (cond-> (with-usage {:delta text :done? false})
                 stop-reason (assoc :stop-reason stop-reason))
 
               ;; No text + no tool calls — still carry stop-reason if
               ;; present so "empty turn" shows a reason.
               stop-reason
-              {:delta "" :done? false :stop-reason stop-reason}))
+              (with-usage {:delta "" :done? false :stop-reason stop-reason})))
 
           ;; Legacy format support
           "stream_event"
@@ -1109,6 +1153,12 @@
   [stream-parser on-chunk progress-monitor accumulated-content accumulated-usage accumulated-cost accumulated-tools accumulated-session-id accumulated-stop-reason accumulated-turns]
   (fn [line]
     (when-let [parsed (stream-parser line)]
+      ;; Per-message usage folds as it streams (see `fold-message-usage`)
+      ;; so a run cut before its result frame still reports what it
+      ;; consumed; the result frame's `:usage` then REPLACES those keys
+      ;; with the backend's authoritative totals.
+      (when-let [message-usage (:message-usage parsed)]
+        (swap! accumulated-usage fold-message-usage (:message-id parsed) message-usage))
       (when-let [usage (:usage parsed)]
         (swap! accumulated-usage (fn [prev] (merge prev usage))))
       (when-let [cost (:cost-usd parsed)]
@@ -1174,6 +1224,27 @@
                                    chars-per-token-estimate)}))
 
 ;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} log-streaming-result
+  "Log the outcome of a streamed run. A cut run (any adaptive timeout)
+   logs at warn with the elapsed time, the ceiling it hit, and the number
+   of tool calls the model had already made — the 2026-09-04 trap-bench
+   series 9 run (`baseline-trap-a-ry1`) hit the 10-minute `:max-total`
+   ceiling twice mid-write and nothing in the run log said so."
+  [logger timeout-info content-length tool-call-count]
+  (when logger
+    (if timeout-info
+      (log/warn logger :system :agent/streaming-timeout
+                {:message (:message timeout-info)
+                 :data (cond-> {:type (:type timeout-info)
+                                :terminated-by (terminated-by timeout-info)
+                                :elapsed-ms (:elapsed-ms timeout-info)
+                                :tool-call-count tool-call-count
+                                :stats (:stats timeout-info)}
+                         (:max-ms timeout-info)
+                         (assoc :max-ms (:max-ms timeout-info)))})
+      (log/debug logger :system :agent/streaming-complete
+                 {:data {:response-length content-length}}))))
 
 (defn- ^{:stratum 2} client-default
   [path]
@@ -1483,7 +1554,15 @@
    - :final-message-preview — last 500 chars of accumulated content (post-mortem aid)
 
    `usage` + `context-window` drive context-overflow classification (N12 §4);
-   optional — the 9-arity form skips it (for callers without them)."
+   optional — the 9-arity form skips it (for callers without them). When
+   `usage` is present it is also carried on the response as `:usage` /
+   `:tokens` (same shape `llm-success` emits) so a run that was cut still
+   reports the tokens it consumed.
+
+   `:llm/terminated-by` is set whenever `timeout-info` carries a known
+   adaptive-timeout type (see `terminated-by`) — `:max-total` for the
+   hard ceiling — so roles can refuse to promote partial work from a run
+   the client cut, instead of treating it like a model that finished."
   ([content exit-code err-result raw-stdout timeout-info stop-reason num-turns
     tool-call-count final-message-preview]
    (streaming-error-response content exit-code err-result raw-stdout timeout-info
@@ -1506,6 +1585,10 @@
                          :stdout content
                          :raw-stdout raw-stdout
                          :timeout timeout-info})
+       (terminated-by timeout-info) (assoc :llm/terminated-by (terminated-by timeout-info))
+       (some? usage)               (assoc :usage usage
+                                          :tokens (+ (get usage :input-tokens 0)
+                                                     (get usage :output-tokens 0)))
        stop-reason                 (assoc :stop-reason stop-reason)
        num-turns                   (assoc :num-turns num-turns)
        (some? tool-call-count)     (assoc :tool-call-count tool-call-count)
@@ -2114,7 +2197,7 @@
                      :done? true
                      :content final-content
                      :timeout timeout-info})
-          (log-streaming-result logger timeout-info (count final-content))
+          (log-streaming-result logger timeout-info (count final-content) tool-call-count)
           (when (and logger (seq tools))
             (log/info logger :system :agent/tools-called
                       {:data {:tools tools :count (count tools)}}))
@@ -2122,36 +2205,43 @@
             (log/info logger :system :agent/stop-reason
                       {:data {:stop-reason stop-reason :num-turns num-turns
                               :content-length (count final-content)}}))
-          (if (zero? exit-code)
-            ;; Cost fallback: some backends (e.g. older Claude Code
-            ;; CLI versions, codex stream parser) don't surface
-            ;; total_cost_usd in the result frame, so
-            ;; @accumulated-cost stays nil and the runner banner
-            ;; reports $0.0000 despite real backend costs. When
-            ;; cost is nil but usage carries tokens, compute the
-            ;; fallback estimate from the model + usage via
-            ;; cost/estimate-cost. Models without pricing in the
-            ;; table return 0.0 (no false-positive cost), so this
-            ;; is a non-decreasing fix — never produces a wrong-
-            ;; direction value.
-            (let [resolved-cost (or @accumulated-cost
-                                    (cost/estimate-cost usage model))]
+          ;; Cost fallback: some backends (e.g. older Claude Code
+          ;; CLI versions, codex stream parser) don't surface
+          ;; total_cost_usd in the result frame, so
+          ;; @accumulated-cost stays nil and the runner banner
+          ;; reports $0.0000 despite real backend costs. When
+          ;; cost is nil but usage carries tokens, compute the
+          ;; fallback estimate from the model + usage via
+          ;; cost/estimate-cost. Models without pricing in the
+          ;; table return 0.0 (no false-positive cost), so this
+          ;; is a non-decreasing fix — never produces a wrong-
+          ;; direction value.
+          (let [resolved-cost (or @accumulated-cost
+                                  (cost/estimate-cost usage model))]
+            (if (zero? exit-code)
               (cond-> (streaming-success-response final-content exit-code
                                                   usage resolved-cost
                                                   stop-reason num-turns
                                                   tool-call-count final-message-preview
                                                   (:err result))
                 (seq tools) (assoc :tools-called tools)
-                session-id  (assoc :session-id session-id)))
-            (cond-> (streaming-error-response final-content exit-code (:err result)
-                                              diagnostic-content
-                                              timeout-info stop-reason num-turns
-                                              tool-call-count final-message-preview
-                                              usage
-                                              ;; effective model actually invoked (honors per-request :model)
-                                              (model-registry/context-window-for-model-id
-                                               (:model request-with-model)))
-              session-id (assoc :session-id session-id))))))))
+                session-id  (assoc :session-id session-id))
+              ;; A run that was cut (timeout) or died still consumed
+              ;; tokens and made tool calls; carry them so the role's
+              ;; bookkeeping (`implementer/llm-called`) reports what
+              ;; actually happened instead of `:tokens 0 :tools-called []`
+              ;; (2026-09-04 trap-bench series 9).
+              (cond-> (streaming-error-response final-content exit-code (:err result)
+                                                diagnostic-content
+                                                timeout-info stop-reason num-turns
+                                                tool-call-count final-message-preview
+                                                usage
+                                                ;; effective model actually invoked (honors per-request :model)
+                                                (model-registry/context-window-for-model-id
+                                                 (:model request-with-model)))
+                (seq tools)   (assoc :tools-called tools)
+                (some? usage) (assoc :cost-usd resolved-cost)
+                session-id    (assoc :session-id session-id)))))))))
 
 ;------------------------------------------------------------------------------ Layer 10
 

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -24,6 +24,7 @@
             [ai.miniforge.llm.protocols.records.llm-client]
             [ai.miniforge.llm.protocols.impl.llm-client :as impl]
             [ai.miniforge.llm.progress-monitor :as pm]
+            [ai.miniforge.logging.interface :as log]
             [cheshire.core :as json]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -1403,6 +1404,179 @@
                                        :is_error    false}]}}))
       (is (< before (:last-activity-at @monitor))
           ":tool-result must advance :last-activity-at to keep monitor alive"))))
+
+;------------------------------------------------------------------------------ Ceiling cut bookkeeping (2026-09-04 trap-bench series 9)
+;;
+;; Two implement turns hit the 10-minute :max-total ceiling mid-work. The
+;; error response carried neither the tools the model had called nor the
+;; tokens it had consumed, and no marker said the CLIENT cut the run. These
+;; pin the response shape a cut run must carry.
+(deftest ^{:stratum 0} terminated-by-maps-adaptive-timeout-types-test
+  (testing "hard-limit is reported as :max-total — the knob operators tune"
+    (is (= :max-total (impl/terminated-by {:type :hard-limit :elapsed-ms 600001}))))
+  (testing "other adaptive-timeout types keep their canonical name"
+    (is (= :stream-idle (impl/terminated-by {:type :stream-idle})))
+    (is (= :stagnation (impl/terminated-by {:type :stagnation})))
+    (is (= :network-drop (impl/terminated-by {:type :network-drop}))))
+  (testing "no envelope / unknown type → nil (the model finished on its own)"
+    (is (nil? (impl/terminated-by nil)))
+    (is (nil? (impl/terminated-by {:type :something-else})))))
+
+(deftest ^{:stratum 0} streaming-error-response-carries-cut-run-bookkeeping-test
+  (testing "usage on a cut run lands as :usage + :tokens, same shape as llm-success"
+    (let [usage {:input-tokens 1200 :output-tokens 300}
+          resp (impl/streaming-error-response "" -1 "timed out" ""
+                                              {:type :hard-limit :message "Hard timeout"
+                                               :elapsed-ms 600001 :max-ms 600000}
+                                              nil 7 12 nil usage 200000)]
+      (is (not (:success resp)))
+      (is (= usage (:usage resp)))
+      (is (= 1500 (:tokens resp)))
+      (is (= 12 (:tool-call-count resp)))))
+
+  (testing "hard-limit envelope stamps :llm/terminated-by :max-total on the response"
+    (let [resp (impl/streaming-error-response "" -1 "timed out" ""
+                                              {:type :hard-limit :message "Hard timeout"
+                                               :elapsed-ms 600001 :max-ms 600000}
+                                              nil nil nil nil)]
+      (is (= :max-total (:llm/terminated-by resp)))
+      (is (= :hard-limit (get-in resp [:error :timeout :type])))))
+
+  (testing "no timeout envelope → no marker, no usage keys"
+    (let [resp (impl/streaming-error-response "" 1 "process died" "" nil nil nil nil nil)]
+      (is (not (contains? resp :llm/terminated-by)))
+      (is (not (contains? resp :usage)))
+      (is (not (contains? resp :tokens))))))
+
+(deftest ^{:stratum 0} log-streaming-result-warns-with-elapsed-and-call-count-test
+  (testing "a cut run logs at warn with elapsed time, ceiling, and tool-call count"
+    (let [[logger entries] (log/collecting-logger {:min-level :trace})]
+      (impl/log-streaming-result logger
+                                 {:type :hard-limit :message "Hard timeout: exceeded 600000ms limit"
+                                  :elapsed-ms 600123 :max-ms 600000
+                                  :stats {:chunks 40}}
+                                 0 14)
+      (let [entry (some #(when (= :agent/streaming-timeout (:log/event %)) %) @entries)]
+        (is (some? entry) "streaming-timeout must be logged")
+        (is (= :warn (:log/level entry)))
+        (is (= :max-total (get-in entry [:data :terminated-by])))
+        (is (= 600123 (get-in entry [:data :elapsed-ms])))
+        (is (= 600000 (get-in entry [:data :max-ms])))
+        (is (= 14 (get-in entry [:data :tool-call-count]))))))
+
+  (testing "a finished run logs at debug only"
+    (let [[logger entries] (log/collecting-logger {:min-level :trace})]
+      (impl/log-streaming-result logger nil 120 3)
+      (is (nil? (some #(when (= :agent/streaming-timeout (:log/event %)) %) @entries)))
+      (is (some #(when (= :agent/streaming-complete (:log/event %)) %) @entries)))))
+
+(deftest ^{:stratum 0} complete-stream-hard-limit-cut-reports-tools-and-tokens-test
+  (testing "a stream cut by the max-total ceiling still reports the tools called and tokens used"
+    ;; The fake stream-exec-fn replays what the Claude CLI had emitted
+    ;; before the cut — two tool_use events and a per-message usage
+    ;; envelope — then returns the hard-limit timeout-result shape that
+    ;; `stream-exec-fn` produces when `pm/check-timeout` fires.
+    (let [[logger entries] (log/collecting-logger {:min-level :trace})
+          tool-line (fn [tool]
+                      (json/generate-string
+                       {:type "assistant"
+                        :message {:content [{:type "tool_use" :name tool :id "t1" :input {}}]
+                                  :stop_reason "tool_use"
+                                  :usage {:input_tokens 1000 :output_tokens 250}}}))
+          timeout {:type :hard-limit
+                   :message "Hard timeout: exceeded 600000ms limit"
+                   :elapsed-ms 600042 :max-ms 600000
+                   :stats {:chunks 2 :unique-chunks 2 :files-written 0 :stagnant-cycles 0}}
+          client (ai.miniforge.llm.protocols.records.llm-client/create-client
+                  {:backend :claude
+                   :logger logger
+                   :stream-exec-fn (fn [_cmd on-line _opts]
+                                     (on-line (tool-line "mcp__context__context_read"))
+                                     (on-line (tool-line "mcp__context__context_write"))
+                                     (impl/timeout-result [] timeout))})
+          resp (llm/complete-stream client {:prompt "test"} (fn [_] nil))]
+      (is (not (:success resp)))
+      (is (= :max-total (:llm/terminated-by resp)))
+      (is (= :hard-limit (get-in resp [:error :timeout :type])))
+      (is (= 600042 (get-in resp [:error :timeout :elapsed-ms])))
+      (is (= ["mcp__context__context_read" "mcp__context__context_write"]
+             (:tools-called resp)))
+      (is (= 2 (:tool-call-count resp)))
+      (is (pos? (:tokens resp)) "tokens consumed before the cut are reported")
+      (is (contains? resp :cost-usd) "cost of the cut run is reported")
+      (let [entry (some #(when (= :agent/streaming-timeout (:log/event %)) %) @entries)]
+        (is (= :warn (:log/level entry)))
+        (is (= 2 (get-in entry [:data :tool-call-count])))
+        (is (= :max-total (get-in entry [:data :terminated-by])))))))
+
+(deftest ^{:stratum 0} parse-claude-stream-line-carries-per-message-usage-test
+  (testing "assistant events surface :message-usage + :message-id"
+    (let [parse-line (:stream-parser (get impl/backends :claude))
+          parsed (parse-line (json/generate-string
+                              {:type "assistant"
+                               :message {:id "msg_1"
+                                         :content [{:type "text" :text "hello"}]
+                                         :usage {:input_tokens 100 :output_tokens 5
+                                                 :cache_read_input_tokens 40}}}))]
+      (is (= {:input-tokens 100 :output-tokens 5 :cache-read-input-tokens 40}
+             (:message-usage parsed)))
+      (is (= "msg_1" (:message-id parsed)))))
+  (testing "no usage on the event → no usage keys"
+    (let [parse-line (:stream-parser (get impl/backends :claude))
+          parsed (parse-line (json/generate-string
+                              {:type "assistant"
+                               :message {:id "msg_2" :content [{:type "text" :text "hi"}]}}))]
+      (is (not (contains? parsed :message-usage)))
+      (is (not (contains? parsed :message-id))))))
+
+(deftest ^{:stratum 0} fold-message-usage-test
+  (testing "input-side counts take the latest call; output tokens accumulate"
+    (let [folded (-> nil
+                     (impl/fold-message-usage "m1" {:input-tokens 1000 :output-tokens 50
+                                                    :cache-read-input-tokens 200})
+                     (impl/fold-message-usage "m2" {:input-tokens 1300 :output-tokens 70
+                                                    :cache-read-input-tokens 900}))]
+      (is (= {:input-tokens 1300 :output-tokens 120 :cache-read-input-tokens 900} folded))))
+  (testing "one message emitted as several content-block events folds once"
+    (let [usage {:input-tokens 500 :output-tokens 30}
+          folded (-> nil
+                     (impl/fold-message-usage "m1" usage)
+                     (impl/fold-message-usage "m1" usage)
+                     (impl/fold-message-usage "m1" usage))]
+      (is (= {:input-tokens 500 :output-tokens 30} folded))))
+  (testing "events without a message id always fold"
+    (let [folded (-> nil
+                     (impl/fold-message-usage nil {:output-tokens 10})
+                     (impl/fold-message-usage nil {:output-tokens 10}))]
+      (is (= {:output-tokens 20} folded))))
+  (testing "the usage map stays plain — the dedupe id is metadata only"
+    (let [folded (impl/fold-message-usage nil "m1" {:input-tokens 1 :output-tokens 1})]
+      (is (= #{:input-tokens :output-tokens} (set (keys folded)))))))
+
+(deftest ^{:stratum 0} stream-with-parser-folds-message-usage-then-result-replaces-test
+  (let [monitor (pm/create-progress-monitor {:min-activity-interval-ms 1})
+        accumulated-usage (atom nil)
+        parse-line (:stream-parser (get impl/backends :claude))
+        on-line (impl/stream-with-parser parse-line (fn [_] nil) monitor
+                                         (atom "") accumulated-usage (atom nil) (atom [])
+                                         (atom nil) (atom nil) (atom nil))
+        assistant (fn [id usage]
+                    (json/generate-string
+                     {:type "assistant"
+                      :message {:id id
+                                :content [{:type "tool_use" :name "Bash" :id "t" :input {}}]
+                                :stop_reason "tool_use"
+                                :usage usage}}))]
+    (testing "usage accumulates across messages before any result frame"
+      (on-line (assistant "m1" {:input_tokens 1000 :output_tokens 40}))
+      (on-line (assistant "m1" {:input_tokens 1000 :output_tokens 40}))
+      (on-line (assistant "m2" {:input_tokens 1400 :output_tokens 60}))
+      (is (= {:input-tokens 1400 :output-tokens 100} @accumulated-usage)))
+    (testing "the result frame's totals replace the folded counts"
+      (on-line (json/generate-string
+                {:type "result" :result "done"
+                 :usage {:input_tokens 2400 :output_tokens 100}}))
+      (is (= {:input-tokens 2400 :output-tokens 100} @accumulated-usage)))))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -1507,7 +1507,23 @@
       (let [entry (some #(when (= :agent/streaming-timeout (:log/event %)) %) @entries)]
         (is (= :warn (:log/level entry)))
         (is (= 2 (get-in entry [:data :tool-call-count])))
-        (is (= :max-total (get-in entry [:data :terminated-by])))))))
+        (is (= :max-total (get-in entry [:data :terminated-by]))))))
+
+  (testing "a backend-reported cost survives the cut even when no usage map arrived"
+    ;; Copilot review on #1897: the error branch used to attach :cost-usd
+    ;; only when usage was present, dropping a known total_cost_usd.
+    (let [timeout {:type :hard-limit :message "Hard timeout" :elapsed-ms 600042
+                   :max-ms 600000 :stats {}}
+          client (ai.miniforge.llm.protocols.records.llm-client/create-client
+                  {:backend :claude
+                   :stream-exec-fn (fn [_cmd on-line _opts]
+                                     (on-line (json/generate-string
+                                               {:type "result" :result "" :total_cost_usd 0.42}))
+                                     (impl/timeout-result [] timeout))})
+          resp (llm/complete-stream client {:prompt "test"} (fn [_] nil))]
+      (is (not (:success resp)))
+      (is (nil? (:usage resp)))
+      (is (= 0.42 (:cost-usd resp))))))
 
 (deftest ^{:stratum 0} parse-claude-stream-line-carries-per-message-usage-test
   (testing "assistant events surface :message-usage + :message-id"

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -1087,6 +1087,40 @@
       (is (clojure.string/includes? text "[stale-references]"))
       (is (clojure.string/includes? text "bb.edn")))))
 
+(deftest ^{:stratum 2} leave-implement-max-total-cut-routes-as-backend-timeout-test
+  ;; 2026-09-04 trap-bench series 9: the implementer used to promote files
+  ;; written before a :max-total cut and the phase reported success. The
+  ;; implementer now fails such a turn with the timeout envelope intact;
+  ;; this pins the phase side — retriable within the iteration budget,
+  ;; then the terminal :implement/backend-timeout verdict.
+  (let [cut-result {:status :error
+                    :error {:message "Adaptive timeout: Hard timeout: exceeded 1800000ms limit (type: hard-limit, elapsed: 1800042ms)"
+                            :data {:type "adaptive_timeout"
+                                   :timeout {:type :hard-limit
+                                             :elapsed-ms 1800042
+                                             :max-ms 1800000}
+                                   :llm/terminated-by :max-total
+                                   :partial-files ["components/codex-gap/deps.edn"]}}
+                    :metrics {:tokens 8000 :duration-ms 1800042}}
+        ctx-at (fn [iterations]
+                 (-> (create-base-context)
+                     (assoc :phase {:name :implement
+                                    :agent :implementer
+                                    :status :running
+                                    :iterations iterations
+                                    :budget {:iterations 3}
+                                    :started-at (System/currentTimeMillis)
+                                    :result cut-result})))]
+    (testing "within the iteration budget the cut is retriable — never a success"
+      (let [final-ctx (implement/leave-implement (ctx-at 1))]
+        (is (not= :completed (get-in final-ctx [:phase :status])))
+        (is (not= :failed (get-in final-ctx [:phase :status])))
+        (is (nil? (get-in final-ctx [:phase :verdict])))))
+    (testing "at the iteration budget the cut is the terminal :implement/backend-timeout"
+      (let [final-ctx (implement/leave-implement (ctx-at 3))]
+        (is (= :failed (get-in final-ctx [:phase :status])))
+        (is (= :implement/backend-timeout (get-in final-ctx [:phase :verdict])))))))
+
 (use-fixtures :each
   (fn [f]
     (phase/reset-phase-loader!)

--- a/components/repo-index/resources/config/repo-index/messages/en-US.edn
+++ b/components/repo-index/resources/config/repo-index/messages/en-US.edn
@@ -54,6 +54,7 @@
   ;; Error messages
   :error/parse-failed             "LLM response could not be parsed as code artifact"
   :error/llm-failed               "LLM call failed"
+  :error/llm-max-total-exceeded   "Implement turn was cut at the LLM run ceiling (:max-total-ms) before it finished; files written before the cut were not promoted"
   :error/no-llm-backend           "No LLM backend provided"
   :error/unverified-already-implemented
   "Implementer claimed :already-implemented without artifact evidence after prior review or verify failures"

--- a/docs/pull-requests/2026-09-07-fix-llm-max-total-cut-not-silent.md
+++ b/docs/pull-requests/2026-09-07-fix-llm-max-total-cut-not-silent.md
@@ -1,0 +1,154 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix: a run cut at the LLM max-total ceiling is reported, accounted, and not promoted
+
+## Overview
+
+Trap bench series 9, run `baseline-trap-a-ry1` (2026-09-04, checkpoint
+`feabb7f0-c85b-4320-853b-f5850695e002`): two implement turns given the
+larger verify-failure prompts (35-40k chars) hit the LLM client's
+10-minute `:max-total-ms` ceiling.
+
+1. Iteration 3 (05:28:58 to 05:38:59) was cut mid-write after several
+   `mcp__context__context_write` calls. `components/codex-gap/deps.edn`
+   was left without its `:paths` line, and every later verify failed with
+   `Error 110: Validation error in components/codex-gap/deps.edn`.
+2. Iteration 5 (05:57:40 to 06:07:40) made ten `context_read` calls and
+   was cut before any write.
+
+In both cases the run log shows `implementer/file-artifact-fallback`
+collecting the working directory, `implementer/llm-called` with
+`{:success false, :tokens 0, :tools-called []}`, and
+`agent/invoke-completed {:status :success}`. Nothing in the run log says
+the run was cut.
+
+## Motivation
+
+Three defects, one per fix below.
+
+1. The LLM client's timeout warning goes to the client's own logger, which
+   is not the run log, and the implementer honored the file-artifact
+   container-promotion precedence for every timeout type. A turn the
+   client cut mid-write was promoted as a success.
+2. The error response built for a cut run carried neither the tools the
+   model had called nor the tokens it had consumed. The Claude stream
+   parser only read usage from the final `result` frame, which a cut run
+   never sees.
+3. The implementer used the framework default ceiling. Planner and
+   reviewer already carry `:prompt/progress-monitor` in their prompt
+   config; the implementer had no block, so its ceiling was not
+   configurable and its turns, which write many files, got the same
+   10 minutes as a planning turn.
+
+## Changes in Detail
+
+### LLM client (`components/llm`)
+
+1. `streaming-error-response` stamps `:llm/terminated-by` on the response
+   for any known adaptive-timeout type. `:hard-limit` is reported as
+   `:max-total`, the name of the knob that changes it. Other types keep
+   their canonical name.
+2. The error response carries `:usage` and `:tokens` when usage is
+   present (same shape `llm-success` emits), and the streaming error
+   branch attaches `:tools-called` and `:cost-usd` like the success
+   branch does.
+3. `parse-claude-stream-line` surfaces per-message `usage` and message
+   id from `assistant` events. `stream-with-parser` folds them via
+   `fold-message-usage`: input-side counts take the latest call (they
+   describe that call's whole context, so summing them would push
+   `context-overflow-by-usage?` into a false overflow on any long cut
+   run), output tokens accumulate, and the message id dedupes the one
+   event per content block Claude Code emits. The `result` frame's
+   totals still replace the folded counts.
+4. `log-streaming-result` takes the tool-call count and logs a cut run
+   at warn with `:terminated-by`, `:elapsed-ms`, `:max-ms`, and
+   `:tool-call-count`.
+
+### Implementer (`components/agent`)
+
+1. `invoke-implementer-session` passes a `:progress-monitor` built from
+   `implementer.edn`'s new `:prompt/progress-monitor` block; the
+   submission-recovery turn gets `:prompt/submission-retry-monitor`.
+   Both go through the existing `prompts/load-progress-monitor`, the
+   same path planner and reviewer use.
+2. `implementer.edn`: `:prompt/progress-monitor` with
+   `:max-total-ms 1800000` (30 minutes). Stagnation and activity spacing
+   stay at the framework values. The recovery turn keeps 10 minutes.
+3. `invoke-with-llm`: when the response carries
+   `:llm/terminated-by :max-total`, the file artifact is not passed as
+   the fallback, no submission-recovery turn runs, and the result is
+   `result-boundary/error-response` with the llm-error (including its
+   `:timeout` envelope) plus `:llm/terminated-by` and the paths written
+   before the cut under `:partial-files`. The phase's existing
+   `backend-timeout-in-result?` classifies it: retriable from the
+   session checkpoint within the iteration budget, then the terminal
+   `:implement/backend-timeout` verdict. A new warn,
+   `implementer/llm-max-total-exceeded`, logs elapsed time, ceiling,
+   tool-call count, and the partial files on the run log's logger.
+   `implementer/llm-called` gains `:terminated-by`.
+4. Stream-idle and stagnation keep the container-promotion precedence:
+   there the model finished writing and hung.
+
+### Messages
+
+`:error/llm-max-total-exceeded` in the repo-index message catalog.
+
+## Testing Plan
+
+New tests:
+
+1. `components/llm/test/.../interface_test.clj`: `terminated-by` mapping;
+   `streaming-error-response` carries usage, tokens, and the marker;
+   `log-streaming-result` warns with elapsed time and call count; a
+   `complete-stream` run whose fake stream replays two `tool_use` events
+   and then returns the hard-limit `timeout-result` reports both tools,
+   positive tokens, cost, the marker, and the warn; per-message usage
+   parsing; `fold-message-usage` latest/sum/dedupe; result-frame
+   replacement through `stream-with-parser`.
+2. `components/agent/test/.../implementer_test.clj`: a `:max-total` cut
+   with files on disk is an error result carrying the timeout envelope,
+   the marker, partial files, and tokens, logs the cut, does not log a
+   file-artifact fallback, and runs no recovery turn; a stream-idle cut
+   still promotes files; the implementer's `:progress-monitor` reaches
+   the LLM client with a ceiling of at least 30 minutes.
+3. `components/phase-software-factory/test/.../implement_test.clj`:
+   the cut result is retriable within the iteration budget and terminal
+   `:implement/backend-timeout` at the budget.
+
+Run locally: every `components/llm` test namespace, the implementer,
+planner, reviewer, and result-boundary namespaces, and the phase
+implement namespace. 333 tests, 1760 assertions, green.
+
+Not verified here: a live rerun of the trap bench series 9 prompt.
+
+## Deployment Plan
+
+No migration. The implementer's ceiling rises from 10 to 30 minutes; a
+turn that would previously have been cut and promoted now either
+finishes or fails as a backend timeout. `bb pre-commit`'s stratum gate
+reports the pre-existing SL003 (over the layer budget) on
+`llm_client.clj` and `implementer.clj`; both were over budget at the
+merge base, so the commits use `MINIFORGE_STRATUM_BUDGET_MODE=warn`.
+
+## Related Issues/PRs
+
+1. Trap bench series 9 pre-registration, #1891.
+2. Phase-timeout stack: `:implement/backend-timeout` verdict and
+   `backend-timeout-in-result?` (2026-06-06).
+3. Separate follow-up, not in this PR: `context_read` took about a minute
+   per call on the same run (`implementer/context-cache-misses`), and the
+   non-streaming `complete-impl` path still runs under `default-exec-fn`'s
+   fixed 10-minute subprocess timeout with no progress monitor.
+
+## Checklist
+
+- [x] LLM client marks and logs a ceiling cut with elapsed time and call count
+- [x] Cut runs report tools, tokens, and cost
+- [x] Implementer fails a `:max-total` cut instead of promoting partial files
+- [x] Implementer ceiling configurable via `implementer.edn`; default 30 minutes
+- [x] Tests for all three
+- [ ] Copilot review settled
+- [ ] Merged


### PR DESCRIPTION
## Summary

Trap bench series 9, run `baseline-trap-a-ry1` (2026-09-04): two implement turns hit the LLM client's 10-minute `:max-total-ms` ceiling. One was cut mid-write and left `components/codex-gap/deps.edn` without its `:paths` line, which failed every later verify. The implementer promoted the files on disk, logged `{:success false, :tokens 0, :tools-called []}`, and the phase reported success. Nothing in the run log said the run was cut.

Three fixes:

1. **Marker + log.** `streaming-error-response` stamps `:llm/terminated-by` (`:max-total` for the hard limit; other adaptive-timeout types keep their name). `log-streaming-result` logs a cut at warn with `:terminated-by`, `:elapsed-ms`, `:max-ms`, and the tool-call count. The implementer refuses file promotion for a `:max-total` cut, runs no submission-recovery turn, and returns an error result with the timeout envelope intact, so the phase's existing `backend-timeout-in-result?` routes it: retriable from the session checkpoint within the iteration budget, then the terminal `:implement/backend-timeout` verdict. New warn `implementer/llm-max-total-exceeded` on the run log's logger carries elapsed time, ceiling, tool-call count, and the partial files. Stream-idle and stagnation keep the container-promotion precedence.
2. **Bookkeeping.** The streaming error branch carries `:tools-called`, `:usage`/`:tokens`, and `:cost-usd`. The Claude parser now surfaces per-message usage (the `result` frame that used to be the only source never arrives on a cut); `fold-message-usage` keeps the latest input-side counts so `context-overflow-by-usage?` is not inflated, sums output tokens, and dedupes Claude Code's one-event-per-content-block.
3. **Per-role ceiling.** `implementer.edn` gains `:prompt/progress-monitor` (30-minute `:max-total-ms`) and `:prompt/submission-retry-monitor` (10 minutes), wired through the same `prompts/load-progress-monitor` path planner and reviewer use.

PR doc: `docs/pull-requests/2026-09-07-fix-llm-max-total-cut-not-silent.md`.

Note on the branch history: the fourth commit's message was mangled by a shell heredoc mix-up (it carries this PR body instead of its own message). The branch is not force-pushed; the squash-merge commit message is the record that lands on `main`.

## Test plan

- [x] New tests in `components/llm` (marker, bookkeeping, warn, per-message usage folding, end-to-end `complete-stream` on a hard-limit cut), `components/agent` (cut is an error result with envelope/marker/partial files; stream-idle still promotes; implementer monitor reaches the client with a ≥30-minute ceiling), `components/phase-software-factory` (retriable then terminal `:implement/backend-timeout`).
- [x] All `components/llm` namespaces + implementer, planner, reviewer, result-boundary, phase implement: 333 tests, 1760 assertions, green.
- [x] `bb pre-commit` green on each of the four commits. Stratum SL003 on `llm_client.clj` and `implementer.clj` is pre-existing at the merge base; commits used `MINIFORGE_STRATUM_BUDGET_MODE=warn`.
- [ ] Not verified: a live rerun of the series 9 prompt.

Out of scope, noted in the PR doc: why `context_read` took about a minute per call on that run, and the non-streaming `complete-impl` path's fixed 10-minute subprocess timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
