### PR TITLE
fix(policy-calibration): catch Exception instead of Throwable in judge-once

### DIFF
--- a/components/policy-calibration/src/ai/miniforge/policy_calibration/core.clj
+++ b/components/policy-calibration/src/ai/miniforge/policy_calibration/core.clj
@@ -197,7 +197,7 @@
    failure records as data rather than aborting the run on deref."
   [judge-fn rules fixture]
   (try (judge-fn rules fixture)
-       (catch Throwable e
+       (catch Exception e
          (backend-error "judge threw" {:error (ex-message e)}))))
 
 (defn- judge-cell


### PR DESCRIPTION
## What

`judge-once` in `policy-calibration/core.clj` caught `Throwable` to convert any judge error into a backend-error data cell. Changed to `Exception`.

## Why

`Throwable` is a superset of `Exception` — it also includes JVM fatal errors (`OutOfMemoryError`, `StackOverflowError`, `ThreadDeath`). Catching these silently converts a fatal JVM condition into a data cell and allows execution to continue, masking a serious resource problem during a long-running calibration run. The intent — prevent a transient judge failure from aborting the pass — only requires catching `Exception` (all application-level failures). JVM fatal errors must propagate.

## Change

```clojure
;; before
(catch Throwable e
  (backend-error "judge threw" {:error (ex-message e)}))

;; after
(catch Exception e
  (backend-error "judge threw" {:error (ex-message e)}))
```

One character diff; identical runtime behaviour for all application-level failures.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZvRndjycn5xjRjnLxEBAY

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZvRndjycn5xjRjnLxEBAY)_